### PR TITLE
fix(docs) Fix code examples, update E2E test steps

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ Please provide the following information with your issue to enable us to respond
 You can run the E2E tests by:
 
 ```sh
-make package # Assemble the latest Pact Go from Ruby and compile Go
+make tools   # Assemble the latest Pact Go from Ruby and compile Go
 make pact    # Run the Pact tests - consumer + provider
 ```
 

--- a/README.md
+++ b/README.md
@@ -167,7 +167,10 @@ func TestConsumer(t *testing.T) {
 	// Pass in test case. This is the component that makes the external HTTP call
 	var test = func() (err error) {
 		u := fmt.Sprintf("http://localhost:%d/foobar", pact.Server.Port)
-		req, _ := http.NewRequest("GET", u, strings.NewReader(`{"name":"billy"}`))
+		req, err := http.NewRequest("GET", u, strings.NewReader(`{"name":"billy"}`))
+		if err != nil {
+			return err
+		}
 
 		// NOTE: by default, request bodies are expected to be sent with a Content-Type
 		// of application/json. If you don't explicitly set the content-type, you
@@ -175,8 +178,9 @@ func TestConsumer(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Authorization", "Bearer 1234")
 
-		_, err = http.DefaultClient.Do(req); err != nil {
-		return
+		if _, err = http.DefaultClient.Do(req); err != nil {
+			return err
+		}
 	}
 
 	// Set up our expected interactions.


### PR DESCRIPTION
Tripped over this while running through the example. Just looks like a bad paste.

Have also added the error checking after `NewRequest` as is in the real example code.

Signed-off-by: Brendan Devenney <brendan.devenney@cloudreach.com>