### PR TITLE
remove duplicated switch case

### DIFF
--- a/examples/go-kit/provider/transport.go
+++ b/examples/go-kit/provider/transport.go
@@ -68,8 +68,6 @@ func codeFrom(err error) int {
 	switch err {
 	case ErrNotFound:
 		return http.StatusNotFound
-	case ErrNotFound:
-		return http.StatusNotFound
 	case ErrUnauthorized:
 		return http.StatusUnauthorized
 	default:


### PR DESCRIPTION
The `ErrNotFound` was repeated twice, fix that.