### PR TITLE
Fix/windows

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -6,6 +6,8 @@ import (
 )
 
 var port int
+var network string
+var address string
 var daemonCmdInstance *daemon.Daemon
 var daemonCmd = &cobra.Command{
 	Use:   "daemon",
@@ -19,11 +21,13 @@ var daemonCmd = &cobra.Command{
 		verifier := &daemon.VerificationService{}
 		verifier.Setup()
 		daemonCmdInstance = daemon.NewDaemon(mock, verifier)
-		daemonCmdInstance.StartDaemon(port)
+		daemonCmdInstance.StartDaemon(port, network, address)
 	},
 }
 
 func init() {
-	daemonCmd.Flags().IntVarP(&port, "port", "p", 6666, "Local daemon port")
+	daemonCmd.Flags().IntVarP(&port, "port", "p", 6666, "Local daemon port to listen on")
+	daemonCmd.Flags().StringVarP(&network, "network", "n", "", "Local network interface to listen on ('tcp', 'tcp4', 'tcp6')")
+	daemonCmd.Flags().StringVarP(&address, "address", "a", "", "Local network address to listen on (e.g. '', '127.0.0.1', '[::1]' etc.)")
 	RootCmd.AddCommand(daemonCmd)
 }

--- a/command/daemon.go
+++ b/command/daemon.go
@@ -27,7 +27,7 @@ var daemonCmd = &cobra.Command{
 
 func init() {
 	daemonCmd.Flags().IntVarP(&port, "port", "p", 6666, "Local daemon port to listen on")
-	daemonCmd.Flags().StringVarP(&network, "network", "n", "", "Local network interface to listen on ('tcp', 'tcp4', 'tcp6')")
+	daemonCmd.Flags().StringVarP(&network, "network", "n", "tcp", "Local network interface to listen on ('tcp', 'tcp4', 'tcp6')")
 	daemonCmd.Flags().StringVarP(&address, "address", "a", "", "Local network address to listen on (e.g. '', '127.0.0.1', '[::1]' etc.)")
 	RootCmd.AddCommand(daemonCmd)
 }

--- a/command/daemon_test.go
+++ b/command/daemon_test.go
@@ -30,6 +30,7 @@ func TestDaemonCommand(t *testing.T) {
 	args := []string{"daemon"}
 	p, _ := utils.GetFreePort()
 	port = p
+	network = "tcp"
 	go daemonCmd.Run(nil, args)
 
 	waitForPortInTest(port, t)

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -46,8 +46,8 @@ func NewDaemon(MockServiceManager Service, verificationServiceManager Service) *
 }
 
 // StartDaemon starts the daemon RPC server.
-func (d Daemon) StartDaemon(port int) {
-	log.Println("[INFO] daemon - starting daemon on port", port)
+func (d Daemon) StartDaemon(port int, network string, address string) {
+	log.Println("[INFO] daemon - starting daemon on network:", network, "address:", address, "port:", port)
 
 	serv := rpc.NewServer()
 	serv.Register(d)
@@ -62,7 +62,7 @@ func (d Daemon) StartDaemon(port int) {
 	// Workaround for multiple RPC ServeMux's
 	http.DefaultServeMux = oldMux
 
-	l, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	l, err := net.Listen(network, fmt.Sprintf("%s:%d", address, port))
 	if err != nil {
 		panic(err)
 	}

--- a/daemon/daemon.go
+++ b/daemon/daemon.go
@@ -97,7 +97,7 @@ func (d Daemon) Shutdown() {
 // StartServer starts a mock server and returns a pointer to atypes.MockServer
 // struct.
 func (d Daemon) StartServer(request types.MockServer, reply *types.MockServer) error {
-	log.Println("[DEBUG] daemon - starting mock server")
+	log.Println("[DEBUG] daemon - starting mock server with args:", request.Args)
 	server := &types.MockServer{}
 	port, svc := d.pactMockSvcManager.NewService(request.Args)
 	server.Port = port

--- a/daemon/daemon_test.go
+++ b/daemon/daemon_test.go
@@ -67,7 +67,7 @@ func TestNewDaemon(t *testing.T) {
 func TestStopDaemon(t *testing.T) {
 	d, _ := createMockedDaemon(true)
 	port, _ := utils.GetFreePort()
-	go d.StartDaemon(port)
+	go d.StartDaemon(port, "tcp", "")
 	connectToDaemon(port, t)
 	var res string
 	d.StopDaemon("", &res)
@@ -77,7 +77,7 @@ func TestStopDaemon(t *testing.T) {
 func TestShutdownDaemon(t *testing.T) {
 	d, _ := createMockedDaemon(true)
 	port, _ := utils.GetFreePort()
-	go d.StartDaemon(port)
+	go d.StartDaemon(port, "tcp", "")
 	connectToDaemon(port, t)
 	d.Shutdown()
 }
@@ -129,7 +129,7 @@ func TestStartAndStopDaemon(t *testing.T) {
 	port, _ := utils.GetFreePort()
 	daemon, _ := createMockedDaemon(true)
 	defer waitForDaemonToShutdown(port, daemon, t)
-	go daemon.StartDaemon(port)
+	go daemon.StartDaemon(port, "tcp", "")
 	connectToDaemon(port, t)
 }
 
@@ -339,7 +339,7 @@ func TestRPCClient_List(t *testing.T) {
 	daemon, _ := createMockedDaemon(true)
 	port, _ := utils.GetFreePort()
 	defer waitForDaemonToShutdown(port, daemon, t)
-	go daemon.StartDaemon(port)
+	go daemon.StartDaemon(port, "tcp", "")
 	connectToDaemon(port, t)
 
 	client, err := rpc.DialHTTP("tcp", fmt.Sprintf(":%d", port))
@@ -358,7 +358,7 @@ func TestRPCClient_StartServer(t *testing.T) {
 	daemon, _ := createMockedDaemon(true)
 	port, _ := utils.GetFreePort()
 	defer waitForDaemonToShutdown(port, daemon, t)
-	go daemon.StartDaemon(port)
+	go daemon.StartDaemon(port, "tcp", "")
 	connectToDaemon(port, t)
 
 	client, err := rpc.DialHTTP("tcp", fmt.Sprintf(":%d", port))
@@ -381,7 +381,7 @@ func TestRPCClient_StopServer(t *testing.T) {
 	daemon, manager := createMockedDaemon(true)
 	port, _ := utils.GetFreePort()
 	defer waitForDaemonToShutdown(port, daemon, t)
-	go daemon.StartDaemon(port)
+	go daemon.StartDaemon(port, "tcp", "")
 	connectToDaemon(port, t)
 
 	var cmd *exec.Cmd
@@ -412,7 +412,7 @@ func TestRPCClient_StopDaemon(t *testing.T) {
 	daemon, _ := createMockedDaemon(true)
 	port, _ := utils.GetFreePort()
 	defer waitForDaemonToShutdown(port, daemon, t)
-	go daemon.StartDaemon(port)
+	go daemon.StartDaemon(port, "tcp", "")
 	connectToDaemon(port, t)
 
 	client, err := rpc.DialHTTP("tcp", fmt.Sprintf(":%d", port))
@@ -429,7 +429,7 @@ func TestRPCClient_Verify(t *testing.T) {
 	daemon, _ := createMockedDaemon(true)
 	port, _ := utils.GetFreePort()
 	defer waitForDaemonToShutdown(port, daemon, t)
-	go daemon.StartDaemon(port)
+	go daemon.StartDaemon(port, "tcp", "")
 	connectToDaemon(port, t)
 
 	client, err := rpc.DialHTTP("tcp", fmt.Sprintf(":%d", port))

--- a/daemon/mock_service.go
+++ b/daemon/mock_service.go
@@ -20,7 +20,8 @@ func (m *MockService) NewService(args []string) (int, Service) {
 	log.Println("[DEBUG] starting mock service on port:", port)
 
 	m.Args = []string{
-		fmt.Sprintf("--port %d", port),
+		"--port",
+		fmt.Sprintf("%d", port),
 	}
 	m.Args = append(m.Args, args...)
 

--- a/daemon/mock_service_test.go
+++ b/daemon/mock_service_test.go
@@ -4,7 +4,7 @@ import "testing"
 
 func TestMockService_NewService(t *testing.T) {
 	s := &MockService{}
-	port, svc := s.NewService([]string{"--foo bar"})
+	port, svc := s.NewService([]string{"--foo"})
 
 	if port <= 0 {
 		t.Fatalf("Expected non-zero port but got: %d", port)
@@ -14,7 +14,7 @@ func TestMockService_NewService(t *testing.T) {
 		t.Fatalf("Expected a non-nil object but got nil")
 	}
 
-	if s.Args[1] != "--foo bar" {
-		t.Fatalf("Expected '--foo bar' argument to be passed")
+	if s.Args[2] != "--foo" {
+		t.Fatalf("Expected '--foo' argument to be passed")
 	}
 }

--- a/dsl/client_test.go
+++ b/dsl/client_test.go
@@ -109,7 +109,7 @@ func createDaemon(port int, success bool) (*daemon.Daemon, *daemon.ServiceMock) 
 	}()
 
 	d := daemon.NewDaemon(svc, svc)
-	go d.StartDaemon(port)
+	go d.StartDaemon(port, "tcp", "")
 	return d, svc
 }
 

--- a/dsl/pact.go
+++ b/dsl/pact.go
@@ -86,8 +86,8 @@ func (p *Pact) Setup() *Pact {
 	if p.Server == nil {
 		args := []string{
 			fmt.Sprintf("--pact-specification-version %d", p.SpecificationVersion),
-			fmt.Sprintf("--pact-dir %s", p.PactDir),
-			fmt.Sprintf("--log %s/pact.log", p.LogDir),
+			fmt.Sprintf("--pact-dir %s", filepath.FromSlash(p.PactDir)),
+			fmt.Sprintf("--log %s/pact.log", filepath.FromSlash(p.LogDir+"/"+"pact.log")),
 			fmt.Sprintf("--consumer %s", p.Consumer),
 			fmt.Sprintf("--provider %s", p.Provider),
 		}

--- a/dsl/pact.go
+++ b/dsl/pact.go
@@ -85,11 +85,16 @@ func (p *Pact) Setup() *Pact {
 
 	if p.Server == nil {
 		args := []string{
-			fmt.Sprintf("--pact-specification-version %d", p.SpecificationVersion),
-			fmt.Sprintf("--pact-dir %s", filepath.FromSlash(p.PactDir)),
-			fmt.Sprintf("--log %s", filepath.FromSlash(p.LogDir+"/"+"pact.log")),
-			fmt.Sprintf("--consumer %s", p.Consumer),
-			fmt.Sprintf("--provider %s", p.Provider),
+			"--pact-specification-version",
+			fmt.Sprintf("%d", p.SpecificationVersion),
+			"--pact-dir",
+			filepath.FromSlash(p.PactDir),
+			"--log",
+			filepath.FromSlash(p.LogDir + "/" + "pact.log"),
+			"--consumer",
+			p.Consumer,
+			"--provider",
+			p.Provider,
 		}
 		client := &PactClient{Port: p.Port}
 		p.pactClient = client

--- a/dsl/pact.go
+++ b/dsl/pact.go
@@ -87,7 +87,7 @@ func (p *Pact) Setup() *Pact {
 		args := []string{
 			fmt.Sprintf("--pact-specification-version %d", p.SpecificationVersion),
 			fmt.Sprintf("--pact-dir %s", filepath.FromSlash(p.PactDir)),
-			fmt.Sprintf("--log %s/pact.log", filepath.FromSlash(p.LogDir+"/"+"pact.log")),
+			fmt.Sprintf("--log %s", filepath.FromSlash(p.LogDir+"/"+"pact.log")),
 			fmt.Sprintf("--consumer %s", p.Consumer),
 			fmt.Sprintf("--provider %s", p.Provider),
 		}

--- a/dsl/pact_test.go
+++ b/dsl/pact_test.go
@@ -181,7 +181,7 @@ func TestPact_Setup(t *testing.T) {
 func TestPact_Teardown(t *testing.T) {
 	old := waitForPort
 	defer func() { waitForPort = old }()
-	waitForPort = func(int, string) error {
+	waitForPort = func(int, string, string, string) error {
 		return nil
 	}
 	port, _ := utils.GetFreePort()
@@ -199,7 +199,7 @@ func TestPact_Teardown(t *testing.T) {
 func TestPact_VerifyProvider(t *testing.T) {
 	old := waitForPort
 	defer func() { waitForPort = old }()
-	waitForPort = func(int, string) error {
+	waitForPort = func(int, string, string, string) error {
 		return nil
 	}
 	port, _ := utils.GetFreePort()
@@ -221,7 +221,7 @@ func TestPact_VerifyProviderBroker(t *testing.T) {
 	brokerPort := setupMockBroker(false)
 	old := waitForPort
 	defer func() { waitForPort = old }()
-	waitForPort = func(int, string) error {
+	waitForPort = func(int, string, string, string) error {
 		return nil
 	}
 	port, _ := utils.GetFreePort()
@@ -243,7 +243,7 @@ func TestPact_VerifyProviderBrokerNoConsumers(t *testing.T) {
 	brokerPort := setupMockBroker(false)
 	old := waitForPort
 	defer func() { waitForPort = old }()
-	waitForPort = func(int, string) error {
+	waitForPort = func(int, string, string, string) error {
 		return nil
 	}
 	port, _ := utils.GetFreePort()
@@ -264,7 +264,7 @@ func TestPact_VerifyProviderBrokerNoConsumers(t *testing.T) {
 func TestPact_VerifyProviderFail(t *testing.T) {
 	old := waitForPort
 	defer func() { waitForPort = old }()
-	waitForPort = func(int, string) error {
+	waitForPort = func(int, string, string, string) error {
 		return nil
 	}
 	port, _ := utils.GetFreePort()

--- a/examples/consumer.go
+++ b/examples/consumer.go
@@ -21,6 +21,7 @@ func main() {
 		Port:     6666, // Ensure this port matches the daemon port!
 		Consumer: "MyConsumer",
 		Provider: "MyProvider",
+		Host:     "localhost",
 	}
 	defer pact.Teardown()
 

--- a/types/verify_request.go
+++ b/types/verify_request.go
@@ -42,31 +42,37 @@ type VerifyRequest struct {
 func (v *VerifyRequest) Validate() error {
 	v.Args = []string{}
 	if v.ProviderBaseURL != "" {
-		v.Args = append(v.Args, fmt.Sprintf("--provider-base-url %s", v.ProviderBaseURL))
+		v.Args = append(v.Args, "--provider-base-url")
+		v.Args = append(v.Args, v.ProviderBaseURL)
 	} else {
 		return fmt.Errorf("ProviderBaseURL is mandatory.")
 	}
 
 	if len(v.PactURLs) != 0 {
-		v.Args = append(v.Args, fmt.Sprintf("--pact-urls %s", strings.Join(v.PactURLs[:], ",")))
+		v.Args = append(v.Args, "--pact-urls")
+		v.Args = append(v.Args, strings.Join(v.PactURLs[:], ","))
 	} else {
 		return fmt.Errorf("PactURLs is mandatory.")
 	}
 
 	if v.ProviderStatesSetupURL != "" {
-		v.Args = append(v.Args, fmt.Sprintf("--provider-states-setup-url %s", v.ProviderStatesSetupURL))
+		v.Args = append(v.Args, "--provider-states-setup-url")
+		v.Args = append(v.Args, v.ProviderStatesSetupURL)
 	}
 
 	if v.ProviderStatesURL != "" {
-		v.Args = append(v.Args, fmt.Sprintf("--provider-states-url %s", v.ProviderStatesURL))
+		v.Args = append(v.Args, "--provider-states-url")
+		v.Args = append(v.Args, v.ProviderStatesURL)
 	}
 
 	if v.BrokerUsername != "" {
-		v.Args = append(v.Args, fmt.Sprintf("--broker-username %s", v.BrokerUsername))
+		v.Args = append(v.Args, "--broker-username")
+		v.Args = append(v.Args, v.BrokerUsername)
 	}
 
 	if v.BrokerPassword != "" {
-		v.Args = append(v.Args, fmt.Sprintf("--broker-password %s", v.BrokerPassword))
+		v.Args = append(v.Args, "--broker-password")
+		v.Args = append(v.Args, v.BrokerPassword)
 	}
 	return nil
 }


### PR DESCRIPTION
Windows binds differently to network devices it seems, so we need to deal with it. Additionally, flags passed out to external commands need to be passed as individual slice elements, they can't be bundled.

This feature makes the following changes:

* New flags `-a` and `-n` on the `daemon` command to specify the address to listen on (e.g. 127.0.0.1) and network (tcp, tcp6, tcp4) respectively
* Ability to specify this Address in the Pact DSL (e.g. `dsl.Pact{Address: "localhost"}
* Specifies flags to Mock Service and Verifier individually

Fixes #9.