### PR TITLE
docs: small fix in golang README

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ Here is the Provider test process broker down:
     }
     ```
 
-2)  Verify provider API
+2.  Verify provider API
 
     You can now tell Pact to read in your Pact files and verify that your API will
     satisfy the requirements of each of your known consumers:


### PR DESCRIPTION
This is a simple PR just fixing the list.

The second step are not making part of the list step. Take a look in the image below
![](https://user-images.githubusercontent.com/91538/110174517-ff0a2a00-7dde-11eb-933f-7820b6dd884c.png)
