### PR TITLE
feat(get-value): implement GetValue in Matcher. Closes #95

### DIFF
--- a/dsl/matcher.go
+++ b/dsl/matcher.go
@@ -187,6 +187,20 @@ func (m Matcher) isMatcher() {}
 // GetValue returns the raw generated value for the matcher
 // without any of the matching detail context
 func (m Matcher) GetValue() interface{} {
+	switch m["json_class"] {
+	default:
+		return nil
+	case "Pact::ArrayLike":
+		return m["contents"]
+	case "Pact::SomethingLike":
+		return m["contents"]
+	case "Pact::Term":
+		data, ok := m["data"].(map[string]interface{})
+		if ok {
+			return data["generate"]
+		}
+	}
+
 	return nil
 }
 

--- a/dsl/matcher_test.go
+++ b/dsl/matcher_test.go
@@ -30,6 +30,15 @@ func TestMatcher_TermString(t *testing.T) {
 	}
 }
 
+func TestMatcher_TermGetValue(t *testing.T) {
+	expected := "myawesomeword"
+	match := Term("myawesomeword", `\w+`).GetValue()
+
+	if expected != match {
+		t.Fatalf("Expected Term Value to match. '%s' != '%s'", expected, match)
+	}
+}
+
 func TestMatcher_LikeBasicString(t *testing.T) {
 	expected := formatJSON(`
 		{
@@ -81,6 +90,15 @@ func TestMatcher_LikeNumberAsString(t *testing.T) {
 	match := formatJSON(Like("42"))
 	if expected != match {
 		t.Fatalf("Expected Term to match. '%s' != '%s'", expected, match)
+	}
+}
+
+func TestMatcher_LikeGetValue(t *testing.T) {
+	expected := "myspecialvalue"
+	match := Like("myspecialvalue").GetValue()
+
+	if expected != match {
+		t.Fatalf("Expected Like Value to match. '%s' != '%s'", expected, match)
 	}
 }
 
@@ -166,6 +184,15 @@ func TestMatcher_EachLikeArray(t *testing.T) {
 	match := formatJSON(EachLike([]int{1, 2, 3}, 1))
 	if expected != match {
 		t.Fatalf("Expected Term to match. '%s' != '%s'", expected, match)
+	}
+}
+
+func TestMatcher_EachLikeGetValue(t *testing.T) {
+	expected := "42"
+	match := EachLike("42", 1).GetValue()
+
+	if expected != match {
+		t.Fatalf("Expected EachLike Value to match. '%s' != '%s'", expected, match)
 	}
 }
 


### PR DESCRIPTION
Return raw generated value for Mather's GetValue to be able to use the expected value for message metadata in VerifyMessageConsumer, e.g.
```
handler.Invoke(
	&MyMessageContext{MyField: m.Metadata["my-field"].GetValue()},
	*m.Content.(*Payload),
)

```

Closes #95