### PR TITLE
docs: misc fixes

### DIFF
--- a/MIGRATION.md
+++ b/MIGRATION.md
@@ -30,7 +30,7 @@ The following package exposes aliases for the most commonly used interfaces for 
 
 #### Primary Interface
 
-- `dsl.Pact` was the primary interface. This is now replaced with `NewPactV2` and the `NewPactV3` methods, which will return you a builder for the corresponding specification.
+- `dsl.Pact` was the primary interface. This is now replaced with `NewV2Pact` and the `NewV3Pact` methods, which will return you a builder for the corresponding specification.
 - `Verify` is now `ExecuteTest` to avoid ambiguity with provider side verification. It also accepts a `*testing.T` argument, to improve error reporting and resolution.
 
 These are available in consumer package: `"github.com/pact-foundation/pact-go/v2/consumer"`
@@ -83,7 +83,7 @@ Query strings are now accepted (and [encoded](https://github.com/pact-foundation
 
 - `dsl.Pact` was the primary interface. This is now replaced with `HTTPVerifier` struct and `VerifyProvider` method.
 
-These are available in consumer package: `"github.com/pact-foundation/pact-go/v2/provider"`
+These are available in provider package: `"github.com/pact-foundation/pact-go/v2/provider"`
 
 #### Provider State Handlers
 

--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ Learn everything in Pact Go in 60 minutes: https://github.com/pact-foundation/pa
 
 ```shell
 # install pact-go as a dev dependency
-go get github.com/pact-foundation/pact-go/v2/@2.x.x
+go get github.com/pact-foundation/pact-go/v2@2.x.x
 
 # download and install the required libraries
 pact-go -l DEBUG install


### PR DESCRIPTION
MIGRATION.md: Fixing a typo and what looks like some renamed functions.

README.md: Not sure this matters much but some related commands work better without the trailing slash... ie when specifying a version tag with `go install`

```
~$ go install github.com/pact-foundation/pact-go/v2/@v2.0.0-beta.8
go install: github.com/pact-foundation/pact-go/v2/@v2.0.0-beta.8: argument must be a clean package path
~$ go install github.com/pact-foundation/pact-go/v2@v2.0.0-beta.8
~$
```

So this would have saved me some trouble.