### PR TITLE
Add better provider verification output

### DIFF
--- a/daemon/mock_service.go
+++ b/daemon/mock_service.go
@@ -19,7 +19,7 @@ func (m *MockService) NewService(args []string) Service {
 	}
 	m.Args = append(m.Args, args...)
 
-	m.Command = getMockServiceCommandPath()
+	m.Cmd = getMockServiceCommandPath()
 	return m
 }
 

--- a/daemon/service.go
+++ b/daemon/service.go
@@ -11,6 +11,7 @@ type Service interface {
 	Setup()
 	Stop(pid int) (bool, error)
 	List() map[int]*exec.Cmd
+	Command() *exec.Cmd
 	Start() *exec.Cmd
 	Run(io.Writer) (*exec.Cmd, error)
 	NewService(args []string) Service

--- a/daemon/service_manager.go
+++ b/daemon/service_manager.go
@@ -6,12 +6,13 @@ import (
 	"log"
 	"os"
 	"os/exec"
+	"strings"
 	"time"
 )
 
 // ServiceManager is the default implementation of the Service interface.
 type ServiceManager struct {
-	Command             string
+	Cmd                 string
 	processes           map[int]*exec.Cmd
 	Args                []string
 	Env                 []string
@@ -102,7 +103,8 @@ func (s *ServiceManager) List() map[int]*exec.Cmd {
 // Run runs a service synchronously and log its output to the given Pipe.
 func (s *ServiceManager) Run(w io.Writer) (*exec.Cmd, error) {
 	log.Println("[DEBUG] starting service")
-	cmd := exec.Command(s.Command, s.Args...)
+	log.Printf("[DEBUG] %s %s\n", s.Cmd, strings.Join(s.Args, " "))
+	cmd := exec.Command(s.Cmd, s.Args...)
 	cmd.Env = s.Env
 	cmd.Stdout = w
 	cmd.Stderr = w
@@ -111,10 +113,16 @@ func (s *ServiceManager) Run(w io.Writer) (*exec.Cmd, error) {
 	return cmd, err
 }
 
+func (s *ServiceManager) Command() *exec.Cmd {
+	cmd := exec.Command(s.Cmd, s.Args...)
+	cmd.Env = s.Env
+	return cmd
+}
+
 // Start a Service and log its output.
 func (s *ServiceManager) Start() *exec.Cmd {
 	log.Println("[DEBUG] starting service")
-	cmd := exec.Command(s.Command, s.Args...)
+	cmd := exec.Command(s.Cmd, s.Args...)
 	cmd.Env = s.Env
 
 	cmdReader, err := cmd.StdoutPipe()

--- a/daemon/service_mock.go
+++ b/daemon/service_mock.go
@@ -8,7 +8,7 @@ import (
 
 // ServiceMock is the mock implementation of the Service interface.
 type ServiceMock struct {
-	Command             string
+	Cmd                 string
 	processes           map[int]*exec.Cmd
 	Args                []string
 	ServiceStopResult   bool
@@ -63,6 +63,10 @@ func (s *ServiceMock) Start() *exec.Cmd {
 	s.processes[cmd.Process.Pid] = cmd
 
 	return cmd
+}
+
+func (s *ServiceMock) Command() *exec.Cmd {
+	return s.ExecFunc()
 }
 
 // NewService creates a new MockService with default settings.

--- a/daemon/service_test.go
+++ b/daemon/service_test.go
@@ -15,9 +15,9 @@ func createServiceManager() *ServiceManager {
 	cs := []string{"-test.run=TestHelperProcess", "--", os.Args[0]}
 	env := []string{"GO_WANT_HELPER_PROCESS=1", fmt.Sprintf("GO_WANT_HELPER_PROCESS_TO_SUCCEED=true")}
 	mgr := &ServiceManager{
-		Command: os.Args[0],
-		Args:    cs,
-		Env:     env,
+		Cmd:  os.Args[0],
+		Args: cs,
+		Env:  env,
 	}
 	mgr.Setup()
 	return mgr

--- a/daemon/verification_service.go
+++ b/daemon/verification_service.go
@@ -28,7 +28,7 @@ func (m *VerificationService) NewService(args []string) Service {
 	log.Printf("[DEBUG] starting verification service with args: %v\n", args)
 
 	m.Args = args
-	m.Command = getVerifierCommandPath()
+	m.Cmd = getVerifierCommandPath()
 	return m
 }
 

--- a/doc.go
+++ b/doc.go
@@ -130,7 +130,7 @@ A typical Provider side test would like something like:
 		}
 		go startMyAPI("http://localhost:8000")
 
-		err := pact.VerifyProvider(types.VerifyRequest{
+		response, err := pact.VerifyProvider(types.VerifyRequest{
 			ProviderBaseURL:        "http://localhost:8000",
 			PactURLs:               []string{"./pacts/my_consumer-my_provider.json"},
 			ProviderStatesSetupURL: "http://localhost:8000/setup",
@@ -138,6 +138,12 @@ A typical Provider side test would like something like:
 
 		if err != nil {
 			t.Fatal("Error:", err)
+		}
+
+		for _, example := range response.Examples {
+			if example.Status != "passed" {
+				t.Errorf("%s\n%s\n", example.FullDescription, example.Exception.Message)
+			}
 		}
 	}
 
@@ -155,7 +161,7 @@ When validating a Provider, you have 3 options to provide the Pact files:
 
 1. Use "PactURLs" to specify the exact set of pacts to be replayed:
 
-	response = pact.VerifyProvider(types.VerifyRequest{
+	response, err = pact.VerifyProvider(types.VerifyRequest{
 		ProviderBaseURL:        "http://myproviderhost",
 		PactURLs:               []string{"http://broker/pacts/provider/them/consumer/me/latest/dev"},
 		ProviderStatesSetupURL: "http://myproviderhost/setup",
@@ -165,7 +171,7 @@ When validating a Provider, you have 3 options to provide the Pact files:
 
 2. Use "PactBroker" to automatically find all of the latest consumers:
 
-	response = pact.VerifyProvider(types.VerifyRequest{
+	response, err = pact.VerifyProvider(types.VerifyRequest{
 		ProviderBaseURL:        "http://myproviderhost",
 		BrokerURL:              brokerHost,
 		ProviderStatesSetupURL: "http://myproviderhost/setup",
@@ -175,7 +181,7 @@ When validating a Provider, you have 3 options to provide the Pact files:
 
 3. Use "PactBroker" and "Tags" to automatically find all of the latest consumers:
 
-	response = pact.VerifyProvider(types.VerifyRequest{
+	response, err = pact.VerifyProvider(types.VerifyRequest{
 		ProviderBaseURL:        "http://myproviderhost",
 		BrokerURL:              brokerHost,
 		Tags:                   []string{"latest", "sit4"},

--- a/dsl/client.go
+++ b/dsl/client.go
@@ -112,7 +112,7 @@ func (p *PactClient) StartServer(args []string, port int) *types.MockServer {
 }
 
 // VerifyProvider runs the verification process against a running Provider.
-func (p *PactClient) VerifyProvider(request types.VerifyRequest) (string, error) {
+func (p *PactClient) VerifyProvider(request types.VerifyRequest) (types.ProviderVerifierResponse, error) {
 	log.Println("[DEBUG] client: verifying a provider")
 
 	port := getPort(request.ProviderBaseURL)
@@ -120,7 +120,7 @@ func (p *PactClient) VerifyProvider(request types.VerifyRequest) (string, error)
 	waitForPort(port, p.getNetworkInterface(), p.Address, fmt.Sprintf(`Timed out waiting for Provider API to start
 		 on port %d - are you sure it's running?`, port))
 
-	var res types.CommandResponse
+	var res types.ProviderVerifierResponse
 	client, err := getHTTPClient(p.Port, p.getNetworkInterface(), p.Address)
 	if err == nil {
 		err = client.Call(commandVerifyProvider, request, &res)
@@ -129,11 +129,7 @@ func (p *PactClient) VerifyProvider(request types.VerifyRequest) (string, error)
 		}
 	}
 
-	if res.ExitCode > 0 {
-		return "", fmt.Errorf("provider verification failed: %s", sanitiseRubyResponse(res.Message))
-	}
-
-	return res.Message, err
+	return res, err
 }
 
 // sanitiseRubyResponse removes Ruby-isms from the response content

--- a/dsl/client_test.go
+++ b/dsl/client_test.go
@@ -83,7 +83,7 @@ func createDaemon(port int, success bool) (*daemon.Daemon, *daemon.ServiceMock) 
 		execFunc = fakeExecFailCommand
 	}
 	svc := &daemon.ServiceMock{
-		Command:           "test",
+		Cmd:               "test",
 		Args:              []string{},
 		ServiceStopResult: true,
 		ServiceStopError:  nil,
@@ -262,7 +262,7 @@ func TestClient_VerifyProviderFailValidation(t *testing.T) {
 		t.Fatal("Expected a error but got none")
 	}
 
-	if !strings.Contains(err.Error(), "ProviderBaseURL is mandatory") {
+	if !strings.Contains(err.Error(), "PactURLs is mandatory") {
 		t.Fatalf("Expected a proper error message but got '%s'", err.Error())
 	}
 }
@@ -365,8 +365,6 @@ func fakeExecCommand(command string, success bool, args ...string) *exec.Cmd {
 	cs = append(cs, args...)
 	cmd := exec.Command(os.Args[0], cs...)
 	cmd.Env = []string{"GO_WANT_HELPER_PROCESS=1", fmt.Sprintf("GO_WANT_HELPER_PROCESS_TO_SUCCEED=%t", success)}
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
 	return cmd
 }
 
@@ -384,7 +382,7 @@ func TestHelperProcess(t *testing.T) {
 	}
 
 	// Success :)
-	fmt.Fprintf(os.Stdout, "COMMAND: oh yays!\n")
+	fmt.Fprintf(os.Stdout, `{"summary_line":"1 examples, 0 failures"}`)
 	os.Exit(0)
 }
 

--- a/dsl/pact.go
+++ b/dsl/pact.go
@@ -236,7 +236,7 @@ func (p *Pact) WritePact() error {
 
 // VerifyProvider reads the provided pact files and runs verification against
 // a running Provider API.
-func (p *Pact) VerifyProvider(request types.VerifyRequest) error {
+func (p *Pact) VerifyProvider(request types.VerifyRequest) (types.ProviderVerifierResponse, error) {
 	p.Setup(false)
 
 	// If we provide a Broker, we go to it to find consumers
@@ -244,16 +244,11 @@ func (p *Pact) VerifyProvider(request types.VerifyRequest) error {
 		log.Printf("[DEBUG] pact provider verification - finding all consumers from broker: %s", request.BrokerURL)
 		err := findConsumers(p.Provider, &request)
 		if err != nil {
-			return err
+			return types.ProviderVerifierResponse{}, err
 		}
 	}
 
 	log.Printf("[DEBUG] pact provider verification")
 
-	content, err := p.pactClient.VerifyProvider(request)
-
-	// Output test result to screen
-	log.Println(content)
-
-	return err
+	return p.pactClient.VerifyProvider(request)
 }

--- a/dsl/pact_test.go
+++ b/dsl/pact_test.go
@@ -271,7 +271,7 @@ func TestPact_VerifyProvider(t *testing.T) {
 	waitForPortInTest(port, t)
 
 	pact := &Pact{Port: port, LogLevel: "DEBUG", pactClient: &PactClient{Port: port}}
-	err := pact.VerifyProvider(types.VerifyRequest{
+	_, err := pact.VerifyProvider(types.VerifyRequest{
 		ProviderBaseURL: "http://www.foo.com",
 		PactURLs:        []string{"foo.json", "bar.json"},
 	})
@@ -294,7 +294,7 @@ func TestPact_VerifyProviderBroker(t *testing.T) {
 	waitForPortInTest(port, t)
 
 	pact := &Pact{Port: port, LogLevel: "DEBUG", pactClient: &PactClient{Port: port}, Provider: "bobby"}
-	err := pact.VerifyProvider(types.VerifyRequest{
+	_, err := pact.VerifyProvider(types.VerifyRequest{
 		ProviderBaseURL:            "http://www.foo.com",
 		BrokerURL:                  s.URL,
 		PublishVerificationResults: true,
@@ -319,7 +319,7 @@ func TestPact_VerifyProviderBrokerNoConsumers(t *testing.T) {
 	waitForPortInTest(port, t)
 
 	pact := &Pact{Port: port, LogLevel: "DEBUG", pactClient: &PactClient{Port: port}, Provider: "providernotexist"}
-	err := pact.VerifyProvider(types.VerifyRequest{
+	_, err := pact.VerifyProvider(types.VerifyRequest{
 		ProviderBaseURL: "http://www.foo.com",
 		BrokerURL:       s.URL,
 	})
@@ -340,7 +340,7 @@ func TestPact_VerifyProviderFail(t *testing.T) {
 	waitForPortInTest(port, t)
 
 	pact := &Pact{Port: port, LogLevel: "DEBUG", pactClient: &PactClient{Port: port}}
-	err := pact.VerifyProvider(types.VerifyRequest{
+	_, err := pact.VerifyProvider(types.VerifyRequest{
 		ProviderBaseURL: "http://www.foo.com",
 		PactURLs:        []string{"foo.json", "bar.json"},
 	})

--- a/examples/go-kit/provider/user_service_test.go
+++ b/examples/go-kit/provider/user_service_test.go
@@ -58,7 +58,7 @@ func TestPact_Provider(t *testing.T) {
 	pact := createPact()
 
 	// Verify the Provider with local Pact Files
-	err := pact.VerifyProvider(types.VerifyRequest{
+	res, err := pact.VerifyProvider(types.VerifyRequest{
 		ProviderBaseURL:        fmt.Sprintf("http://localhost:%d", port),
 		PactURLs:               []string{filepath.ToSlash(fmt.Sprintf("%s/billy-bobby.json", pactDir))},
 		ProviderStatesSetupURL: fmt.Sprintf("http://localhost:%d/setup", port),
@@ -67,13 +67,14 @@ func TestPact_Provider(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error:", err)
 	}
+	assertExamples(t, res)
 
 	// Pull from pact broker, used in e2e/integrated tests for pact-go release
 	if os.Getenv("PACT_INTEGRATED_TESTS") != "" {
 		var brokerHost = os.Getenv("PACT_BROKER_HOST")
 
 		// Verify the Provider - Specific Published Pacts
-		err = pact.VerifyProvider(types.VerifyRequest{
+		res, err = pact.VerifyProvider(types.VerifyRequest{
 			ProviderBaseURL:            fmt.Sprintf("http://127.0.0.1:%d", port),
 			PactURLs:                   []string{fmt.Sprintf("%s/pacts/provider/bobby/consumer/billy/latest/sit4", brokerHost)},
 			ProviderStatesSetupURL:     fmt.Sprintf("http://127.0.0.1:%d/setup", port),
@@ -81,15 +82,15 @@ func TestPact_Provider(t *testing.T) {
 			BrokerPassword:             os.Getenv("PACT_BROKER_PASSWORD"),
 			PublishVerificationResults: true,
 			ProviderVersion:            "1.0.0",
-			Verbose:                    true,
 		})
 
 		if err != nil {
 			t.Fatal("Error:", err)
 		}
+		assertExamples(t, res)
 
 		// Verify the Provider - Latest Published Pacts for any known consumers
-		err = pact.VerifyProvider(types.VerifyRequest{
+		res, err = pact.VerifyProvider(types.VerifyRequest{
 			ProviderBaseURL:            fmt.Sprintf("http://127.0.0.1:%d", port),
 			BrokerURL:                  brokerHost,
 			ProviderStatesSetupURL:     fmt.Sprintf("http://127.0.0.1:%d/setup", port),
@@ -97,15 +98,15 @@ func TestPact_Provider(t *testing.T) {
 			BrokerPassword:             os.Getenv("PACT_BROKER_PASSWORD"),
 			PublishVerificationResults: true,
 			ProviderVersion:            "1.0.0",
-			Verbose:                    true,
 		})
 
 		if err != nil {
 			t.Fatal("Error:", err)
 		}
+		assertExamples(t, res)
 
 		// Verify the Provider - Tag-based Published Pacts for any known consumers
-		err = pact.VerifyProvider(types.VerifyRequest{
+		res, err = pact.VerifyProvider(types.VerifyRequest{
 			ProviderBaseURL:            fmt.Sprintf("http://127.0.0.1:%d", port),
 			ProviderStatesSetupURL:     fmt.Sprintf("http://127.0.0.1:%d/setup", port),
 			BrokerURL:                  brokerHost,
@@ -119,8 +120,17 @@ func TestPact_Provider(t *testing.T) {
 		if err != nil {
 			t.Fatal("Error:", err)
 		}
+		assertExamples(t, res)
 	} else {
 		t.Log("Skipping pulling from broker as PACT_INTEGRATED_TESTS is not set")
+	}
+}
+
+func assertExamples(t *testing.T, r types.ProviderVerifierResponse) {
+	for _, example := range r.Examples {
+		if example.Status != "passed" {
+			t.Errorf("%s\n%s\n", example.FullDescription, example.Exception.Message)
+		}
 	}
 }
 

--- a/examples/mux/provider/user_service_test.go
+++ b/examples/mux/provider/user_service_test.go
@@ -24,7 +24,7 @@ func TestPact_Provider(t *testing.T) {
 	pact := createPact()
 
 	// Verify the Provider with local Pact Files
-	err := pact.VerifyProvider(types.VerifyRequest{
+	res, err := pact.VerifyProvider(types.VerifyRequest{
 		ProviderBaseURL:        fmt.Sprintf("http://localhost:%d", port),
 		PactURLs:               []string{filepath.ToSlash(fmt.Sprintf("%s/billy-bobby.json", pactDir))},
 		ProviderStatesSetupURL: fmt.Sprintf("http://localhost:%d/setup", port),
@@ -33,13 +33,14 @@ func TestPact_Provider(t *testing.T) {
 	if err != nil {
 		t.Fatal("Error:", err)
 	}
+	assertExamples(t, res)
 
 	// Pull from pact broker, used in e2e/integrated tests for pact-go release
 	if os.Getenv("PACT_INTEGRATED_TESTS") != "" {
 		var brokerHost = os.Getenv("PACT_BROKER_HOST")
 
 		// Verify the Provider - Specific Published Pacts
-		err = pact.VerifyProvider(types.VerifyRequest{
+		res, err = pact.VerifyProvider(types.VerifyRequest{
 			ProviderBaseURL:            fmt.Sprintf("http://127.0.0.1:%d", port),
 			PactURLs:                   []string{fmt.Sprintf("%s/pacts/provider/bobby/consumer/billy/latest/sit4", brokerHost)},
 			ProviderStatesSetupURL:     fmt.Sprintf("http://127.0.0.1:%d/setup", port),
@@ -47,15 +48,15 @@ func TestPact_Provider(t *testing.T) {
 			BrokerPassword:             os.Getenv("PACT_BROKER_PASSWORD"),
 			PublishVerificationResults: true,
 			ProviderVersion:            "1.0.0",
-			Verbose:                    true,
 		})
 
 		if err != nil {
 			t.Fatal("Error:", err)
 		}
+		assertExamples(t, res)
 
 		// Verify the Provider - Latest Published Pacts for any known consumers
-		err = pact.VerifyProvider(types.VerifyRequest{
+		res, err = pact.VerifyProvider(types.VerifyRequest{
 			ProviderBaseURL:            fmt.Sprintf("http://127.0.0.1:%d", port),
 			BrokerURL:                  brokerHost,
 			ProviderStatesSetupURL:     fmt.Sprintf("http://127.0.0.1:%d/setup", port),
@@ -63,15 +64,15 @@ func TestPact_Provider(t *testing.T) {
 			BrokerPassword:             os.Getenv("PACT_BROKER_PASSWORD"),
 			PublishVerificationResults: true,
 			ProviderVersion:            "1.0.0",
-			Verbose:                    true,
 		})
 
 		if err != nil {
 			t.Fatal("Error:", err)
 		}
+		assertExamples(t, res)
 
 		// Verify the Provider - Tag-based Published Pacts for any known consumers
-		err = pact.VerifyProvider(types.VerifyRequest{
+		res, err = pact.VerifyProvider(types.VerifyRequest{
 			ProviderBaseURL:            fmt.Sprintf("http://127.0.0.1:%d", port),
 			ProviderStatesSetupURL:     fmt.Sprintf("http://127.0.0.1:%d/setup", port),
 			BrokerURL:                  brokerHost,
@@ -85,8 +86,18 @@ func TestPact_Provider(t *testing.T) {
 		if err != nil {
 			t.Fatal("Error:", err)
 		}
+		assertExamples(t, res)
+
 	} else {
 		t.Log("Skipping pulling from broker as PACT_INTEGRATED_TESTS is not set")
+	}
+}
+
+func assertExamples(t *testing.T, r types.ProviderVerifierResponse) {
+	for _, example := range r.Examples {
+		if example.Status != "passed" {
+			t.Errorf("%s\n%s\n", example.FullDescription, example.Exception.Message)
+		}
 	}
 }
 

--- a/scripts/build_standalone_packages.sh
+++ b/scripts/build_standalone_packages.sh
@@ -23,7 +23,7 @@ osarchs=(osx win32 linux-x86 linux-x86_64)
 
 echo "--> Packaging distributions"
 mkdir -p ../dist
-for os in "${osarchs[@]}" 
+for os in "${osarchs[@]}"
 do
   echo "Building ${os}"
   osarch=""
@@ -50,5 +50,3 @@ do
     cp pact-$PACT_STANDALONE_VERSION-$os.tar.gz ../dist/pact-go_$osarch.tar.gz
   fi
 done
-
- 

--- a/types/provider_verifier_response.go
+++ b/types/provider_verifier_response.go
@@ -1,0 +1,30 @@
+package types
+
+// PactVerifierResponse contains the ouput of the pact-provider-verifier
+// command.
+type ProviderVerifierResponse struct {
+	Version  string `json:"version"`
+	Examples []struct {
+		ID              string      `json:"id"`
+		Description     string      `json:"description"`
+		FullDescription string      `json:"full_description"`
+		Status          string      `json:"status"`
+		FilePath        string      `json:"file_path"`
+		LineNumber      int         `json:"line_number"`
+		RunTime         float64     `json:"run_time"`
+		PendingMessage  interface{} `json:"pending_message"`
+		Exception       struct {
+			Class     string   `json:"class"`
+			Message   string   `json:"message"`
+			Backtrace []string `json:"backtrace"`
+		} `json:"exception,omitempty"`
+	} `json:"examples"`
+	Summary struct {
+		Duration                     float64 `json:"duration"`
+		ExampleCount                 int     `json:"example_count"`
+		FailureCount                 int     `json:"failure_count"`
+		PendingCount                 int     `json:"pending_count"`
+		ErrorsOutsideOfExamplesCount int     `json:"errors_outside_of_examples_count"`
+	} `json:"summary"`
+	SummaryLine string `json:"summary_line"`
+}

--- a/types/verify_request.go
+++ b/types/verify_request.go
@@ -51,18 +51,20 @@ type VerifyRequest struct {
 // and should not be used outside of this library.
 func (v *VerifyRequest) Validate() error {
 	v.Args = []string{}
+
+	if len(v.PactURLs) != 0 {
+		v.Args = append(v.Args, strings.Join(v.PactURLs, " "))
+	} else {
+		return fmt.Errorf("PactURLs is mandatory.")
+	}
+
+	v.Args = append(v.Args, "--format", "json")
+
 	if v.ProviderBaseURL != "" {
 		v.Args = append(v.Args, "--provider-base-url")
 		v.Args = append(v.Args, v.ProviderBaseURL)
 	} else {
 		return fmt.Errorf("ProviderBaseURL is mandatory.")
-	}
-
-	if len(v.PactURLs) != 0 {
-		v.Args = append(v.Args, "--pact-urls")
-		v.Args = append(v.Args, strings.Join(v.PactURLs[:], ","))
-	} else {
-		return fmt.Errorf("PactURLs is mandatory.")
 	}
 
 	if v.ProviderStatesSetupURL != "" {


### PR DESCRIPTION
This enables you to write your provider verification tests like this:

``` golang
res, err := pact.VerifyProvider(types.VerifyRequest{
	ProviderBaseURL: "baseurl",
	PactURLs:        []string{"url1.json","url2.json"},
})
if err != nil {
	t.Fatal(err)
}
for _, ex := range res.Examples {
	if ex.Status != "passed" {
		t.Errorf("%s\n%s\n", ex.FullDescription, ex.Exception.Message)
	}
}
```

## Changes

The main change is to `func (p PactClient) VerifyProvider(request types.VerifyRequest, reply *types.ProviderVerifierResponse) error`. The reply type is specific to the JSON output of the `pact-provider-verifier` binary. Also, I've changed the semantics of the error a bit. If a valid JSON response from the binary can be parsed, there will be no error. Otherwise, there will be an error, and it will include both stderr and stdout from the binary.

## Notes

In doing this, I realized it would be pretty easy to repurpose the daemon package to remove the rpc layer and use it directly to execute the external ruby binaries. That could be a first step in solving #31 
