### PR TITLE
Add flag --mock-port / -m to specify port for Mock

### DIFF
--- a/command/daemon.go
+++ b/command/daemon.go
@@ -8,6 +8,7 @@ import (
 var port int
 var network string
 var address string
+var mockPort int
 var daemonCmdInstance *daemon.Daemon
 var daemonCmd = &cobra.Command{
 	Use:   "daemon",
@@ -16,7 +17,9 @@ var daemonCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		setLogLevel(verbose, logLevel)
 
-		mock := &daemon.MockService{}
+		mock := &daemon.MockService{
+			Port: mockPort,
+		}
 		mock.Setup()
 		verifier := &daemon.VerificationService{}
 		verifier.Setup()
@@ -29,5 +32,6 @@ func init() {
 	daemonCmd.Flags().IntVarP(&port, "port", "p", 6666, "Local daemon port to listen on")
 	daemonCmd.Flags().StringVarP(&network, "network", "n", "tcp", "Local network interface to listen on ('tcp', 'tcp4', 'tcp6')")
 	daemonCmd.Flags().StringVarP(&address, "address", "a", "", "Local network address to listen on (e.g. '', '127.0.0.1', '[::1]' etc.)")
+	daemonCmd.Flags().IntVarP(&mockPort, "mock-port", "m", 0, "Local port for mock service to attach to if not provided will be random (for use in containers)")
 	RootCmd.AddCommand(daemonCmd)
 }

--- a/daemon/mock_service.go
+++ b/daemon/mock_service.go
@@ -12,11 +12,19 @@ import (
 // MockService is a wrapper for the Pact Mock Service.
 type MockService struct {
 	ServiceManager
+
+	// Extra field for only MockService
+	Port int
 }
 
 // NewService creates a new MockService with default settings.
 func (m *MockService) NewService(args []string) (int, Service) {
-	port, _ := utils.GetFreePort()
+	var port int
+	if m.Port != 0 {
+		port = m.Port
+	} else {
+		port, _ = utils.GetFreePort()
+	}
 	log.Println("[DEBUG] starting mock service on port:", port)
 
 	m.Args = []string{


### PR DESCRIPTION
When running pact-go in containers we want to expose minimal number of
ports. Currently it randomly selects _any_ port. This makes it
impossible to expose ports in a container.

This change will add a CLI option to specify a port to deploy the
mocking service on. This way we know exactly which port to expose.