### PR TITLE
WIP: feat(dsl): support a map of structs in matcher

### DIFF
--- a/dsl/matcher.go
+++ b/dsl/matcher.go
@@ -231,6 +231,12 @@ func match(srcType reflect.Type, params params) Matcher {
 		return match(srcType.Elem(), params)
 	case reflect.Slice, reflect.Array:
 		return EachLike(match(srcType.Elem(), getDefaults()), params.slice.min)
+	case reflect.Map:
+		if srcType.Key().Kind == reflect.String {
+			return match(srcType.Elem(), params)
+		} else {
+			panic(fmt.Sprintf("match: unhandled map key type: %v", srcType.Key()))
+		}
 	case reflect.Struct:
 		result := make(map[string]interface{})
 

--- a/dsl/matcher.go
+++ b/dsl/matcher.go
@@ -232,11 +232,12 @@ func match(srcType reflect.Type, params params) Matcher {
 	case reflect.Slice, reflect.Array:
 		return EachLike(match(srcType.Elem(), getDefaults()), params.slice.min)
 	case reflect.Map:
-		if srcType.Key().Kind() == reflect.String {
-			return match(srcType.Elem(), params)
-		} else {
+		if srcType.Key().Kind() != reflect.String {
 			panic(fmt.Sprintf("match: unhandled map key type: %v", srcType.Key()))
 		}
+		result := make(map[string]interface{})
+		result[`"string"`] = match(srcType.Elem(), getDefaults())
+		return result
 	case reflect.Struct:
 		result := make(map[string]interface{})
 

--- a/dsl/matcher.go
+++ b/dsl/matcher.go
@@ -232,7 +232,7 @@ func match(srcType reflect.Type, params params) Matcher {
 	case reflect.Slice, reflect.Array:
 		return EachLike(match(srcType.Elem(), getDefaults()), params.slice.min)
 	case reflect.Map:
-		if srcType.Key().Kind == reflect.String {
+		if srcType.Key().Kind() == reflect.String {
 			return match(srcType.Elem(), params)
 		} else {
 			panic(fmt.Sprintf("match: unhandled map key type: %v", srcType.Key()))

--- a/dsl/matcher_test.go
+++ b/dsl/matcher_test.go
@@ -694,9 +694,40 @@ func TestMatch(t *testing.T) {
 			want: Like(1),
 		},
 		{
-			name: "error - unhandled type",
+			name: "map[string]int",
 			args: args{
-				src: make(map[string]string),
+				src: make(map[string]int),
+			},
+			want: map[string]interface{}{
+				`"string"`: Like(1),
+			},
+		},
+		{
+			name: "map[string]struct",
+			args: args{
+				src: map[string]wordDTO{
+					"word1": wordDTO{},
+					"word2": wordDTO{},
+				},
+			},
+			want: map[string]interface{}{
+				`"string"`: Matcher{
+					"word":   Like(`"string"`),
+					"length": Like(1),
+				},
+			},
+		},
+		{
+			name: "invalid map key type - only allow string",
+			args: args{
+				src: make(map[int]string),
+			},
+			wantPanic: true,
+		},
+		{
+			name: "unhandled type: func()",
+			args: args{
+				src: func() {},
 			},
 			wantPanic: true,
 		},


### PR DESCRIPTION
Example JSON which this matcher will support:
```
{
  "departments": {
    "10": {
      "name": "Men's Clothing",
      "hours": "10am - 9pm"
    },
    "20": {
      "name": "Women's Clothing",
      "hours": "10am - 9pm"
    }
  }
}
```