### PR TITLE
feat: add missing return to README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,10 +184,7 @@ func TestConsumer(t *testing.T) {
 		req.Header.Set("Content-Type", "application/json")
 		req.Header.Set("Authorization", "Bearer 1234")
 
-		if _, err = http.DefaultClient.Do(req); err != nil {
-			return
-		}
-		
+		_, err = http.DefaultClient.Do(req)
 		return
 	}
 

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ func TestConsumer(t *testing.T) {
 		u := fmt.Sprintf("http://localhost:%d/foobar", pact.Server.Port)
 		req, err := http.NewRequest("GET", u, strings.NewReader(`{"name":"billy"}`))
 		if err != nil {
-			return err
+			return
 		}
 
 		// NOTE: by default, request bodies are expected to be sent with a Content-Type
@@ -185,10 +185,10 @@ func TestConsumer(t *testing.T) {
 		req.Header.Set("Authorization", "Bearer 1234")
 
 		if _, err = http.DefaultClient.Do(req); err != nil {
-			return err
+			return
 		}
 		
-		return nil
+		return
 	}
 
 	// Set up our expected interactions.

--- a/README.md
+++ b/README.md
@@ -187,6 +187,8 @@ func TestConsumer(t *testing.T) {
 		if _, err = http.DefaultClient.Do(req); err != nil {
 			return err
 		}
+		
+		return nil
 	}
 
 	// Set up our expected interactions.


### PR DESCRIPTION
The compiler return a `missing return` error in this README code example:

```go
	// Pass in test case. This is the component that makes the external HTTP call
	var test = func() (err error) {
		u := fmt.Sprintf("http://localhost:%d/foobar", pact.Server.Port)
		req, err := http.NewRequest("GET", u, strings.NewReader(`{"name":"billy"}`))
		if err != nil {
			return err
		}

		// NOTE: by default, request bodies are expected to be sent with a Content-Type
		// of application/json. If you don't explicitly set the content-type, you
		// will get a mismatch during Verification.
		req.Header.Set("Content-Type", "application/json")
		req.Header.Set("Authorization", "Bearer 1234")

		if _, err = http.DefaultClient.Do(req); err != nil {
			return err
		}
	}
```

Just added a `return` after the last `if`. Also omitted return values, as the function has a named return `err error`.