### PR TITLE
fix: linker warning

### DIFF
--- a/internal/native/lib.go
+++ b/internal/native/lib.go
@@ -2,7 +2,7 @@
 package native
 
 /*
-#cgo darwin,amd64 LDFLAGS: -L/tmp -L/opt/pact/lib -L/usr/local/lib -Wl,-rpath -Wl,/opt/pact/lib -Wl,-rpath -Wl,/tmp -Wl,-rpath -Wl,/usr/local/lib -lpact_ffi
+#cgo darwin,amd64 LDFLAGS: -L/tmp -L/usr/local/lib -Wl,-rpath -Wl,/tmp -Wl,-rpath -Wl,/usr/local/lib -lpact_ffi
 #cgo windows,amd64 LDFLAGS: -lpact_ffi
 #cgo linux,amd64 LDFLAGS: -L/tmp -L/opt/pact/lib -L/usr/local/lib -Wl,-rpath -Wl,/opt/pact/lib -Wl,-rpath -Wl,/tmp -Wl,-rpath -Wl,/usr/local/lib -lpact_ffi
 */


### PR DESCRIPTION
Using v2 I get a persistent warning when running tests:
```
ld: warning: directory not found for option '-L/opt/pact/lib'
```

When I poked around I discovered I didn't have any pact tooling installed under `/opt/pact`. I'm assuming this was left over from previous stuff but is not used by the go based installer?

All I seem to get after installing is `/usr/local/lib/libpact_ffi.dylib`