### PR TITLE
removed extra quotes from string Like match

### DIFF
--- a/dsl/matcher.go
+++ b/dsl/matcher.go
@@ -261,7 +261,7 @@ func match(srcType reflect.Type, params params) Matcher {
 			return Like(params.str.example)
 		}
 
-		return Like(`"string"`)
+		return Like("string")
 	case reflect.Bool:
 		return Like(true)
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,

--- a/dsl/matcher_test.go
+++ b/dsl/matcher_test.go
@@ -578,21 +578,21 @@ func TestMatch(t *testing.T) {
 			args: args{
 				src: &str,
 			},
-			want: Like(`"string"`),
+			want: Like("string"),
 		},
 		{
 			name: "recursive case - slice",
 			args: args{
 				src: []string{},
 			},
-			want: EachLike(Like(`"string"`), 1),
+			want: EachLike(Like("string"), 1),
 		},
 		{
 			name: "recursive case - array",
 			args: args{
 				src: [1]string{},
 			},
-			want: EachLike(Like(`"string"`), 1),
+			want: EachLike(Like("string"), 1),
 		},
 		{
 			name: "recursive case - struct",
@@ -600,7 +600,7 @@ func TestMatch(t *testing.T) {
 				src: wordDTO{},
 			},
 			want: map[string]interface{}{
-				"word":   Like(`"string"`),
+				"word":   Like("string"),
 				"length": Like(1),
 			},
 		},
@@ -619,7 +619,7 @@ func TestMatch(t *testing.T) {
 				src: wordsDTO{},
 			},
 			want: map[string]interface{}{
-				"words": EachLike(Like(`"string"`), 2),
+				"words": EachLike(Like("string"), 2),
 			},
 		},
 		{
@@ -627,7 +627,7 @@ func TestMatch(t *testing.T) {
 			args: args{
 				src: "string",
 			},
-			want: Like(`"string"`),
+			want: Like("string"),
 		},
 		{
 			name: "base case - bool",


### PR DESCRIPTION
Now that Like accepts an `interface{}` and the results get serialized into JSON, there's no need for these extra quotes.