### PR TITLE
Fix broken links to realestate-com-au/pact/wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,7 +222,7 @@ for more matching examples.
 [regular expressions](http://ruby-doc.org/core-2.1.5/Regexp.html) and double
 escape backslashes.
 
-Read more about [flexible matching](https://github.com/realestate-com-au/pact/wiki/Regular-expressions-and-type-matching-with-Pact).
+Read more about [flexible matching](https://github.com/pact-foundation/pact-ruby/wiki/Regular-expressions-and-type-matching-with-Pact).
 
 
 ### Provider
@@ -502,7 +502,7 @@ Once these variables have been exported, cd into one of the directories containi
 
 ## Documentation
 
-Additional documentation can be found at the main [Pact website](http://pact.io) and in the [Pact Wiki](https://github.com/realestate-com-au/pact/wiki).
+Additional documentation can be found at the main [Pact website](http://pact.io) and in the [Pact Wiki](https://github.com/pact-foundation/pact-ruby/wiki).
 
 ## Troubleshooting
 

--- a/doc.go
+++ b/doc.go
@@ -113,7 +113,7 @@ for more matching examples.
 NOTE: You will need to use valid Ruby regular expressions
 (http://ruby-doc.org/core-2.1.5/Regexp.html) and double escape backslashes.
 
-Read more about flexible matching (https://github.com/realestate-com-au/pact/wiki/Regular-expressions-and-type-matching-with-Pact.
+Read more about flexible matching (https://github.com/pact-foundation/pact-ruby/wiki/Regular-expressions-and-type-matching-with-Pact.
 
 Provider Tests
 

--- a/dsl/mock_service.go
+++ b/dsl/mock_service.go
@@ -28,7 +28,7 @@ type MockService struct {
 	// "overwrite" will always truncate and replace the pact after each run
 	// "update" will append to the pact file, which is useful if your tests
 	// are split over multiple files and instantiations of a Mock Server
-	// See https://github.com/realestate-com-au/pact/blob/master/documentation/configuration.md#pactfile_write_mode
+	// See https://github.com/pact-foundation/pact-ruby/blob/master/documentation/configuration.md#pactfile_write_mode
 	PactFileWriteMode string
 }
 

--- a/dsl/pact.go
+++ b/dsl/pact.go
@@ -55,7 +55,7 @@ type Pact struct {
 	// "overwrite" will always truncate and replace the pact after each run
 	// "update" will append to the pact file, which is useful if your tests
 	// are split over multiple files and instantiations of a Mock Server
-	// See https://github.com/realestate-com-au/pact/blob/master/documentation/configuration.md#pactfile_write_mode
+	// See https://github.com/pact-foundation/pact-ruby/blob/master/documentation/configuration.md#pactfile_write_mode
 	PactFileWriteMode string
 
 	// Specify which version of the Pact Specification should be used (1 or 2).


### PR DESCRIPTION
To point to links in pact-foundation/pact-ruby/wiki/