### PR TITLE
fix HOME/.pact dir permission

### DIFF
--- a/installer/installer.go
+++ b/installer/installer.go
@@ -420,7 +420,7 @@ func (configuration) writeConfig(c pactConfig) error {
 	log.Println("[DEBUG] writing config", c)
 	pactConfigPath := getConfigPath()
 
-	err := os.MkdirAll(filepath.Dir(pactConfigPath), 0644)
+	err := os.MkdirAll(filepath.Dir(pactConfigPath), 0755)
 	if err != nil {
 		log.Println("[DEBUG] error creating pact config directory")
 		return err


### PR DESCRIPTION
causes error such as: 
`2022/08/25 16:18:11 [ERROR] Your Pact library installation is out of date and we were unable to download a newer one for you: open /Users/me/.pact/pact-go.yml: permission denied`