### PR TITLE
Pact Go v1.x - Support for ARM64/MacOS

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,18 +1,37 @@
-
-
-test_task:
-  env:
-    matrix:
-      VERSION: 1.17
-      VERSION: 1.18
-  name: Tests (Go $VERSION)
-  container:
-    image: golang:$VERSION
+test_task_template: &TEST_TASK_TEMPLATE
   modules_cache:
     fingerprint_script: cat go.sum
     folder: $GOPATH/pkg/mod
-  test_script: DOCKER_GATEWAY_HOST=172.17.0.1 DOCKER_HOST_HTTP="http://172.17.0.1" make
+  deps_script: make deps
+  clean_script: make clean
+  bin_script: make bin
+  test_script: make test
 
+linux_test_task:
+  env:
+    matrix:
+      - VERSION: 1.17
+      - VERSION: 1.18
+  name: Tests (Go $VERSION)
+  container:
+    image: golang:$VERSION
+  <<: *TEST_TASK_TEMPLATE
+
+linux_arm64_test_task:
+  env:
+    matrix:
+      - VERSION: 1.17
+      - VERSION: 1.18
+  name: Tests (Go $VERSION)
+  arm_container:
+    image: golang:$VERSION
+  <<: *TEST_TASK_TEMPLATE
+
+macos_arm64_test_task:
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
+  pre_req_script: brew install gox
+  <<: *TEST_TASK_TEMPLATE
 
 lint_task:
   name: GolangCI Lint

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,26 @@
+
+
+test_task:
+  env:
+    matrix:
+      VERSION: 1.17
+      VERSION: 1.18
+  name: Tests (Go $VERSION)
+  container:
+    image: golang:$VERSION
+  modules_cache:
+    fingerprint_script: cat go.sum
+    folder: $GOPATH/pkg/mod
+  test_script: DOCKER_GATEWAY_HOST=172.17.0.1 DOCKER_HOST_HTTP="http://172.17.0.1" make
+
+
+lint_task:
+  name: GolangCI Lint
+  container:
+    image: golangci/golangci-lint:latest
+  run_script: golangci-lint run -v --out-format json > lint-report.json
+  always:
+    golangci_artifacts:
+      path: lint-report.json
+      type: text/json
+      format: golangci

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -12,9 +12,9 @@ jobs:
     name: lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           version: v1.29

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Test
         run: GIT_BRANCH=${GIT_REF:11} DOCKER_GATEWAY_HOST=172.17.0.1 DOCKER_HOST_HTTP="http://172.17.0.1" make
       - name: Install goveralls

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM golang:1.18
 
 # Install pact ruby standalone binaries
-RUN curl -LO https://github.com/you54f/pact-ruby-standalone/releases/download/v2.2.1/pact-2.2.1-linux-x86_64.tar.gz; \
-    tar -C /usr/local -xzf pact-2.2.1-linux-x86_64.tar.gz; \
-    rm pact-2.2.1-linux-x86_64.tar.gz
+RUN curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v2.0.0/pact-2.0.0-linux-x86_64.tar.gz; \
+    tar -C /usr/local -xzf pact-2.0.0-linux-x86_64.tar.gz; \
+    rm pact-2.0.0-linux-x86_64.tar.gz
 
 ENV PATH /usr/local/pact/bin:$PATH
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM golang:1.18
 
 # Install pact ruby standalone binaries
-RUN curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.88.78/pact-1.88.78-linux-x86_64.tar.gz; \
-    tar -C /usr/local -xzf pact-1.88.78-linux-x86_64.tar.gz; \
-    rm pact-1.88.78-linux-x86_64.tar.gz
+RUN curl -LO https://github.com/you54f/pact-ruby-standalone/releases/download/v2.2.1/pact-2.2.1-linux-x86_64.tar.gz; \
+    tar -C /usr/local -xzf pact-2.2.1-linux-x86_64.tar.gz; \
+    rm pact-2.2.1-linux-x86_64.tar.gz
 
 ENV PATH /usr/local/pact/bin:$PATH
 

--- a/Makefile
+++ b/Makefile
@@ -14,9 +14,10 @@ docker:
 bin:
 	gox -os="darwin" -arch="amd64" -output="build/pact-go_{{.OS}}_{{.Arch}}"
 	gox -os="darwin" -arch="arm64" -output="build/pact-go_{{.OS}}_{{.Arch}}"
+	gox -os="windows" -arch="amd64" -output="build/pact-go_{{.OS}}_{{.Arch}}"
 	gox -os="windows" -arch="386" -output="build/pact-go_{{.OS}}_{{.Arch}}"
-	gox -os="linux" -arch="386" -output="build/pact-go_{{.OS}}_{{.Arch}}"
 	gox -os="linux" -arch="amd64" -output="build/pact-go_{{.OS}}_{{.Arch}}"
+	gox -os="linux" -arch="arm64" -output="build/pact-go_{{.OS}}_{{.Arch}}"
 	@echo "==> Results:"
 	ls -hl build/
 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ deps:
 install:
 	@if [ ! -d pact/bin ]; then\
 		echo "--- 🐿 Installing Pact CLI dependencies"; \
-		curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | v2.0.1 bash -x; \
+		curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | tag=v2.0.1 bash -x; \
   	fi
 
 publish_pacts: 

--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ deps:
 install:
 	@if [ ! -d pact/bin ]; then\
 		echo "--- 🐿 Installing Pact CLI dependencies"; \
-		curl -fsSL https://raw.githubusercontent.com/you54f/pact-ruby-standalone/master/install.sh | bash -x; \
+		curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | v2.0.1 bash -x; \
   	fi
 
 publish_pacts: 

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ deps:
 install:
 	@if [ ! -d pact/bin ]; then\
 		echo "--- 🐿 Installing Pact CLI dependencies"; \
-		curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | bash -x; \
+		curl -fsSL https://raw.githubusercontent.com/you54f/pact-ruby-standalone/master/install.sh | bash -x; \
   	fi
 
 publish_pacts: 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ Read [Getting started with Pact] for more information for beginners.
 
 - [Pact Go](#pact-go)
 	- [Introduction](#introduction)
-	- [Announcement 📣](#announcement-)
 	- [Table of Contents](#table-of-contents)
 	- [Versions](#versions)
 	- [Installation](#installation)
@@ -134,7 +133,7 @@ The following will install pact binaries into `/opt/pact/bin`:
 
 ```sh
 cd /opt
-curl -fsSL https://raw.githubusercontent.com/you54f/pact-ruby-standalone/master/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | bash
 export PATH=$PATH:/opt/pact/bin
 go get github.com/pact-foundation/pact-go@v1
 ```
@@ -145,7 +144,11 @@ Test the installation:
 pact help
 ```
 
-_NOTE_: the above script installs the latest standalone tools at the time it was ran. It is recommended you pin the installation to a [specific version](https://github.com/you54f/pact-ruby-standalone/releases) of a release so that you may control the upgrade cycle.
+_NOTE_: the above script installs the latest standalone tools at the time it was ran. It is recommended you pin the installation to a [specific version](https://github.com/pact-foundation/pact-ruby-standalone/releases) of a release so that you may control the upgrade cycle, as shown below with `tag=v1.92.0`
+
+```sh
+curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | tag=v1.92.0 bash
+```
 
 ## Using Pact
 
@@ -944,7 +947,7 @@ See [CONTRIBUTING](https://github.com/pact-foundation/pact-go/edit/master/CONTRI
 [@pact_up]: https://twitter.com/pact_up
 [pact specification v2]: https://github.com/pact-foundation/pact-specification/tree/version-2
 [pact specification v3]: https://github.com/pact-foundation/pact-specification/tree/version-3
-[cli tools]: https://github.com/you54f/pact-ruby-standalone/releases
+[cli tools]: https://github.com/pact-foundation/pact-ruby-standalone/releases
 [installation]: #installation
 [message support]: https://github.com/pact-foundation/pact-specification/tree/version-3#introduces-messages-for-services-that-communicate-via-event-streams-and-message-queues
 [changelog]: https://github.com/pact-foundation/pact-go/blob/master/CHANGELOG.md

--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The following will install pact binaries into `/opt/pact/bin`:
 
 ```sh
 cd /opt
-curl -fsSL https://raw.githubusercontent.com/pact-foundation/pact-ruby-standalone/master/install.sh | bash
+curl -fsSL https://raw.githubusercontent.com/you54f/pact-ruby-standalone/master/install.sh | bash
 export PATH=$PATH:/opt/pact/bin
 go get github.com/pact-foundation/pact-go@v1
 ```
@@ -145,7 +145,7 @@ Test the installation:
 pact help
 ```
 
-_NOTE_: the above script installs the latest standalone tools at the time it was ran. It is recommended you pin the installation to a [specific version](https://github.com/pact-foundation/pact-ruby-standalone/releases) of a release so that you may control the upgrade cycle.
+_NOTE_: the above script installs the latest standalone tools at the time it was ran. It is recommended you pin the installation to a [specific version](https://github.com/you54f/pact-ruby-standalone/releases) of a release so that you may control the upgrade cycle.
 
 ## Using Pact
 
@@ -944,7 +944,7 @@ See [CONTRIBUTING](https://github.com/pact-foundation/pact-go/edit/master/CONTRI
 [@pact_up]: https://twitter.com/pact_up
 [pact specification v2]: https://github.com/pact-foundation/pact-specification/tree/version-2
 [pact specification v3]: https://github.com/pact-foundation/pact-specification/tree/version-3
-[cli tools]: https://github.com/pact-foundation/pact-ruby-standalone/releases
+[cli tools]: https://github.com/you54f/pact-ruby-standalone/releases
 [installation]: #installation
 [message support]: https://github.com/pact-foundation/pact-specification/tree/version-3#introduces-messages-for-services-that-communicate-via-event-streams-and-message-queues
 [changelog]: https://github.com/pact-foundation/pact-go/blob/master/CHANGELOG.md

--- a/scripts/pact.ps1
+++ b/scripts/pact.ps1
@@ -20,11 +20,11 @@ New-Item -Force -ItemType Directory $pactDir
 
 Write-Host "--> Downloading Latest Ruby binaries)"
 $downloadDir = $env:TEMP
-$latestRelease = Invoke-WebRequest https://github.com/pact-foundation/pact-ruby-standalone/releases/latest -Headers @{"Accept"="application/json"}
+$latestRelease = Invoke-WebRequest https://github.com/you54f/pact-ruby-standalone/releases/latest -Headers @{"Accept"="application/json"}
 $json = $latestRelease.Content | ConvertFrom-Json
 $tag = $json.tag_name
 $latestVersion = $tag.Substring(1)
-$url = "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/$tag/pact-$latestVersion-win32.zip"
+$url = "https://github.com/you54f/pact-ruby-standalone/releases/download/$tag/pact-$latestVersion-windows-x86_64.zip"
 
 Write-Host "Downloading $url"
 $zip = "$downloadDir\pact.zip"

--- a/scripts/pact.ps1
+++ b/scripts/pact.ps1
@@ -8,6 +8,7 @@ if (!($env:GOPATH)) {
 $env:PACT_BROKER_BASE_URL = "http://localhost"
 $env:PACT_BROKER_USERNAME = "pact_workshop"
 $env:PACT_BROKER_PASSWORD = "pact_workshop"
+$env:tag = "v2.0.1"
 
 if (Test-Path "$pactDir") {
   Write-Host "-> Deleting old pact directory"
@@ -20,11 +21,11 @@ New-Item -Force -ItemType Directory $pactDir
 
 Write-Host "--> Downloading Latest Ruby binaries)"
 $downloadDir = $env:TEMP
-$latestRelease = Invoke-WebRequest https://github.com/you54f/pact-ruby-standalone/releases/latest -Headers @{"Accept"="application/json"}
+$latestRelease = Invoke-WebRequest https://github.com/pact-foundation/pact-ruby-standalone/releases/latest -Headers @{"Accept"="application/json"}
 $json = $latestRelease.Content | ConvertFrom-Json
 $tag = $json.tag_name
 $latestVersion = $tag.Substring(1)
-$url = "https://github.com/you54f/pact-ruby-standalone/releases/download/$tag/pact-$latestVersion-windows-x86_64.zip"
+$url = "https://github.com/pact-foundation/pact-ruby-standalone/releases/download/$tag/pact-$latestVersion-windows-x86_64.zip"
 
 Write-Host "Downloading $url"
 $zip = "$downloadDir\pact.zip"


### PR DESCRIPTION
## Changes to traveling ruby to support additional platforms

### Details of changes made to travelling ruby

PR's to Travelling ruby to update the supported archs

- https://github.com/phusion/traveling-ruby/pull/132
- https://github.com/phusion/traveling-ruby/pull/133

Which means we can now support


| OS     | Ruby      | Architecture | Supported |
| -------| ------- | ------------ | --------- |
| OSX    | 3.2.2     | x86_64       | ✅         |
| OSX    | 3.2.2     | aarch64 (arm)| ✅         |
| Linux  | 3.2.2   | x86_64       | ✅         |
| Linux  | 3.2.2   | aarch64 (arm)| ✅          |
| Windows| 3.2.2 | x86_64       | ✅        |
| Windows| 3.2.2 | x86       | ✅        |
| Windows| 3.2.2 | aarch64 (via x86 emulation) |  ✅        |

### Details of changes made to pact-ruby-standalone

- https://github.com/pact-foundation/pact-ruby-standalone/pull/100
- https://github.com/pact-foundation/pact-ruby-standalone/releases/tag/v2.0.1

### Details of changes made to pact-go

These have been consumed in the pact-go project, and tested cross platform

In order to test ARM64 on MacOS, and Linux, I have utilised cirrus-ci, which is free for open-source usage (within reasonable limits)

| OS     | Standalone Version     | Architecture | Tested |
| -------| ------- | ------------ | --------- |
| OSX    | v2.0.1     | x86_64       | GitHub Actions            |
| OSX    | v2.0.1     | aarch64 (arm)| Cirrus CI         |
| Linux  | v2.0.1  | x86_64       | GitHub Actions          |
| Linux  | v2.0.1  | aarch64 (arm)| Cirrus-CI       |
| Windows| v2.0.1 | x86_64       | untested        |
| Windows| v2.0.1 | aarch64 (via x86 emulation) |  untested    |
| Windows| v2.0.1 | x86       | untested      |

_Note_ For the master branch, there is no macos/windows tests
  
### User facing notes




-  Linux
  - Linux users will require libyaml-dev installed as there is a requirement, most relevant in slim docker images
  - Adds support for arm64
  - Drops support for x86 Linux
- Adds support for macos arm64
  - macOS arm64 (m1/m2) users will no require require installing rosetta
- Windows
  - i386 and x86_64 builds available