### PR TITLE
docs: update pact-support@googlegroups.com to pact-foundation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at pact-support@googlegroups.com. All
+reported by contacting the project team at pact-foundation@googlegroups.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/dsl/matcher_test.go
+++ b/dsl/matcher_test.go
@@ -599,7 +599,7 @@ func TestMatch(t *testing.T) {
 		WordDash string `json:"-,"`
 	}
 	type unexportedDTO struct {
-		unexported string
+		unexported string //nolint
 	}
 	str := "str"
 	type args struct {


### PR DESCRIPTION
update deprecated email address