### PR TITLE
fix: increase max size of pact output buffer

### DIFF
--- a/dsl/client.go
+++ b/dsl/client.go
@@ -195,6 +195,9 @@ func (p *PactClient) VerifyProvider(request types.VerifyRequest) ([]types.Provid
 	// See https://github.com/pact-foundation/pact-go/issues/88#issuecomment-404686337
 	stdOutScanner := bufio.NewScanner(stdOutPipe)
 	go func() {
+		stdOutBuf := make([]byte, bufio.MaxScanTokenSize)
+		stdOutScanner.Buffer(stdOutBuf, 64*1024*1024)
+
 		for stdOutScanner.Scan() {
 			verifications = append(verifications, stdOutScanner.Text())
 		}


### PR DESCRIPTION
by default, `Scanner.Scan()` halts for lines larger than [MaxScanTokenSize](https://golang.org/pkg/bufio/#pkg-constants) (64kb). if a JSON document in pact's output is larger than this, scanning stops and stdout contents are discarded

this change allocates a 64kb buffer up front, but grows the buffer up to 64mb for larger output