### PR TITLE
fix(verify) prevent crash when calling VerifyProvider()

### DIFF
--- a/dsl/pact.go
+++ b/dsl/pact.go
@@ -101,6 +101,9 @@ func (p *Pact) Setup(startMockServer bool) *Pact {
 		p.SpecificationVersion = 2
 	}
 
+	client := &PactClient{Port: p.Port, Network: p.Network, Address: p.Host}
+	p.pactClient = client
+
 	if p.Server == nil && startMockServer {
 		args := []string{
 			"--pact-specification-version",
@@ -114,8 +117,6 @@ func (p *Pact) Setup(startMockServer bool) *Pact {
 			"--provider",
 			p.Provider,
 		}
-		client := &PactClient{Port: p.Port, Network: p.Network, Address: p.Host}
-		p.pactClient = client
 		p.Server = client.StartServer(args)
 	}
 

--- a/dsl/pact_test.go
+++ b/dsl/pact_test.go
@@ -182,6 +182,9 @@ func TestPact_Setup(t *testing.T) {
 	if pact.Server != nil {
 		t.Fatalf("Expected server to be nil")
 	}
+	if pact.pactClient == nil {
+		t.Fatalf("Needed to still have a client")
+	}
 }
 
 func TestPact_Teardown(t *testing.T) {


### PR DESCRIPTION
I believe this closes #24, but I haven't been yet able to run the smoke tests, because of missing configuration.