### PR TITLE
Fixes the dsl.WritePact Godoc phrasing

### DIFF
--- a/dsl/pact.go
+++ b/dsl/pact.go
@@ -282,9 +282,8 @@ func (p *Pact) Verify(integrationTest func() error) error {
 	return err
 }
 
-// WritePact should be called writes when all tests have been performed for a
-// given Consumer <-> Provider pair. It will write out the Pact to the
-// configured file.
+// WritePact writes out the Pact to the configured file when all tests have been performed for a given
+// Consumer <-> Provider pair.
 func (p *Pact) WritePact() error {
 	p.Setup(true)
 	log.Println("[DEBUG] pact write Pact file")


### PR DESCRIPTION
There is a phrasing problem in the `dsl.WritePact` Godoc, where perhaps two previous docs were merged. This PR clarifies the doc.