### PR TITLE
feat(api): use static types for matchers

### DIFF
--- a/dsl/matcher.go
+++ b/dsl/matcher.go
@@ -25,7 +25,6 @@ var timeExample = time.Date(2000, 2, 1, 12, 30, 0, 0, time.UTC)
 
 type eachLike struct {
 	Contents interface{} `json:"contents"`
-	Type     string      `json:"json_class"`
 	Min      int         `json:"min"`
 }
 
@@ -36,9 +35,17 @@ func (m eachLike) GetValue() interface{} {
 func (m eachLike) isMatcher() {
 }
 
+func (m eachLike) MarshalJSON() ([]byte, error) {
+	type marshaler eachLike
+
+	return json.Marshal(struct {
+		Type string `json:"json_class"`
+		marshaler
+	}{"Pact::ArrayLike", marshaler(m)})
+}
+
 type like struct {
 	Contents interface{} `json:"contents"`
-	Type     string      `json:"json_class"`
 }
 
 func (m like) GetValue() interface{} {
@@ -48,9 +55,17 @@ func (m like) GetValue() interface{} {
 func (m like) isMatcher() {
 }
 
+func (m like) MarshalJSON() ([]byte, error) {
+	type marshaler like
+
+	return json.Marshal(struct {
+		Type string `json:"json_class"`
+		marshaler
+	}{"Pact::SomethingLike", marshaler(m)})
+}
+
 type term struct {
 	Data termData `json:"data"`
-	Type string   `json:"json_class"`
 }
 
 func (m term) GetValue() interface{} {
@@ -58,6 +73,15 @@ func (m term) GetValue() interface{} {
 }
 
 func (m term) isMatcher() {
+}
+
+func (m term) MarshalJSON() ([]byte, error) {
+	type marshaler term
+
+	return json.Marshal(struct {
+		Type string `json:"json_class"`
+		marshaler
+	}{"Pact::Term", marshaler(m)})
 }
 
 type termData struct {
@@ -75,7 +99,6 @@ type termMatcher struct {
 // "minRequired" times. Number needs to be 1 or greater
 func EachLike(content interface{}, minRequired int) StringMatcher {
 	return eachLike{
-		Type:     "Pact::ArrayLike",
 		Contents: content,
 		Min:      minRequired,
 	}
@@ -85,7 +108,6 @@ func EachLike(content interface{}, minRequired int) StringMatcher {
 // on type (int, string etc.) instead of a verbatim match.
 func Like(content interface{}) StringMatcher {
 	return like{
-		Type:     "Pact::SomethingLike",
 		Contents: content,
 	}
 }
@@ -94,7 +116,6 @@ func Like(content interface{}) StringMatcher {
 // and also match using a regular expression.
 func Term(generate string, matcher string) StringMatcher {
 	return term{
-		Type: "Pact::Term",
 		Data: termData{
 			Generate: generate,
 			Matcher: termMatcher{

--- a/dsl/matcher_test.go
+++ b/dsl/matcher_test.go
@@ -318,7 +318,7 @@ func TestMatcher_NestAllTheThings(t *testing.T) {
 				Matcher{
 					"colour": Term("red", "red|green|blue"),
 					"size":   Like(10),
-					"tag":    EachLike([]Matcher{Like("jumper"), Like("shirt")}, 2),
+					"tag":    EachLike([]StringMatcher{Like("jumper"), Like("shirt")}, 2),
 				},
 				1),
 			1))
@@ -346,7 +346,7 @@ func formatJSON(object interface{}) interface{} {
 
 // Instrument the Matcher type to be able to assert the
 // values and regexs contained within!
-func (m Matcher) getValue() interface{} {
+func getMatcherValue(m interface{}) interface{} {
 	mString := objectToString(m)
 
 	// try like
@@ -369,7 +369,7 @@ func (m Matcher) getValue() interface{} {
 func TestMatcher_SugarMatchers(t *testing.T) {
 
 	type matcherTestCase struct {
-		matcher  Matcher
+		matcher  StringMatcher
 		testCase func(val interface{}) error
 	}
 	matchers := map[string]matcherTestCase{
@@ -483,7 +483,7 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 	}
 	var err error
 	for k, v := range matchers {
-		if err = v.testCase(v.matcher.getValue()); err != nil {
+		if err = v.testCase(getMatcherValue(v.matcher)); err != nil {
 			t.Fatalf("error validating matcher '%s': %v", k, err)
 		}
 	}
@@ -570,7 +570,7 @@ func TestMatch(t *testing.T) {
 	tests := []struct {
 		name      string
 		args      args
-		want      Matcher
+		want      StringMatcher
 		wantPanic bool
 	}{
 		{
@@ -599,7 +599,7 @@ func TestMatch(t *testing.T) {
 			args: args{
 				src: wordDTO{},
 			},
-			want: map[string]interface{}{
+			want: Matcher{
 				"word":   Like(`"string"`),
 				"length": Like(1),
 			},
@@ -609,7 +609,7 @@ func TestMatch(t *testing.T) {
 			args: args{
 				src: dateDTO{},
 			},
-			want: map[string]interface{}{
+			want: Matcher{
 				"date": Term("2000-01-01", `^\\d{4}-\\d{2}-\\d{2}$`),
 			},
 		},
@@ -618,7 +618,7 @@ func TestMatch(t *testing.T) {
 			args: args{
 				src: wordsDTO{},
 			},
-			want: map[string]interface{}{
+			want: Matcher{
 				"words": EachLike(Like(`"string"`), 2),
 			},
 		},
@@ -730,7 +730,7 @@ func TestMatch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var got Matcher
+			var got StringMatcher
 			var didPanic bool
 			defer func() {
 				if rec := recover(); rec != nil {

--- a/dsl/matcher_test.go
+++ b/dsl/matcher_test.go
@@ -209,7 +209,7 @@ func TestMatcher_NestLikeInEachLike(t *testing.T) {
 		  "min": 1
 		}`)
 
-	match := formatJSON(EachLike(Matcher{
+	match := formatJSON(EachLike(StructMatcher{
 		"id": Like(10),
 	}, 1))
 
@@ -240,7 +240,7 @@ func TestMatcher_NestTermInEachLike(t *testing.T) {
 
 	match := formatJSON(
 		EachLike(
-			Matcher{
+			StructMatcher{
 				"colour": Term("red", "red|green")},
 			1))
 
@@ -315,10 +315,10 @@ func TestMatcher_NestAllTheThings(t *testing.T) {
 	match := formatJSON(
 		EachLike(
 			EachLike(
-				Matcher{
+				StructMatcher{
 					"colour": Term("red", "red|green|blue"),
 					"size":   Like(10),
-					"tag":    EachLike([]StringMatcher{Like("jumper"), Like("shirt")}, 2),
+					"tag":    EachLike([]Matcher{Like("jumper"), Like("shirt")}, 2),
 				},
 				1),
 			1))
@@ -344,7 +344,7 @@ func formatJSON(object interface{}) interface{} {
 	return string(out.Bytes())
 }
 
-// Instrument the Matcher type to be able to assert the
+// Instrument the StructMatcher type to be able to assert the
 // values and regexs contained within!
 func getMatcherValue(m interface{}) interface{} {
 	mString := objectToString(m)
@@ -369,7 +369,7 @@ func getMatcherValue(m interface{}) interface{} {
 func TestMatcher_SugarMatchers(t *testing.T) {
 
 	type matcherTestCase struct {
-		matcher  StringMatcher
+		matcher  Matcher
 		testCase func(val interface{}) error
 	}
 	matchers := map[string]matcherTestCase{
@@ -570,7 +570,7 @@ func TestMatch(t *testing.T) {
 	tests := []struct {
 		name      string
 		args      args
-		want      StringMatcher
+		want      Matcher
 		wantPanic bool
 	}{
 		{
@@ -599,7 +599,7 @@ func TestMatch(t *testing.T) {
 			args: args{
 				src: wordDTO{},
 			},
-			want: Matcher{
+			want: StructMatcher{
 				"word":   Like(`"string"`),
 				"length": Like(1),
 			},
@@ -609,7 +609,7 @@ func TestMatch(t *testing.T) {
 			args: args{
 				src: dateDTO{},
 			},
-			want: Matcher{
+			want: StructMatcher{
 				"date": Term("2000-01-01", `^\\d{4}-\\d{2}-\\d{2}$`),
 			},
 		},
@@ -618,7 +618,7 @@ func TestMatch(t *testing.T) {
 			args: args{
 				src: wordsDTO{},
 			},
-			want: Matcher{
+			want: StructMatcher{
 				"words": EachLike(Like(`"string"`), 2),
 			},
 		},
@@ -730,7 +730,7 @@ func TestMatch(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			var got StringMatcher
+			var got Matcher
 			var didPanic bool
 			defer func() {
 				if rec := recover(); rec != nil {

--- a/dsl/matcher_test.go
+++ b/dsl/matcher_test.go
@@ -13,6 +13,7 @@ import (
 func TestMatcher_TermString(t *testing.T) {
 	expected := formatJSON(`
 		{
+      "json_class": "Pact::Term",
       "data": {
         "generate": "myawesomeword",
 			  "matcher": {
@@ -20,8 +21,7 @@ func TestMatcher_TermString(t *testing.T) {
 			    "o": 0,
 			    "s": "\\w+"
 			  }
-			},
-      "json_class": "Pact::Term"
+			}
 		}`)
 
 	match := formatJSON(Term("myawesomeword", `\w+`))
@@ -42,8 +42,8 @@ func TestMatcher_TermGetValue(t *testing.T) {
 func TestMatcher_LikeBasicString(t *testing.T) {
 	expected := formatJSON(`
 		{
-      "contents": "myspecialvalue",
-		  "json_class": "Pact::SomethingLike"
+		  "json_class": "Pact::SomethingLike",
+		  "contents": "myspecialvalue"
 		}`)
 
 	match := formatJSON(Like("myspecialvalue"))
@@ -55,8 +55,8 @@ func TestMatcher_LikeBasicString(t *testing.T) {
 func TestMatcher_LikeAsObject(t *testing.T) {
 	expected := formatJSON(`
 		{
-      "contents": {"baz":"bat"},
-		  "json_class": "Pact::SomethingLike"
+		  "json_class": "Pact::SomethingLike",
+		  "contents": {"baz":"bat"}
 		}`)
 
 	match := formatJSON(Like(map[string]string{
@@ -70,8 +70,8 @@ func TestMatcher_LikeAsObject(t *testing.T) {
 func TestMatcher_LikeNumber(t *testing.T) {
 	expected := formatJSON(`
 		{
-		  "contents": 42,
-		  "json_class": "Pact::SomethingLike"
+		  "json_class": "Pact::SomethingLike",
+		  "contents": 42
 		}`)
 
 	match := formatJSON(Like(42))
@@ -83,8 +83,8 @@ func TestMatcher_LikeNumber(t *testing.T) {
 func TestMatcher_LikeNumberAsString(t *testing.T) {
 	expected := formatJSON(`
 		{
-		  "contents": "42",
-		  "json_class": "Pact::SomethingLike"
+		  "json_class": "Pact::SomethingLike",
+		  "contents": "42"
 		}`)
 
 	match := formatJSON(Like("42"))
@@ -105,8 +105,8 @@ func TestMatcher_LikeGetValue(t *testing.T) {
 func TestMatcher_EachLikeNumber(t *testing.T) {
 	expected := formatJSON(`
 		{
-      "contents": 42,
 		  "json_class": "Pact::ArrayLike",
+		  "contents": 42,
 		  "min": 1
 		}`)
 
@@ -118,8 +118,8 @@ func TestMatcher_EachLikeNumber(t *testing.T) {
 func TestMatcher_EachLikeNumberAsString(t *testing.T) {
 	expected := formatJSON(`
 		{
-      "contents": "42",
 		  "json_class": "Pact::ArrayLike",
+		  "contents": "42",
 		  "min": 1
 		}`)
 
@@ -132,8 +132,8 @@ func TestMatcher_EachLikeNumberAsString(t *testing.T) {
 func TestMatcher_EachLikeString(t *testing.T) {
 	expected := formatJSON(`
 		{
-		  "contents": "someword",
 		  "json_class": "Pact::ArrayLike",
+		  "contents": "someword",
 		  "min": 7
 		}`)
 
@@ -146,8 +146,8 @@ func TestMatcher_EachLikeString(t *testing.T) {
 func TestMatcher_EachLikeObject(t *testing.T) {
 	expected := formatJSON(`
 		{
-      "contents": {"somekey":"someval"},
 		  "json_class": "Pact::ArrayLike",
+		  "contents": {"somekey":"someval"},
 		  "min": 3
 		}`)
 
@@ -162,8 +162,8 @@ func TestMatcher_EachLikeObject(t *testing.T) {
 func TestMatcher_EachLikeObjectAsStringFail(t *testing.T) {
 	expected := formatJSON(`
 		{
-		  "contents": {"somekey":"someval"},
 		  "json_class": "Pact::ArrayLike",
+		  "contents": {"somekey":"someval"},
 		  "min": 3
 		}`)
 
@@ -176,8 +176,8 @@ func TestMatcher_EachLikeObjectAsStringFail(t *testing.T) {
 func TestMatcher_EachLikeArray(t *testing.T) {
 	expected := formatJSON(`
 		{
-      "contents": [1,2,3],
 		  "json_class": "Pact::ArrayLike",
+		  "contents": [1,2,3],
 		  "min": 1
 		}`)
 
@@ -199,13 +199,13 @@ func TestMatcher_EachLikeGetValue(t *testing.T) {
 func TestMatcher_NestLikeInEachLike(t *testing.T) {
 	expected := formatJSON(`
 		{
+      "json_class": "Pact::ArrayLike",
       "contents": {
         "id": {
-          "contents": 10,
-		      "json_class": "Pact::SomethingLike"
+          "json_class": "Pact::SomethingLike",
+          "contents": 10
 		    }
 		  },
-      "json_class": "Pact::ArrayLike",
 		  "min": 1
 		}`)
 
@@ -221,8 +221,10 @@ func TestMatcher_NestLikeInEachLike(t *testing.T) {
 func TestMatcher_NestTermInEachLike(t *testing.T) {
 	expected := formatJSON(`
 		{
+	    "json_class": "Pact::ArrayLike",
 	    "contents": {
 	      "colour": {
+	        "json_class": "Pact::Term",
 	        "data": {
 	          "generate": "red",
 	          "matcher": {
@@ -230,11 +232,9 @@ func TestMatcher_NestTermInEachLike(t *testing.T) {
 	            "o": 0,
 	            "s": "red|green"
 	          }
-          },
-          "json_class": "Pact::Term"
+          }
 	      }
       },
-      "json_class": "Pact::ArrayLike",
 	    "min": 1
 	  }`)
 
@@ -252,12 +252,12 @@ func TestMatcher_NestTermInEachLike(t *testing.T) {
 func TestMatcher_NestedEachLike(t *testing.T) {
 	expected := formatJSON(`
 		{
+      "json_class": "Pact::ArrayLike",
       "contents": {
-	      "contents": "blue",
         "json_class": "Pact::ArrayLike",
+	      "contents": "blue",
 	      "min": 1
 	    },
-      "json_class": "Pact::ArrayLike",
 	    "min": 1
 	  }`)
 
@@ -273,42 +273,42 @@ func TestMatcher_NestedEachLike(t *testing.T) {
 
 func TestMatcher_NestAllTheThings(t *testing.T) {
 	expected := formatJSON(`{
+					"json_class": "Pact::ArrayLike",
 					"contents": {
+						"json_class": "Pact::ArrayLike",
 						"contents": {
 							"colour": {
-                "data": {
-                  "generate": "red",
-									"matcher": {
-                    "json_class": "Regexp",
-										"o": 0,
-										"s": "red|green|blue"
-									}
-								},
-                "json_class": "Pact::Term"
-              },
+							  "json_class": "Pact::Term",
+							  "data": {
+							    "generate": "red",
+							    "matcher": {
+							      "json_class": "Regexp",
+							      "o": 0,
+							      "s": "red|green|blue"
+							    }
+							  }
+							},
 							"size": {
-                "contents": 10,
-								"json_class": "Pact::SomethingLike"
+							  "json_class": "Pact::SomethingLike",
+							  "contents": 10
 							},
 							"tag": {
-                "contents": [
-                  {
-                    "contents": "jumper",
-                    "json_class": "Pact::SomethingLike"
-									},
-									{
-                    "contents": "shirt",
-                    "json_class": "Pact::SomethingLike"
-									}
-                ],
-                "json_class": "Pact::ArrayLike",
-								"min": 2
+							  "json_class": "Pact::ArrayLike",
+							  "contents": [
+							    {
+							      "json_class": "Pact::SomethingLike",
+							      "contents": "jumper"
+							    },
+							    {
+							      "json_class": "Pact::SomethingLike",
+							      "contents": "shirt"
+							    }
+							  ],
+							  "min": 2
 							}
-            },
-            "json_class": "Pact::ArrayLike",
+						},
 						"min": 1
-          },
-          "json_class": "Pact::ArrayLike",
+					},
 					"min": 1
 				}`)
 
@@ -494,8 +494,8 @@ func ExampleLike_string() {
 	fmt.Println(formatJSON(match))
 	// Output:
 	//{
-	//	"contents": "myspecialvalue",
-	//	"json_class": "Pact::SomethingLike"
+	//	"json_class": "Pact::SomethingLike",
+	//	"contents": "myspecialvalue"
 	//}
 }
 
@@ -504,10 +504,10 @@ func ExampleLike_object() {
 	fmt.Println(formatJSON(match))
 	// Output:
 	//{
+	//	"json_class": "Pact::SomethingLike",
 	//	"contents": {
 	//		"baz": "bat"
-	//	},
-	//	"json_class": "Pact::SomethingLike"
+	//	}
 	//}
 }
 func ExampleLike_number() {
@@ -515,8 +515,8 @@ func ExampleLike_number() {
 	fmt.Println(formatJSON(match))
 	// Output:
 	//{
-	//	"contents": 42,
-	//	"json_class": "Pact::SomethingLike"
+	//	"json_class": "Pact::SomethingLike",
+	//	"contents": 42
 	//}
 }
 
@@ -525,6 +525,7 @@ func ExampleTerm() {
 	fmt.Println(formatJSON(match))
 	// Output:
 	//{
+	//	"json_class": "Pact::Term",
 	//	"data": {
 	//		"generate": "myawesomeword",
 	//		"matcher": {
@@ -532,8 +533,7 @@ func ExampleTerm() {
 	//			"o": 0,
 	//			"s": "\\w+"
 	//		}
-	//	},
-	//	"json_class": "Pact::Term"
+	//	}
 	//}
 }
 
@@ -542,12 +542,12 @@ func ExampleEachLike() {
 	fmt.Println(formatJSON(match))
 	// Output:
 	//{
+	//	"json_class": "Pact::ArrayLike",
 	//	"contents": [
 	//		1,
 	//		2,
 	//		3
 	//	],
-	//	"json_class": "Pact::ArrayLike",
 	//	"min": 1
 	//}
 }

--- a/dsl/request.go
+++ b/dsl/request.go
@@ -2,9 +2,9 @@ package dsl
 
 // Request is the default implementation of the Request interface.
 type Request struct {
-	Method  string        `json:"method"`
-	Path    StringMatcher `json:"path"`
-	Query   MapMatcher    `json:"query,omitempty"`
-	Headers MapMatcher    `json:"headers,omitempty"`
-	Body    interface{}   `json:"body,omitempty"`
+	Method  string      `json:"method"`
+	Path    Matcher     `json:"path"`
+	Query   MapMatcher  `json:"query,omitempty"`
+	Headers MapMatcher  `json:"headers,omitempty"`
+	Body    interface{} `json:"body,omitempty"`
 }


### PR DESCRIPTION
This PR includes three commits:
- 633eb1f, switches to typed matchers for Like, EachLike, Term; changes the type of certain API parameters from Matcher struct to StringMatcher interface
    **This is the core of the change**
- c4d672d, removes the Type field from matcher structs and injects it only for marshaling to JSON.
    The Type field isn't needed in go because of static typing, moreover, if any caller changes the value of the Type field it would likely cause incorrect behavior
    
    Note that tests had to be updated because the order of the corresponding `json_class` property in JSON changed. This is generally inconsequential in JSON but the current tests specify a strict order of JSON properties. Alternatively the tests could be written in a more permissible way without enforcing the order or JSON props
- da3653c, renames StringMatcher to Matcher and Matcher to StructMatcher
  This is mainly because StringMatcher has probably outgrown its original intent

I'm still on the fence about the whole change because even though it seems to leverage the language and proper design patterns it also adds complexity.