### PR TITLE
fix(version check): Only parse the last line on stdout when checking version of cli tools

### DIFF
--- a/install/installer.go
+++ b/install/installer.go
@@ -82,9 +82,10 @@ func (i *Installer) GetVersionForBinary(binary string) (version string, err erro
 	log.Println("[DEBUG] running binary", binary)
 
 	content, err := i.commander.Output(binary, "version")
-	version = string(content)
+	elements := strings.Split(strings.TrimSpace(string(content)), "\n")
+	version = strings.TrimSpace(elements[len(elements)-1])
 
-	return strings.TrimSpace(version), err
+	return version, err
 }
 
 // commander wraps the exec package, allowing us

--- a/install/installer_test.go
+++ b/install/installer_test.go
@@ -2,6 +2,7 @@ package install
 
 import (
 	"errors"
+	"fmt"
 	"reflect"
 	"testing"
 )
@@ -60,6 +61,23 @@ func TestInstaller_CheckVersionFail(t *testing.T) {
 func TestInstaller_getVersionForBinary(t *testing.T) {
 	version := "1.5.0"
 	i := getInstaller(version, nil)
+	v, err := i.GetVersionForBinary("pact-mock-service")
+
+	if err != nil {
+		t.Fatal("error:", err)
+	}
+	if v != version {
+		t.Fatal("Want", version, "got", v)
+	}
+}
+
+func TestInstaller_getVersionForBinaryMultilineOutput(t *testing.T) {
+	version := "1.5.0"
+	actualOutput := fmt.Sprintf(`
+	some other characters sent to stdout
+	%s
+	`, version)
+	i := getInstaller(actualOutput, nil)
 	v, err := i.GetVersionForBinary("pact-mock-service")
 
 	if err != nil {


### PR DESCRIPTION
# Problem

`GetVersionForBinary` assumes that only one line will be printed to stdout. If for any reason more than one line is printed to stdout `GetVersionForBinary` will fail. 

# Solution

Make `GetVersionForBinary` assume that only the last line printed to stdout contains the version number. 