### PR TITLE
fix: use stderr scanner on captureing stderr

### DIFF
--- a/dsl/client.go
+++ b/dsl/client.go
@@ -202,7 +202,7 @@ func (p *PactClient) VerifyProvider(request types.VerifyRequest) ([]types.Provid
 	stdErrScanner := bufio.NewScanner(stdErrPipe)
 	go func() {
 		for stdErrScanner.Scan() {
-			stdErr.WriteString(fmt.Sprintf("%s\n", stdOutScanner.Text()))
+			stdErr.WriteString(fmt.Sprintf("%s\n", stdErrScanner.Text()))
 		}
 
 		done <- struct{}{}


### PR DESCRIPTION
Use a stderr scanner instead of a stdout scanner to capture texts on stderr.  This change fixes an incorrect output and sometimes a data race.