### PR TITLE
feat(verification): publish verification results to broker

### DIFF
--- a/daemon/verification_service.go
+++ b/daemon/verification_service.go
@@ -22,6 +22,8 @@ type VerificationService struct {
 // 		--provider-states-setup-url
 // 		--broker-username
 // 		--broker-password
+//    --publish_verification_results
+//    --provider_app_version
 func (m *VerificationService) NewService(args []string) (int, Service) {
 	log.Printf("[DEBUG] starting verification service with args: %v\n", args)
 

--- a/dsl/pact_integration_test.go
+++ b/dsl/pact_integration_test.go
@@ -131,10 +131,11 @@ func TestPact_Integration(t *testing.T) {
 			PactDir:  pactDir,
 		}
 		err = providerPact.VerifyProvider(types.VerifyRequest{
-			ProviderBaseURL:        fmt.Sprintf("http://localhost:%d", providerPort),
-			PactURLs:               []string{fmt.Sprintf("%s/billy-bobby.json", pactDir)},
-			ProviderStatesURL:      fmt.Sprintf("http://localhost:%d/states", providerPort),
-			ProviderStatesSetupURL: fmt.Sprintf("http://localhost:%d/setup", providerPort),
+			ProviderBaseURL:            fmt.Sprintf("http://localhost:%d", providerPort),
+			PactURLs:                   []string{fmt.Sprintf("%s/billy-bobby.json", pactDir)},
+			ProviderStatesURL:          fmt.Sprintf("http://localhost:%d/states", providerPort),
+			ProviderStatesSetupURL:     fmt.Sprintf("http://localhost:%d/setup", providerPort),
+			PublishVerificationResults: false, // No HAL links in local pacts
 		})
 
 		if err != nil {
@@ -143,12 +144,14 @@ func TestPact_Integration(t *testing.T) {
 
 		// Verify the Provider - Specific Published Pacts
 		err = providerPact.VerifyProvider(types.VerifyRequest{
-			ProviderBaseURL:        fmt.Sprintf("http://localhost:%d", providerPort),
-			PactURLs:               []string{fmt.Sprintf("%s/pacts/provider/bobby/consumer/billy/latest/sit4", brokerHost)},
-			ProviderStatesURL:      fmt.Sprintf("http://localhost:%d/states", providerPort),
-			ProviderStatesSetupURL: fmt.Sprintf("http://localhost:%d/setup", providerPort),
-			BrokerUsername:         os.Getenv("PACT_BROKER_USERNAME"),
-			BrokerPassword:         os.Getenv("PACT_BROKER_PASSWORD"),
+			ProviderBaseURL:            fmt.Sprintf("http://localhost:%d", providerPort),
+			PactURLs:                   []string{fmt.Sprintf("%s/pacts/provider/bobby/consumer/billy/latest/sit4", brokerHost)},
+			ProviderStatesURL:          fmt.Sprintf("http://localhost:%d/states", providerPort),
+			ProviderStatesSetupURL:     fmt.Sprintf("http://localhost:%d/setup", providerPort),
+			BrokerUsername:             os.Getenv("PACT_BROKER_USERNAME"),
+			BrokerPassword:             os.Getenv("PACT_BROKER_PASSWORD"),
+			PublishVerificationResults: true,
+			ProviderVersion:            "1.0.0",
 		})
 
 		if err != nil {
@@ -157,12 +160,14 @@ func TestPact_Integration(t *testing.T) {
 
 		// Verify the Provider - Latest Published Pacts for any known consumers
 		err = providerPact.VerifyProvider(types.VerifyRequest{
-			ProviderBaseURL:        fmt.Sprintf("http://localhost:%d", providerPort),
-			BrokerURL:              brokerHost,
-			ProviderStatesURL:      fmt.Sprintf("http://localhost:%d/states", providerPort),
-			ProviderStatesSetupURL: fmt.Sprintf("http://localhost:%d/setup", providerPort),
-			BrokerUsername:         os.Getenv("PACT_BROKER_USERNAME"),
-			BrokerPassword:         os.Getenv("PACT_BROKER_PASSWORD"),
+			ProviderBaseURL:            fmt.Sprintf("http://localhost:%d", providerPort),
+			BrokerURL:                  brokerHost,
+			ProviderStatesURL:          fmt.Sprintf("http://localhost:%d/states", providerPort),
+			ProviderStatesSetupURL:     fmt.Sprintf("http://localhost:%d/setup", providerPort),
+			BrokerUsername:             os.Getenv("PACT_BROKER_USERNAME"),
+			BrokerPassword:             os.Getenv("PACT_BROKER_PASSWORD"),
+			PublishVerificationResults: true,
+			ProviderVersion:            "1.0.0",
 		})
 
 		if err != nil {
@@ -171,13 +176,15 @@ func TestPact_Integration(t *testing.T) {
 
 		// Verify the Provider - Tag-based Published Pacts for any known consumers
 		err = providerPact.VerifyProvider(types.VerifyRequest{
-			ProviderBaseURL:        fmt.Sprintf("http://localhost:%d", providerPort),
-			BrokerURL:              brokerHost,
-			Tags:                   []string{"latest", "sit4"},
-			ProviderStatesURL:      fmt.Sprintf("http://localhost:%d/states", providerPort),
-			ProviderStatesSetupURL: fmt.Sprintf("http://localhost:%d/setup", providerPort),
-			BrokerUsername:         os.Getenv("PACT_BROKER_USERNAME"),
-			BrokerPassword:         os.Getenv("PACT_BROKER_PASSWORD"),
+			ProviderBaseURL:            fmt.Sprintf("http://localhost:%d", providerPort),
+			BrokerURL:                  brokerHost,
+			Tags:                       []string{"latest", "sit4"},
+			ProviderStatesURL:          fmt.Sprintf("http://localhost:%d/states", providerPort),
+			ProviderStatesSetupURL:     fmt.Sprintf("http://localhost:%d/setup", providerPort),
+			BrokerUsername:             os.Getenv("PACT_BROKER_USERNAME"),
+			BrokerPassword:             os.Getenv("PACT_BROKER_PASSWORD"),
+			PublishVerificationResults: true,
+			ProviderVersion:            "1.0.0",
 		})
 
 		if err != nil {

--- a/dsl/pact_test.go
+++ b/dsl/pact_test.go
@@ -239,8 +239,10 @@ func TestPact_VerifyProviderBroker(t *testing.T) {
 
 	pact := &Pact{Port: port, LogLevel: "DEBUG", pactClient: &PactClient{Port: port}, Provider: "bobby"}
 	err := pact.VerifyProvider(types.VerifyRequest{
-		ProviderBaseURL: "http://www.foo.com",
-		BrokerURL:       fmt.Sprintf("http://localhost:%d", brokerPort),
+		ProviderBaseURL:            "http://www.foo.com",
+		BrokerURL:                  fmt.Sprintf("http://localhost:%d", brokerPort),
+		PublishVerificationResults: true,
+		ProviderVersion:            "1.0.0",
 	})
 
 	if err != nil {

--- a/scripts/package.sh
+++ b/scripts/package.sh
@@ -3,7 +3,7 @@
 set -e
 
 export PACT_MOCK_SERVICE_VERSION=2.0.0 # Seg faults...
-export PACT_PROVIDER_VERIFIER_VERSION=0.0.15
+export PACT_PROVIDER_VERIFIER_VERSION=1.0.1
 
 # Create the OS specific versions of the mock service and verifier
 echo "==> Building Ruby Binaries..."

--- a/types/verify_request.go
+++ b/types/verify_request.go
@@ -31,6 +31,12 @@ type VerifyRequest struct {
 	// Password when authenticating to a Pact Broker.
 	BrokerPassword string
 
+	// PublishVerificationResults to the Pact Broker.
+	PublishVerificationResults bool
+
+	// ProviderVersion is the semantical version of the Provider API.
+	ProviderVersion string
+
 	// Verbose increases verbosity of output
 	Verbose bool
 
@@ -76,6 +82,16 @@ func (v *VerifyRequest) Validate() error {
 	if v.BrokerPassword != "" {
 		v.Args = append(v.Args, "--broker-password")
 		v.Args = append(v.Args, v.BrokerPassword)
+	}
+
+	if v.ProviderVersion != "" {
+		v.Args = append(v.Args, "--provider_app_version")
+		v.Args = append(v.Args, v.ProviderVersion)
+	}
+
+	if v.PublishVerificationResults {
+		v.Args = append(v.Args, "--publish_verification_results")
+		v.Args = append(v.Args, "true")
 	}
 
 	if v.Verbose {


### PR DESCRIPTION
Adds support for a new feature of the broker - the ability to send provider verification results back to the Broker, allowing more intelligent CI practices.

The main use case this solves is allowing you (probably via a CI / CD processe) to detect Consumer changes that have not yet been verified by a provider. Publishing the status to the broker allows tooling to then query this status, and block a deployment if the contract has changed or has not been verified since last published.

See https://github.com/realestate-com-au/pact/blob/master/CHANGELOG.md#1110-8-may-2017 for more.

**Commit Details**:
- Upgrade to latest verifier (v1.0.1)
- Add new flags to verifier to allow results to be published
  to a Pact Broker