### PR TITLE
[docs] Remove 4 lines of code from an example

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,12 +99,6 @@ func TestLogin(t *testing.T) {
 	// Shuts down Mock Service when done
 	defer pact.Teardown()
 
-	// Pass in your test case as a function to Verify()
-	var test = func() error {
-		_, err := http.Get(fmt.Sprintf("http://localhost:%d/login", pact.Server.Port))
-		return err
-	}
-
 	// Set up our interactions. Note we have multiple in this test case!
 	pact.
 		AddInteraction().


### PR DESCRIPTION
Hi,

it seems to me, that these lines of code are an artefact and should be removed. Is that right? I've been confused by these, because they aren't necessary.

Cheers