### PR TITLE
Fix syntax issues in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -574,10 +574,8 @@ var userHandlerWrapper = func(m dsl.Message) error {
 
 // 3 Create the Pact Message Consumer
 pact := dsl.Pact {
-	return dsl.Pact{
-		Consumer:                 "PactGoMessageConsumer",
-		Provider:                 "PactGoMessageProvider",
-	}
+	Consumer: "PactGoMessageConsumer",
+	Provider: "PactGoMessageProvider",
 }
 
 // 4 Write the consumer test, and call VerifyMessageConsumer
@@ -594,7 +592,7 @@ func TestMessageConsumer_Success(t *testing.T) {
 			"access": eachLike(map[string]interface{}{
 				"role": term("admin", "admin|controller|user"),
 			}, 3),
-    })
+    }).
     AsType(&User{}) // Optional
 
 	pact.VerifyMessageConsumer(t, message, userHandlerWrapper)


### PR DESCRIPTION
A small change to fix some minor syntax issues in the readme.