### PR TITLE
Ability to verify pacts from a broker and optionally given tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -261,6 +261,55 @@ Read more about [flexible matching](https://github.com/realestate-com-au/pact/wi
 	See the `Skip()'ed` [integration tests](https://github.com/pact-foundation/pact-go/blob/master/dsl/pact_test.go)
 	for a more complete E2E example.
 
+#### Provider Verification
+
+When validating a Provider, you have 3 options to provide the Pact files:
+
+1. Use `PactURLs` to specify the exact set of pacts to be replayed:
+
+	```go
+	response = pact.VerifyProvider(&types.VerifyRequest{
+		ProviderBaseURL:        "http://myproviderhost",
+		PactURLs:               []string{"http://broker/pacts/provider/them/consumer/me/latest/dev"},
+		ProviderStatesURL:      "http://myproviderhost/states",
+		ProviderStatesSetupURL: "http://myproviderhost/setup",
+		BrokerUsername:         os.Getenv("PACT_BROKER_USERNAME"),
+		BrokerPassword:         os.Getenv("PACT_BROKER_PASSWORD"),
+	})
+	```
+1. Use `PactBroker` to automatically find all of the latest consumers:
+
+	```go
+	response = pact.VerifyProvider(&types.VerifyRequest{
+		ProviderBaseURL:        "http://myproviderhost",
+		BrokerURL:              "http://brokerHost",
+		ProviderStatesURL:      "http://myproviderhost/states",
+		ProviderStatesSetupURL: "http://myproviderhost/setup",
+		BrokerUsername:         os.Getenv("PACT_BROKER_USERNAME"),
+		BrokerPassword:         os.Getenv("PACT_BROKER_PASSWORD"),
+	})
+	```
+1. Use `PactBroker` and `Tags` to automatically find all of the latest consumers:
+
+	```go
+	response = pact.VerifyProvider(&types.VerifyRequest{
+		ProviderBaseURL:        "http://myproviderhost",
+		BrokerURL:              "http://brokerHost",
+		Tags:                   []string{"latest", "sit4"},
+		ProviderStatesURL:      "http://myproviderhost/states",
+		ProviderStatesSetupURL: "http://myproviderhost/setup",
+		BrokerUsername:         os.Getenv("PACT_BROKER_USERNAME"),
+		BrokerPassword:         os.Getenv("PACT_BROKER_PASSWORD"),
+	})
+	```
+
+Options 2 and 3 are particularly useful when you want to validate that your
+Provider is able to meet the contracts of what's in Production and also the latest
+in development.
+
+See this [article](http://rea.tech/enter-the-pact-matrix-or-how-to-decouple-the-release-cycles-of-your-microservices/)
+for more on this strategy.
+
 #### Provider States
 
 Each interaction in a pact should be verified in isolation, with no context

--- a/dsl/broker.go
+++ b/dsl/broker.go
@@ -1,0 +1,91 @@
+package dsl
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"net/http"
+
+	"github.com/pact-foundation/pact-go/types"
+)
+
+var pactURLPattern = "%s/pacts/provider/%s/latest"
+var pactURLPatternWithTag = "%s/pacts/provider/%s/latest/%s"
+
+// PactLink represents the Pact object in the HAL response.
+type PactLink struct {
+	Href  string `json:"href"`
+	Title string `json:"title"`
+	Name  string `json:"name"`
+}
+
+// HalLinks represents the _links key in a HAL document.
+type HalLinks struct {
+	Pacts []PactLink `json:"pacts"`
+}
+
+// HalDoc is a simple representation of the HAL response from a Pact Broker.
+type HalDoc struct {
+	Links HalLinks `json:"_links"`
+}
+
+// findConsumers navigates a Pact Broker's HAL system to find consumers
+// based on the latest Pacts or using tags.
+func findConsumers(provider string, request *types.VerifyRequest) error {
+	log.Println("findConsumers")
+
+	// Check for Broker-based requests and if so, fetch from Broker before
+	// verifying.
+
+	// 2 Scenarios:
+	//   1. Ask for all 'latest' consumers.
+	//   2. Pass a set of tags (e.g. 'latest' and 'prod') and find all consumers that match.
+
+	// 1. Find all consumers
+	// 2. Construct all URLs with relevent tags
+	// 3. Populate 'PactURLs'
+	// 4. Send off to Daemon
+
+	client := &http.Client{}
+	var url string
+	if len(request.Tags) > 0 {
+		url = fmt.Sprintf(pactURLPatternWithTag, request.BrokerURL, provider, "dev")
+	} else {
+		url = fmt.Sprintf(pactURLPattern, request.BrokerURL, provider)
+	}
+	var req *http.Request
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Set("Accept", "application/hal+json")
+
+	res, err := client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	responseBody, err := ioutil.ReadAll(res.Body)
+	res.Body.Close()
+	log.Printf("[DEBUG] pact broker response Body: %s\n", responseBody)
+
+	var doc HalDoc
+	err = json.Unmarshal(responseBody, &doc)
+
+	if res.StatusCode < 200 || res.StatusCode >= 300 {
+		return errors.New(string(responseBody))
+	}
+
+	if err != nil {
+		return err
+	}
+
+	for _, p := range doc.Links.Pacts {
+		request.PactURLs = append(request.PactURLs, p.Href)
+	}
+
+	return nil
+}

--- a/dsl/broker_test.go
+++ b/dsl/broker_test.go
@@ -13,11 +13,42 @@ import (
 func TestPact_findConsumers(t *testing.T) {
 	port := setupMockBroker()
 	request := &types.VerifyRequest{
+		BrokerURL: fmt.Sprintf("http://localhost:%d", port),
+	}
+	err := findConsumers("bobby", request)
+	if err != nil {
+		t.Fatalf("Error: %s", err.Error())
+	}
+
+	if len(request.PactURLs) != 2 {
+		t.Fatalf("Expected 2 PactURLs but got: %d", len(request.PactURLs))
+	}
+
+	pactURL := fmt.Sprintf("http://localhost:%d/pacts/provider/bobby/consumer/jessica/version/2.0.0", port)
+	if request.PactURLs[0] != pactURL {
+		t.Fatalf("Expected '%s', but got '%s'", pactURL, request.PactURLs[0])
+	}
+}
+
+func TestPact_findConsumersWithTags(t *testing.T) {
+	port := setupMockBroker()
+	request := &types.VerifyRequest{
 		Tags:      []string{"dev", "prod"},
 		BrokerURL: fmt.Sprintf("http://localhost:%d", port),
 	}
 	err := findConsumers("bobby", request)
-	fmt.Println(err)
+	if err != nil {
+		t.Fatalf("Error: %s", err.Error())
+	}
+
+	if len(request.PactURLs) != 2 {
+		t.Fatalf("Expected 2 PactURLs but got: %d", len(request.PactURLs))
+	}
+
+	pactURL := fmt.Sprintf("http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.1", port)
+	if request.PactURLs[0] != pactURL {
+		t.Fatalf("Expected '%s', but got '%s'", pactURL, request.PactURLs[0])
+	}
 }
 
 // Pretend to be a Broker for fetching Pacts
@@ -29,7 +60,7 @@ func setupMockBroker() int {
 	// curl --user pactuser:pact -H "accept: application/hal+json" "http://pact.onegeek.com.au/pacts/provider/bobby/latest"
 	mux.HandleFunc("/pacts/provider/bobby/latest", func(w http.ResponseWriter, req *http.Request) {
 		log.Println("[DEBUG] get pacts for provider 'bobby'")
-		fmt.Fprintf(w, `{"_links":{"self":{"href":"http://localhost:%d/pacts/provider/bobby/latest","title":"Latest pact versions for the provider bobby"},"provider":{"href":"http://localhost:%d/pacticipants/bobby","title":"bobby"},"pacts":[{"href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.0","title":"Pact between billy (v1.0.0) and bobby","name":"billy"}]}}`, port, port, port)
+		fmt.Fprintf(w, `{"_links":{"self":{"href":"http://localhost:%d/pacts/provider/bobby/latest","title":"Latest pact versions for the provider bobby"},"provider":{"href":"http://localhost:%d/pacticipants/bobby","title":"bobby"},"pacts":[{"href":"http://localhost:%d/pacts/provider/bobby/consumer/jessica/version/2.0.0","title":"Pact between jessica (v2.0.0) and bobby","name":"jessica"},{"href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.0","title":"Pact between billy (v1.0.0) and bobby","name":"billy"}]}}`, port, port, port, port)
 		w.Header().Add("Content-Type", "application/hal+json")
 	})
 
@@ -45,14 +76,14 @@ func setupMockBroker() int {
 	// curl --user pactuser:pact -H "accept: application/hal+json" "http://pact.onegeek.com.au/pacts/provider/bobby/latest/sit4"
 	mux.HandleFunc("/pacts/provider/bobby/latest/dev", func(w http.ResponseWriter, req *http.Request) {
 		log.Println("[DEBUG] get all pacts for provider 'bobby' where the tag 'dev' exists")
-		fmt.Fprintf(w, `{"_links":{"self":{"href":"http://localhost:%d/pacts/provider/bobby/latest/dev","title":"Latest pact versions for the provider bobby with tag 'dev'"},"provider":{"href":"http://localhost:%d/pacticipants/bobby","title":"bobby"},"pacts":[{"href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.0","title":"Pact between billy (v1.0.0) and bobby","name":"billy"}]}}`, port, port, port)
+		fmt.Fprintf(w, `{"_links":{"self":{"href":"http://localhost:%d/pacts/provider/bobby/latest/dev","title":"Latest pact versions for the provider bobby with tag 'dev'"},"provider":{"href":"http://localhost:%d/pacticipants/bobby","title":"bobby"},"pacts":[{"href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.1","title":"Pact between billy (v1.0.1) and bobby","name":"billy"}]}}`, port, port, port)
 		w.Header().Add("Content-Type", "application/hal+json")
 	})
 
-	// Consumer Pact
+	// Actual Consumer Pact
 	// curl -v --user pactuser:pact -H "accept: application/json" http://pact.onegeek.com.au/pacts/provider/bobby/consumer/billy/version/1.0.0
-	mux.HandleFunc("/pacts/provider/bobby/consumer/billy/version/1.0.0", func(w http.ResponseWriter, req *http.Request) {
-		log.Println("[DEBUG] get all pacts for provider 'bobby' where the tag 'dev' exists")
+	mux.HandleFunc("/pacts/provider/bobby/consumer/billy/version/", func(w http.ResponseWriter, req *http.Request) {
+		log.Println("[DEBUG] get all pacts for provider 'bobby' where any tag exists")
 		fmt.Fprintf(w, `{"consumer":{"name":"billy"},"provider":{"name":"bobby"},"interactions":[{"description":"Some name for the test","provider_state":"Some state","request":{"method":"GET","path":"/foobar"},"response":{"status":200,"headers":{"Content-Type":"application/json"}}},{"description":"Some name for the test","provider_state":"Some state2","request":{"method":"GET","path":"/bazbat"},"response":{"status":200,"headers":{},"body":[[{"colour":"red","size":10,"tag":[["jumper","shirt"],["jumper","shirt"]]}]],"matchingRules":{"$.body":{"min":1},"$.body[*].*":{"match":"type"},"$.body[*]":{"min":1},"$.body[*][*].*":{"match":"type"},"$.body[*][*].colour":{"match":"regex","regex":"red|green|blue"},"$.body[*][*].size":{"match":"type"},"$.body[*][*].tag":{"min":2},"$.body[*][*].tag[*].*":{"match":"type"},"$.body[*][*].tag[*][0]":{"match":"type"},"$.body[*][*].tag[*][1]":{"match":"type"}}}}],"metadata":{"pactSpecificationVersion":"2.0.0"},"updatedAt":"2016-06-11T13:11:33+00:00","createdAt":"2016-06-09T12:46:42+00:00","_links":{"self":{"title":"Pact","name":"Pact between billy (v1.0.0) and bobby","href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.0"},"pb:consumer":{"title":"Consumer","name":"billy","href":"http://localhost:%d/pacticipants/billy"},"pb:provider":{"title":"Provider","name":"bobby","href":"http://localhost:%d/pacticipants/bobby"},"pb:latest-pact-version":{"title":"Pact","name":"Latest version of this pact","href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/latest"},"pb:previous-distinct":{"title":"Pact","name":"Previous distinct version of this pact","href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.0/previous-distinct"},"pb:diff-previous-distinct":{"title":"Diff","name":"Diff with previous distinct version of this pact","href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.0/diff/previous-distinct"},"pb:pact-webhooks":{"title":"Webhooks for the pact between billy and bobby","href":"http://localhost:%d/webhooks/provider/bobby/consumer/billy"},"pb:tag-prod-version":{"title":"Tag this version as 'production'","href":"http://localhost:%d/pacticipants/billy/versions/1.0.0/tags/prod"},"pb:tag-version":{"title":"Tag version","href":"http://localhost:%d/pacticipants/billy/versions/1.0.0/tags/{tag}"},"curies":[{"name":"pb","href":"http://localhost:%d/doc/{rel}","templated":true}]}}`, port, port, port, port, port, port, port, port, port, port)
 		w.Header().Add("Content-Type", "application/hal+json")
 	})

--- a/dsl/broker_test.go
+++ b/dsl/broker_test.go
@@ -1,0 +1,62 @@
+package dsl
+
+import (
+	"fmt"
+	"log"
+	"net/http"
+	"testing"
+
+	"github.com/pact-foundation/pact-go/types"
+	"github.com/pact-foundation/pact-go/utils"
+)
+
+func TestPact_findConsumers(t *testing.T) {
+	port := setupMockBroker()
+	request := &types.VerifyRequest{
+		Tags:      []string{"dev", "prod"},
+		BrokerURL: fmt.Sprintf("http://localhost:%d", port),
+	}
+	err := findConsumers("bobby", request)
+	fmt.Println(err)
+}
+
+// Pretend to be a Broker for fetching Pacts
+func setupMockBroker() int {
+	port, _ := utils.GetFreePort()
+	mux := http.NewServeMux()
+
+	// Find latest 'bobby' consumers (no tag)
+	// curl --user pactuser:pact -H "accept: application/hal+json" "http://pact.onegeek.com.au/pacts/provider/bobby/latest"
+	mux.HandleFunc("/pacts/provider/bobby/latest", func(w http.ResponseWriter, req *http.Request) {
+		log.Println("[DEBUG] get pacts for provider 'bobby'")
+		fmt.Fprintf(w, `{"_links":{"self":{"href":"http://localhost:%d/pacts/provider/bobby/latest","title":"Latest pact versions for the provider bobby"},"provider":{"href":"http://localhost:%d/pacticipants/bobby","title":"bobby"},"pacts":[{"href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.0","title":"Pact between billy (v1.0.0) and bobby","name":"billy"}]}}`, port, port, port)
+		w.Header().Add("Content-Type", "application/hal+json")
+	})
+
+	// Find 'bobby' consumers for tag 'prod'
+	// curl --user pactuser:pact -H "accept: application/hal+json" "http://pact.onegeek.com.au/pacts/provider/bobby/latest/sit4"
+	mux.HandleFunc("/pacts/provider/bobby/latest/prod", func(w http.ResponseWriter, req *http.Request) {
+		log.Println("[DEBUG] get all pacts for provider 'bobby' where the tag 'prod' exists")
+		fmt.Fprintf(w, `{"_links":{"self":{"href":"http://localhost:%d/pacts/provider/bobby/latest/dev","title":"Latest pact versions for the provider bobby with tag 'dev'"},"provider":{"href":"http://localhost:%d/pacticipants/bobby","title":"bobby"},"pacts":[{"href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.0","title":"Pact between billy (v1.0.0) and bobby","name":"billy"}]}}`, port, port, port)
+		w.Header().Add("Content-Type", "application/hal+json")
+	})
+
+	// Find 'bobby' consumers for tag 'dev'
+	// curl --user pactuser:pact -H "accept: application/hal+json" "http://pact.onegeek.com.au/pacts/provider/bobby/latest/sit4"
+	mux.HandleFunc("/pacts/provider/bobby/latest/dev", func(w http.ResponseWriter, req *http.Request) {
+		log.Println("[DEBUG] get all pacts for provider 'bobby' where the tag 'dev' exists")
+		fmt.Fprintf(w, `{"_links":{"self":{"href":"http://localhost:%d/pacts/provider/bobby/latest/dev","title":"Latest pact versions for the provider bobby with tag 'dev'"},"provider":{"href":"http://localhost:%d/pacticipants/bobby","title":"bobby"},"pacts":[{"href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.0","title":"Pact between billy (v1.0.0) and bobby","name":"billy"}]}}`, port, port, port)
+		w.Header().Add("Content-Type", "application/hal+json")
+	})
+
+	// Consumer Pact
+	// curl -v --user pactuser:pact -H "accept: application/json" http://pact.onegeek.com.au/pacts/provider/bobby/consumer/billy/version/1.0.0
+	mux.HandleFunc("/pacts/provider/bobby/consumer/billy/version/1.0.0", func(w http.ResponseWriter, req *http.Request) {
+		log.Println("[DEBUG] get all pacts for provider 'bobby' where the tag 'dev' exists")
+		fmt.Fprintf(w, `{"consumer":{"name":"billy"},"provider":{"name":"bobby"},"interactions":[{"description":"Some name for the test","provider_state":"Some state","request":{"method":"GET","path":"/foobar"},"response":{"status":200,"headers":{"Content-Type":"application/json"}}},{"description":"Some name for the test","provider_state":"Some state2","request":{"method":"GET","path":"/bazbat"},"response":{"status":200,"headers":{},"body":[[{"colour":"red","size":10,"tag":[["jumper","shirt"],["jumper","shirt"]]}]],"matchingRules":{"$.body":{"min":1},"$.body[*].*":{"match":"type"},"$.body[*]":{"min":1},"$.body[*][*].*":{"match":"type"},"$.body[*][*].colour":{"match":"regex","regex":"red|green|blue"},"$.body[*][*].size":{"match":"type"},"$.body[*][*].tag":{"min":2},"$.body[*][*].tag[*].*":{"match":"type"},"$.body[*][*].tag[*][0]":{"match":"type"},"$.body[*][*].tag[*][1]":{"match":"type"}}}}],"metadata":{"pactSpecificationVersion":"2.0.0"},"updatedAt":"2016-06-11T13:11:33+00:00","createdAt":"2016-06-09T12:46:42+00:00","_links":{"self":{"title":"Pact","name":"Pact between billy (v1.0.0) and bobby","href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.0"},"pb:consumer":{"title":"Consumer","name":"billy","href":"http://localhost:%d/pacticipants/billy"},"pb:provider":{"title":"Provider","name":"bobby","href":"http://localhost:%d/pacticipants/bobby"},"pb:latest-pact-version":{"title":"Pact","name":"Latest version of this pact","href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/latest"},"pb:previous-distinct":{"title":"Pact","name":"Previous distinct version of this pact","href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.0/previous-distinct"},"pb:diff-previous-distinct":{"title":"Diff","name":"Diff with previous distinct version of this pact","href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.0/diff/previous-distinct"},"pb:pact-webhooks":{"title":"Webhooks for the pact between billy and bobby","href":"http://localhost:%d/webhooks/provider/bobby/consumer/billy"},"pb:tag-prod-version":{"title":"Tag this version as 'production'","href":"http://localhost:%d/pacticipants/billy/versions/1.0.0/tags/prod"},"pb:tag-version":{"title":"Tag version","href":"http://localhost:%d/pacticipants/billy/versions/1.0.0/tags/{tag}"},"curies":[{"name":"pb","href":"http://localhost:%d/doc/{rel}","templated":true}]}}`, port, port, port, port, port, port, port, port, port, port)
+		w.Header().Add("Content-Type", "application/hal+json")
+	})
+
+	go http.ListenAndServe(fmt.Sprintf(":%d", port), mux)
+	return port
+}

--- a/dsl/broker_test.go
+++ b/dsl/broker_test.go
@@ -10,8 +10,8 @@ import (
 	"github.com/pact-foundation/pact-go/utils"
 )
 
-func TestPact_findConsumers(t *testing.T) {
-	port := setupMockBroker()
+func TestPact_findConsumersNoTags(t *testing.T) {
+	port := setupMockBroker(false)
 	request := &types.VerifyRequest{
 		BrokerURL: fmt.Sprintf("http://localhost:%d", port),
 	}
@@ -25,13 +25,13 @@ func TestPact_findConsumers(t *testing.T) {
 	}
 
 	pactURL := fmt.Sprintf("http://localhost:%d/pacts/provider/bobby/consumer/jessica/version/2.0.0", port)
-	if request.PactURLs[0] != pactURL {
+	if request.PactURLs[0] != pactURL && request.PactURLs[1] != pactURL {
 		t.Fatalf("Expected '%s', but got '%s'", pactURL, request.PactURLs[0])
 	}
 }
 
 func TestPact_findConsumersWithTags(t *testing.T) {
-	port := setupMockBroker()
+	port := setupMockBroker(false)
 	request := &types.VerifyRequest{
 		Tags:      []string{"dev", "prod"},
 		BrokerURL: fmt.Sprintf("http://localhost:%d", port),
@@ -46,47 +46,179 @@ func TestPact_findConsumersWithTags(t *testing.T) {
 	}
 
 	pactURL := fmt.Sprintf("http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.1", port)
-	if request.PactURLs[0] != pactURL {
+	if request.PactURLs[0] != pactURL && request.PactURLs[1] != pactURL {
 		t.Fatalf("Expected '%s', but got '%s'", pactURL, request.PactURLs[0])
 	}
 }
 
+func TestPact_findConsumersBrokerDown(t *testing.T) {
+	port, _ := utils.GetFreePort()
+	request := &types.VerifyRequest{
+		Tags:      []string{"dev", "prod"},
+		BrokerURL: fmt.Sprintf("http://localhost:%d", port),
+	}
+	err := findConsumers("idontexist", request)
+
+	if err == nil {
+		t.Fatalf("Expected error but got none")
+	}
+}
+
+func TestPact_findConsumersInvalidResponse(t *testing.T) {
+	port := setupMockBroker(false)
+	request := &types.VerifyRequest{
+		Tags:      []string{"broken"},
+		BrokerURL: fmt.Sprintf("http://localhost:%d", port),
+	}
+	err := findConsumers("bobby", request)
+
+	if err == nil {
+		t.Fatalf("Expected error but got none")
+	}
+}
+
+func TestPact_findConsumersInvalidURL(t *testing.T) {
+	request := &types.VerifyRequest{
+		BrokerURL: "%%%",
+	}
+	err := findConsumers("broken", request)
+
+	if err == nil {
+		t.Fatalf("Expected error but got none")
+	}
+}
+
+func TestPact_findConsumersErrorResponse(t *testing.T) {
+	port := setupMockBroker(false)
+	request := &types.VerifyRequest{
+		Tags:      []string{"dev"},
+		BrokerURL: fmt.Sprintf("http://localhost:%d", port),
+	}
+	err := findConsumers("broken", request)
+
+	if err == nil {
+		t.Fatalf("Expected error but got none")
+	}
+}
+
+func TestPact_findConsumersNoConsumers(t *testing.T) {
+	port := setupMockBroker(false)
+	request := &types.VerifyRequest{
+		Tags:      []string{"dev", "prod"},
+		BrokerURL: fmt.Sprintf("http://localhost:%d", port),
+	}
+	err := findConsumers("idontexist", request)
+	if err == nil {
+		t.Fatalf("Expected error but got none")
+	}
+}
+
+func TestPact_findConsumersAuthenticated(t *testing.T) {
+	port := setupMockBroker(true)
+	request := &types.VerifyRequest{
+		Tags:           []string{"dev", "prod"},
+		BrokerURL:      fmt.Sprintf("http://localhost:%d", port),
+		BrokerUsername: "foo",
+		BrokerPassword: "bar",
+	}
+	err := findConsumers("bobby", request)
+	if err != nil {
+		t.Fatalf("Error: %s", err)
+	}
+}
+
+func TestPact_findConsumersAuthenticatedFail(t *testing.T) {
+	port := setupMockBroker(true)
+	request := &types.VerifyRequest{
+		Tags:      []string{"dev", "prod"},
+		BrokerURL: fmt.Sprintf("http://localhost:%d", port),
+	}
+	err := findConsumers("bobby", request)
+
+	switch err {
+	case ErrUnauthorized:
+	default:
+		t.Fatalf("Expected error to be 'ErrNotAuthorized' but got %s", err)
+	}
+}
+
 // Pretend to be a Broker for fetching Pacts
-func setupMockBroker() int {
+func setupMockBroker(auth bool) int {
 	port, _ := utils.GetFreePort()
 	mux := http.NewServeMux()
+	var authFunc func(inner http.HandlerFunc) http.HandlerFunc
+
+	if auth {
+		// Use the foo/bar basic authentication middleware in publish_test.go
+		authFunc = func(inner http.HandlerFunc) http.HandlerFunc {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if checkAuth(w, r) {
+					log.Println("[DEBUG] broker - authenticated!")
+					inner.ServeHTTP(w, r)
+					return
+				}
+
+				w.Header().Set("WWW-Authenticate", `Basic realm="Broker Authentication Required"`)
+				w.WriteHeader(401)
+				w.Write([]byte("401 Unauthorized\n"))
+			})
+		}
+	} else {
+		// Create a do-nothing authentication middleware
+		authFunc = func(inner http.HandlerFunc) http.HandlerFunc {
+			return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				log.Println("[DEBUG] broker - no authentication")
+				inner.ServeHTTP(w, r)
+			})
+		}
+	}
 
 	// Find latest 'bobby' consumers (no tag)
 	// curl --user pactuser:pact -H "accept: application/hal+json" "http://pact.onegeek.com.au/pacts/provider/bobby/latest"
-	mux.HandleFunc("/pacts/provider/bobby/latest", func(w http.ResponseWriter, req *http.Request) {
+	mux.HandleFunc("/pacts/provider/bobby/latest", authFunc(func(w http.ResponseWriter, req *http.Request) {
 		log.Println("[DEBUG] get pacts for provider 'bobby'")
 		fmt.Fprintf(w, `{"_links":{"self":{"href":"http://localhost:%d/pacts/provider/bobby/latest","title":"Latest pact versions for the provider bobby"},"provider":{"href":"http://localhost:%d/pacticipants/bobby","title":"bobby"},"pacts":[{"href":"http://localhost:%d/pacts/provider/bobby/consumer/jessica/version/2.0.0","title":"Pact between jessica (v2.0.0) and bobby","name":"jessica"},{"href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.0","title":"Pact between billy (v1.0.0) and bobby","name":"billy"}]}}`, port, port, port, port)
 		w.Header().Add("Content-Type", "application/hal+json")
-	})
+	}))
 
 	// Find 'bobby' consumers for tag 'prod'
 	// curl --user pactuser:pact -H "accept: application/hal+json" "http://pact.onegeek.com.au/pacts/provider/bobby/latest/sit4"
-	mux.HandleFunc("/pacts/provider/bobby/latest/prod", func(w http.ResponseWriter, req *http.Request) {
+	mux.Handle("/pacts/provider/bobby/latest/prod", authFunc(func(w http.ResponseWriter, req *http.Request) {
 		log.Println("[DEBUG] get all pacts for provider 'bobby' where the tag 'prod' exists")
 		fmt.Fprintf(w, `{"_links":{"self":{"href":"http://localhost:%d/pacts/provider/bobby/latest/dev","title":"Latest pact versions for the provider bobby with tag 'dev'"},"provider":{"href":"http://localhost:%d/pacticipants/bobby","title":"bobby"},"pacts":[{"href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.0","title":"Pact between billy (v1.0.0) and bobby","name":"billy"}]}}`, port, port, port)
 		w.Header().Add("Content-Type", "application/hal+json")
-	})
+	}))
+
+	// Broken response
+	mux.Handle("/pacts/provider/bobby/latest/broken", authFunc(func(w http.ResponseWriter, req *http.Request) {
+		log.Println("[DEBUG] broken broker")
+		fmt.Fprintf(w, `broken response`)
+		w.Header().Add("Content-Type", "application/hal+json")
+	}))
+
+	// 50x response
+	// curl --user pactuser:pact -H "accept: application/hal+json" "http://pact.onegeek.com.au/pacts/provider/bobby/latest/sit4"
+	mux.Handle("/pacts/provider/broken/latest/dev", authFunc(func(w http.ResponseWriter, req *http.Request) {
+		log.Println("[DEBUG] broker broker response")
+		w.WriteHeader(500)
+		w.Write([]byte("500 Server Error\n"))
+	}))
 
 	// Find 'bobby' consumers for tag 'dev'
 	// curl --user pactuser:pact -H "accept: application/hal+json" "http://pact.onegeek.com.au/pacts/provider/bobby/latest/sit4"
-	mux.HandleFunc("/pacts/provider/bobby/latest/dev", func(w http.ResponseWriter, req *http.Request) {
+	mux.Handle("/pacts/provider/bobby/latest/dev", authFunc(func(w http.ResponseWriter, req *http.Request) {
 		log.Println("[DEBUG] get all pacts for provider 'bobby' where the tag 'dev' exists")
 		fmt.Fprintf(w, `{"_links":{"self":{"href":"http://localhost:%d/pacts/provider/bobby/latest/dev","title":"Latest pact versions for the provider bobby with tag 'dev'"},"provider":{"href":"http://localhost:%d/pacticipants/bobby","title":"bobby"},"pacts":[{"href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.1","title":"Pact between billy (v1.0.1) and bobby","name":"billy"}]}}`, port, port, port)
 		w.Header().Add("Content-Type", "application/hal+json")
-	})
+	}))
 
 	// Actual Consumer Pact
 	// curl -v --user pactuser:pact -H "accept: application/json" http://pact.onegeek.com.au/pacts/provider/bobby/consumer/billy/version/1.0.0
-	mux.HandleFunc("/pacts/provider/bobby/consumer/billy/version/", func(w http.ResponseWriter, req *http.Request) {
+	mux.Handle("/pacts/provider/bobby/consumer/billy/version/", authFunc(func(w http.ResponseWriter, req *http.Request) {
 		log.Println("[DEBUG] get all pacts for provider 'bobby' where any tag exists")
 		fmt.Fprintf(w, `{"consumer":{"name":"billy"},"provider":{"name":"bobby"},"interactions":[{"description":"Some name for the test","provider_state":"Some state","request":{"method":"GET","path":"/foobar"},"response":{"status":200,"headers":{"Content-Type":"application/json"}}},{"description":"Some name for the test","provider_state":"Some state2","request":{"method":"GET","path":"/bazbat"},"response":{"status":200,"headers":{},"body":[[{"colour":"red","size":10,"tag":[["jumper","shirt"],["jumper","shirt"]]}]],"matchingRules":{"$.body":{"min":1},"$.body[*].*":{"match":"type"},"$.body[*]":{"min":1},"$.body[*][*].*":{"match":"type"},"$.body[*][*].colour":{"match":"regex","regex":"red|green|blue"},"$.body[*][*].size":{"match":"type"},"$.body[*][*].tag":{"min":2},"$.body[*][*].tag[*].*":{"match":"type"},"$.body[*][*].tag[*][0]":{"match":"type"},"$.body[*][*].tag[*][1]":{"match":"type"}}}}],"metadata":{"pactSpecificationVersion":"2.0.0"},"updatedAt":"2016-06-11T13:11:33+00:00","createdAt":"2016-06-09T12:46:42+00:00","_links":{"self":{"title":"Pact","name":"Pact between billy (v1.0.0) and bobby","href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.0"},"pb:consumer":{"title":"Consumer","name":"billy","href":"http://localhost:%d/pacticipants/billy"},"pb:provider":{"title":"Provider","name":"bobby","href":"http://localhost:%d/pacticipants/bobby"},"pb:latest-pact-version":{"title":"Pact","name":"Latest version of this pact","href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/latest"},"pb:previous-distinct":{"title":"Pact","name":"Previous distinct version of this pact","href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.0/previous-distinct"},"pb:diff-previous-distinct":{"title":"Diff","name":"Diff with previous distinct version of this pact","href":"http://localhost:%d/pacts/provider/bobby/consumer/billy/version/1.0.0/diff/previous-distinct"},"pb:pact-webhooks":{"title":"Webhooks for the pact between billy and bobby","href":"http://localhost:%d/webhooks/provider/bobby/consumer/billy"},"pb:tag-prod-version":{"title":"Tag this version as 'production'","href":"http://localhost:%d/pacticipants/billy/versions/1.0.0/tags/prod"},"pb:tag-version":{"title":"Tag version","href":"http://localhost:%d/pacticipants/billy/versions/1.0.0/tags/{tag}"},"curies":[{"name":"pb","href":"http://localhost:%d/doc/{rel}","templated":true}]}}`, port, port, port, port, port, port, port, port, port, port)
 		w.Header().Add("Content-Type", "application/hal+json")
-	})
+	}))
 
 	go http.ListenAndServe(fmt.Sprintf(":%d", port), mux)
 	return port

--- a/dsl/mock_service.go
+++ b/dsl/mock_service.go
@@ -28,6 +28,7 @@ type MockService struct {
 func (m *MockService) call(method string, url string, content interface{}) error {
 	body, err := json.Marshal(content)
 	if err != nil {
+		fmt.Println(err)
 		return err
 	}
 

--- a/dsl/mock_service_test.go
+++ b/dsl/mock_service_test.go
@@ -4,9 +4,12 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math"
 	"net/http"
 	"net/http/httptest"
 	"testing"
+
+	"github.com/pact-foundation/pact-go/utils"
 )
 
 // Simple mock server for testing. This is getting confusing...
@@ -139,6 +142,37 @@ func TestMockService_VerifyFail(t *testing.T) {
 	}
 
 	err := mockService.Verify()
+
+	if err == nil {
+		t.Fatalf("Expected error but got none")
+	}
+}
+
+func TestMockService_callBadMethod(t *testing.T) {
+	mockService := &MockService{}
+
+	err := mockService.call("BADVERB", "%%", nil)
+	if err == nil {
+		t.Fatalf("Expected error but got none")
+	}
+}
+
+func TestMockService_callNoBroker(t *testing.T) {
+	port, _ := utils.GetFreePort()
+	mockService := &MockService{}
+
+	err := mockService.call("GET", fmt.Sprintf("http://localhost:%d/", port), nil)
+
+	if err == nil {
+		t.Fatalf("Expected error but got none")
+	}
+}
+
+func TestMockService_callInvalidObject(t *testing.T) {
+	port, _ := utils.GetFreePort()
+	mockService := &MockService{}
+
+	err := mockService.call("GET", fmt.Sprintf("http://localhost:%d/", port), math.Inf(-1))
 
 	if err == nil {
 		t.Fatalf("Expected error but got none")

--- a/dsl/pact.go
+++ b/dsl/pact.go
@@ -181,6 +181,19 @@ func (p *Pact) WritePact() error {
 // a running Provider API.
 func (p *Pact) VerifyProvider(request *types.VerifyRequest) *types.CommandResponse {
 	p.Setup()
+
+	// If we provide a Broker, we go to it to find consumers
+	if request.BrokerURL != "" {
+		log.Printf("[DEBUG] pact provider verification - finding all consumers from broker: %s", request.BrokerURL)
+		err := findConsumers(p.Provider, request)
+		if err != nil {
+			return &types.CommandResponse{
+				Message: err.Error(),
+			}
+		}
+	}
+
 	log.Printf("[DEBUG] pact provider verification")
+
 	return p.pactClient.VerifyProvider(request)
 }

--- a/dsl/pact.go
+++ b/dsl/pact.go
@@ -188,7 +188,8 @@ func (p *Pact) VerifyProvider(request *types.VerifyRequest) *types.CommandRespon
 		err := findConsumers(p.Provider, request)
 		if err != nil {
 			return &types.CommandResponse{
-				Message: err.Error(),
+				Message:  err.Error(),
+				ExitCode: 1,
 			}
 		}
 	}

--- a/dsl/pact_test.go
+++ b/dsl/pact_test.go
@@ -406,7 +406,7 @@ func TestPact_Integration(t *testing.T) {
 			PactURLs:        []string{"../pacts/billy-bobby.json"},
 			PactBroker:      brokerHost,
 			ConsumerVersion: "1.0.0",
-			Tags:            []string{"latest", "foobar", "sit4"},
+			Tags:            []string{"latest", "sit4"},
 			BrokerUsername:  os.Getenv("PACT_BROKER_USERNAME"),
 			BrokerPassword:  os.Getenv("PACT_BROKER_PASSWORD"),
 		})
@@ -428,10 +428,41 @@ func TestPact_Integration(t *testing.T) {
 			t.Fatalf("Expected exit code of 0, got %d", response.ExitCode)
 		}
 
-		// Verify the Provider - Published Pacts
+		// Verify the Provider - Specific Published Pacts
 		response = pact.VerifyProvider(&types.VerifyRequest{
 			ProviderBaseURL:        fmt.Sprintf("http://localhost:%d", providerPort),
 			PactURLs:               []string{fmt.Sprintf("%s/pacts/provider/bobby/consumer/billy/latest/sit4", brokerHost)},
+			ProviderStatesURL:      fmt.Sprintf("http://localhost:%d/states", providerPort),
+			ProviderStatesSetupURL: fmt.Sprintf("http://localhost:%d/setup", providerPort),
+			BrokerUsername:         os.Getenv("PACT_BROKER_USERNAME"),
+			BrokerPassword:         os.Getenv("PACT_BROKER_PASSWORD"),
+		})
+		fmt.Println(response.Message)
+
+		if response.ExitCode != 0 {
+			t.Fatalf("Expected exit code of 0, got %d", response.ExitCode)
+		}
+
+		// Verify the Provider - Latest Published Pacts for any known consumers
+		response = pact.VerifyProvider(&types.VerifyRequest{
+			ProviderBaseURL:        fmt.Sprintf("http://localhost:%d", providerPort),
+			BrokerURL:              brokerHost,
+			ProviderStatesURL:      fmt.Sprintf("http://localhost:%d/states", providerPort),
+			ProviderStatesSetupURL: fmt.Sprintf("http://localhost:%d/setup", providerPort),
+			BrokerUsername:         os.Getenv("PACT_BROKER_USERNAME"),
+			BrokerPassword:         os.Getenv("PACT_BROKER_PASSWORD"),
+		})
+		fmt.Println(response.Message)
+
+		if response.ExitCode != 0 {
+			t.Fatalf("Expected exit code of 0, got %d", response.ExitCode)
+		}
+
+		// Verify the Provider - Tag-based Published Pacts for any known consumers
+		response = pact.VerifyProvider(&types.VerifyRequest{
+			ProviderBaseURL:        fmt.Sprintf("http://localhost:%d", providerPort),
+			BrokerURL:              brokerHost,
+			Tags:                   []string{"latest", "sit4"},
 			ProviderStatesURL:      fmt.Sprintf("http://localhost:%d/states", providerPort),
 			ProviderStatesSetupURL: fmt.Sprintf("http://localhost:%d/setup", providerPort),
 			BrokerUsername:         os.Getenv("PACT_BROKER_USERNAME"),

--- a/dsl/publish.go
+++ b/dsl/publish.go
@@ -62,8 +62,8 @@ func (p *Publisher) validate() error {
 		return errors.New("ConsumerVersion is mandatory")
 	}
 
-	if (p.request.BrokerUsername != "" && p.request.PactBrokerPassword == "") || (p.request.BrokerUsername == "" && p.request.PactBrokerPassword != "") {
-		return errors.New("Must provide both or none of BrokerUsername and PactBrokerPassword")
+	if (p.request.BrokerUsername != "" && p.request.BrokerPassword == "") || (p.request.BrokerUsername == "" && p.request.BrokerPassword != "") {
+		return errors.New("Must provide both or none of BrokerUsername and BrokerPassword")
 	}
 
 	return nil
@@ -81,8 +81,8 @@ func (p *Publisher) call(method string, url string, content []byte) error {
 
 	req.Header.Set("Content-Type", "application/json")
 
-	if p.request != nil && p.request.BrokerUsername != "" && p.request.PactBrokerPassword != "" {
-		req.SetBasicAuth(p.request.BrokerUsername, p.request.PactBrokerPassword)
+	if p.request != nil && p.request.BrokerUsername != "" && p.request.BrokerPassword != "" {
+		req.SetBasicAuth(p.request.BrokerUsername, p.request.BrokerPassword)
 	}
 
 	res, err := client.Do(req)

--- a/dsl/publish_test.go
+++ b/dsl/publish_test.go
@@ -64,27 +64,26 @@ func createSimplePact(valid bool) *os.File {
 	return tmpfile
 }
 
-func createMockRemoteServerWithAuth(valid bool) *httptest.Server {
-	var checkAuth = func(w http.ResponseWriter, r *http.Request) bool {
-		s := strings.SplitN(r.Header.Get("Authorization"), " ", 2)
-		if len(s) != 2 {
-			return false
-		}
-
-		b, err := base64.StdEncoding.DecodeString(s[1])
-		if err != nil {
-			return false
-		}
-
-		pair := strings.SplitN(string(b), ":", 2)
-		if len(pair) != 2 {
-			return false
-		}
-
-		return pair[0] == "foo" && pair[1] == "bar"
-
+var checkAuth = func(w http.ResponseWriter, r *http.Request) bool {
+	s := strings.SplitN(r.Header.Get("Authorization"), " ", 2)
+	if len(s) != 2 {
+		return false
 	}
 
+	b, err := base64.StdEncoding.DecodeString(s[1])
+	if err != nil {
+		return false
+	}
+
+	pair := strings.SplitN(string(b), ":", 2)
+	if len(pair) != 2 {
+		return false
+	}
+
+	return pair[0] == "foo" && pair[1] == "bar"
+}
+
+func createMockRemoteServerWithAuth(valid bool) *httptest.Server {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		if checkAuth(w, r) {
 			w.Write([]byte("Authenticated!"))
@@ -157,8 +156,8 @@ func TestPublish_validate(t *testing.T) {
 			PactURLs: []string{
 				testFile,
 			},
-			ConsumerVersion:    "1.0.0",
-			BrokerPassword: "passwithoutuser",
+			ConsumerVersion: "1.0.0",
+			BrokerPassword:  "passwithoutuser",
 		},
 	}
 
@@ -397,6 +396,24 @@ func TestPublish_PublishFail(t *testing.T) {
 	}
 }
 
+func TestPublish_callFail(t *testing.T) {
+	p := &Publisher{}
+	err := p.call("GET", "%%%", nil)
+
+	if err == nil {
+		t.Fatalf("Expected error but got none")
+	}
+}
+
+func TestPublish_callFailNoBroker(t *testing.T) {
+	p := &Publisher{}
+	port, _ := utils.GetFreePort()
+	err := p.call("GET", fmt.Sprintf("http://localhost:%d/", port), nil)
+	if err == nil {
+		t.Fatalf("Expected error but got none")
+	}
+}
+
 func TestPublish_PublishWithTags(t *testing.T) {
 	p := &Publisher{}
 
@@ -424,11 +441,11 @@ func TestPublish_PublishWithAuth(t *testing.T) {
 	defer broker.Close()
 
 	err := p.Publish(&types.PublishRequest{
-		PactURLs:           []string{f.Name()},
-		PactBroker:         broker.URL,
-		ConsumerVersion:    "1.0.0",
-		BrokerUsername:     "foo",
-		BrokerPassword: "bar",
+		PactURLs:        []string{f.Name()},
+		PactBroker:      broker.URL,
+		ConsumerVersion: "1.0.0",
+		BrokerUsername:  "foo",
+		BrokerPassword:  "bar",
 	})
 
 	if err != nil {
@@ -444,11 +461,11 @@ func TestPublish_PublishWithAuthFail(t *testing.T) {
 	defer broker.Close()
 
 	err := p.Publish(&types.PublishRequest{
-		PactURLs:           []string{f.Name()},
-		PactBroker:         broker.URL,
-		ConsumerVersion:    "1.0.0",
-		BrokerUsername:     "foo",
-		BrokerPassword: "fail",
+		PactURLs:        []string{f.Name()},
+		PactBroker:      broker.URL,
+		ConsumerVersion: "1.0.0",
+		BrokerUsername:  "foo",
+		BrokerPassword:  "fail",
 	})
 
 	if err == nil {

--- a/dsl/publish_test.go
+++ b/dsl/publish_test.go
@@ -147,7 +147,7 @@ func TestPublish_validate(t *testing.T) {
 	}
 
 	err = p.validate()
-	if err.Error() != "Must provide both or none of BrokerUsername and PactBrokerPassword" {
+	if err.Error() != "Must provide both or none of BrokerUsername and BrokerPassword" {
 		t.Fatalf("Expected a different error but got '%s'", err.Error())
 	}
 
@@ -158,12 +158,12 @@ func TestPublish_validate(t *testing.T) {
 				testFile,
 			},
 			ConsumerVersion:    "1.0.0",
-			PactBrokerPassword: "passwithoutuser",
+			BrokerPassword: "passwithoutuser",
 		},
 	}
 
 	err = p.validate()
-	if err.Error() != "Must provide both or none of BrokerUsername and PactBrokerPassword" {
+	if err.Error() != "Must provide both or none of BrokerUsername and BrokerPassword" {
 		t.Fatalf("Expected a different error but got '%s'", err.Error())
 	}
 
@@ -428,7 +428,7 @@ func TestPublish_PublishWithAuth(t *testing.T) {
 		PactBroker:         broker.URL,
 		ConsumerVersion:    "1.0.0",
 		BrokerUsername:     "foo",
-		PactBrokerPassword: "bar",
+		BrokerPassword: "bar",
 	})
 
 	if err != nil {
@@ -448,7 +448,7 @@ func TestPublish_PublishWithAuthFail(t *testing.T) {
 		PactBroker:         broker.URL,
 		ConsumerVersion:    "1.0.0",
 		BrokerUsername:     "foo",
-		PactBrokerPassword: "fail",
+		BrokerPassword: "fail",
 	})
 
 	if err == nil {

--- a/types/publish_request.go
+++ b/types/publish_request.go
@@ -12,7 +12,7 @@ type PublishRequest struct {
 	BrokerUsername string
 
 	// Password for Pact Broker basic authentication. Optional
-	PactBrokerPassword string
+	BrokerPassword string
 
 	// ConsumerVersion is the semantical version of the consumer API.
 	ConsumerVersion string

--- a/types/verify_request.go
+++ b/types/verify_request.go
@@ -13,6 +13,12 @@ type VerifyRequest struct {
 	// Local/HTTP paths to Pact files.
 	PactURLs []string
 
+	// Pact Broker URL for broker-based verification
+	BrokerURL string
+
+	// Tags to find in Broker for matrix-based testing
+	Tags []string
+
 	// URL to retrieve valid Provider States.
 	ProviderStatesURL string
 


### PR DESCRIPTION
Added new fields `BrokerURL` and `Tags` to the `pact.Verify()` function.

If `BrokerURL` is provided, pact will explore a Pact Broker and find all of the latest versions of any consumers (using HAL to navigate). This alleviates the need to explicitly pass in `PactURLs` and is more flexible as more consumers come on board.

Additionally, if `Tags` is provided, Pact will find all of the latest consumers by each Tag. This is useful when using [Matrix based testing](http://rea.tech/enter-the-pact-matrix-or-how-to-decouple-the-release-cycles-of-your-microservices/).