### PR TITLE
use the ProviderBaseURL's host when verifying the provider is alive 🐛

### DIFF
--- a/dsl/client.go
+++ b/dsl/client.go
@@ -120,9 +120,10 @@ func (p *PactClient) VerifyProvider(request types.VerifyRequest) (types.Provider
 		return response, err
 	}
 
+	address := getAddress(request.ProviderBaseURL)
 	port := getPort(request.ProviderBaseURL)
 
-	waitForPort(port, p.getNetworkInterface(), p.Address, p.TimeoutDuration,
+	waitForPort(port, p.getNetworkInterface(), address, p.TimeoutDuration,
 		fmt.Sprintf(`Timed out waiting for Provider API to start on port %d - are you sure it's running?`, port))
 
 	// Run command, splitting out stderr and stdout. The command can fail for
@@ -295,8 +296,9 @@ func (p *PactClient) ReifyMessage(request *types.PactReificationRequest) (res *t
 func getPort(rawURL string) int {
 	parsedURL, err := url.Parse(rawURL)
 	if err == nil {
-		if len(strings.Split(parsedURL.Host, ":")) == 2 {
-			port, err := strconv.Atoi(strings.Split(parsedURL.Host, ":")[1])
+		splitHost := strings.Split(parsedURL.Host, ":")
+		if len(splitHost) == 2 {
+			port, err := strconv.Atoi(splitHost[1])
 			if err == nil {
 				return port
 			}
@@ -308,6 +310,17 @@ func getPort(rawURL string) int {
 	}
 
 	return -1
+}
+
+// Get the address given a URL
+func getAddress(rawURL string) string {
+	parsedURL, err := url.Parse(rawURL)
+	if err != nil {
+		return ""
+	}
+
+	splitHost := strings.Split(parsedURL.Host, ":")
+	return splitHost[0]
 }
 
 // Use this to wait for a port to be running prior

--- a/dsl/client_test.go
+++ b/dsl/client_test.go
@@ -135,6 +135,21 @@ func TestClient_getPort(t *testing.T) {
 	}
 }
 
+func TestClient_getAddress(t *testing.T) {
+	testCases := map[string]string{
+		"http://localhost:8000": "localhost",
+		"http://localhost":      "localhost",
+		"http://127.0.0.1":      "127.0.0.1",
+		":::::":                 "",
+	}
+
+	for host, address := range testCases {
+		if getAddress(host) != address {
+			t.Fatalf("Expected host '%s' to return address '%s' but got '%s'", host, address, getAddress(host))
+		}
+	}
+}
+
 func TestClient_sanitiseRubyResponse(t *testing.T) {
 	var tests = map[string]string{
 		"this is a sentence with a hash # so it should be in tact":                                           "this is a sentence with a hash # so it should be in tact",


### PR DESCRIPTION
Currently, when verifying that the provider is alive pact-go uses the pactClient's address https://github.com/pact-foundation/pact-go/blob/c2dcd782ab0bb3ee4a6a689ba0c4083f31258628/dsl/client.go#L125.

When attempting to run a pact-go test against a provider that isn't running on localhost you currently see the following error:
```
[ERROR] Expected server to start < 10s. Timed out waiting for Provider API to start on port 8000 - are you sure it's running?
```

This is because pactClient's address is not based on the provider base URL. This PR fixes the issue by attempting to establish a connection using the host from the ProviderBaseURL, similarly to how the port is established.