### PR TITLE
feat(client) allow customization of client timeout

### DIFF
--- a/dsl/client.go
+++ b/dsl/client.go
@@ -17,10 +17,6 @@ import (
 	"github.com/pact-foundation/pact-go/types"
 )
 
-var (
-	timeoutDuration = 10 * time.Second
-)
-
 // PactClient is the main interface into starting/stopping
 // the underlying Pact CLI subsystem
 type PactClient struct {
@@ -36,6 +32,9 @@ type PactClient struct {
 
 	// Address the Daemon is listening on
 	Address string
+
+	// TimeoutDuration specifies how long to wait for Pact CLI to start
+	TimeoutDuration time.Duration
 }
 
 // newClient creates a new Pact client manager with the provided services
@@ -63,8 +62,8 @@ func (p *PactClient) StartServer(args []string, port int) *types.MockServer {
 	svc := p.pactMockSvcManager.NewService(args)
 	cmd := svc.Start()
 
-	waitForPort(port, p.getNetworkInterface(), p.Address, fmt.Sprintf(`Timed out waiting for Mock Server to
-    start on port %d - are you sure it's running?`, port))
+	waitForPort(port, p.getNetworkInterface(), p.Address, p.TimeoutDuration,
+		fmt.Sprintf(`Timed out waiting for Mock Server to start on port %d - are you sure it's running?`, port))
 
 	return &types.MockServer{
 		Pid:  cmd.Process.Pid,
@@ -122,8 +121,8 @@ func (p *PactClient) VerifyProvider(request types.VerifyRequest) (types.Provider
 
 	port := getPort(request.ProviderBaseURL)
 
-	waitForPort(port, p.getNetworkInterface(), p.Address, fmt.Sprintf(`Timed out waiting for Provider API to start
-		 on port %d - are you sure it's running?`, port))
+	waitForPort(port, p.getNetworkInterface(), p.Address, p.TimeoutDuration,
+		fmt.Sprintf(`Timed out waiting for Provider API to start on port %d - are you sure it's running?`, port))
 
 	// Run command, splitting out stderr and stdout. The command can fail for
 	// several reasons:
@@ -302,7 +301,7 @@ func getPort(rawURL string) int {
 
 // Use this to wait for a port to be running prior
 // to running tests.
-var waitForPort = func(port int, network string, address string, message string) error {
+var waitForPort = func(port int, network string, address string, timeoutDuration time.Duration, message string) error {
 	log.Println("[DEBUG] waiting for port", port, "to become available")
 	timeout := time.After(timeoutDuration)
 

--- a/dsl/client_test.go
+++ b/dsl/client_test.go
@@ -35,17 +35,12 @@ func TestClient_StartServer(t *testing.T) {
 	}
 }
 
-var oldTimeoutDuration = timeoutDuration
-
 func TestClient_StartServerFail(t *testing.T) {
-	timeoutDuration = 50 * time.Millisecond
-
 	client, _ := createClient(false)
 	server := client.StartServer([]string{}, 0)
 	if server.Port != 0 {
 		t.Fatalf("Expected server to be empty %v", server)
 	}
-	timeoutDuration = oldTimeoutDuration
 }
 
 func TestClient_StopServer(t *testing.T) {
@@ -58,7 +53,6 @@ func TestClient_StopServer(t *testing.T) {
 }
 
 func TestClient_StopServerFail(t *testing.T) {
-	timeoutDuration = 50 * time.Millisecond
 	client, _ := createClient(true)
 	res, err := client.StopServer(&types.MockServer{})
 	should := &types.MockServer{}
@@ -68,7 +62,6 @@ func TestClient_StopServerFail(t *testing.T) {
 	if err != nil {
 		t.Fatalf("wanted error, got none")
 	}
-	timeoutDuration = oldTimeoutDuration
 }
 
 func TestClient_VerifyProvider(t *testing.T) {
@@ -213,6 +206,7 @@ func createClient(success bool) (*PactClient, *ServiceMock) {
 	}()
 
 	d := newClient(svc, svc, svc)
+	d.TimeoutDuration = 50 * time.Millisecond
 	return d, svc
 }
 

--- a/dsl/pact_test.go
+++ b/dsl/pact_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/pact-foundation/pact-go/types"
 )
@@ -372,7 +373,7 @@ func captureOutput(action func()) string {
 func stubPorts() func() {
 	log.Println("Stubbing port timeout")
 	old := waitForPort
-	waitForPort = func(int, string, string, string) error {
+	waitForPort = func(int, string, string, time.Duration, string) error {
 		return nil
 	}
 	return func() { waitForPort = old }


### PR DESCRIPTION
CI servers are sometimes under pressure... This PR adds an option to setup the maximum duration before timing-out waiting for Pact CLI (or provider server) to startup.