### PR TITLE
fix: set specification version on v4 message types

### DIFF
--- a/internal/native/message_server.go
+++ b/internal/native/message_server.go
@@ -40,6 +40,7 @@ void pactffi_with_message_pact_metadata(PactHandle pact, const char *namespace, 
 int pactffi_write_pact_file(int mock_server_port, const char *directory, bool overwrite);
 bool pactffi_given(InteractionHandle interaction, const char *description);
 bool pactffi_given_with_param(InteractionHandle interaction, const char *description, const char *name, const char *value);
+void pactffi_with_specification(PactHandle pact, int specification_version);
 
 int pactffi_using_plugin(PactHandle pact, const char *plugin_name, const char *plugin_version);
 void pactffi_cleanup_plugins(PactHandle pact);
@@ -192,6 +193,10 @@ func (m *MessageServer) NewAsyncMessageInteraction(description string) *Message 
 	m.messages = append(m.messages, i)
 
 	return i
+}
+
+func (m *MessageServer) WithSpecificationVersion(version specificationVersion) {
+	C.pactffi_with_specification(m.messagePact.handle, C.int(version))
 }
 
 func (m *Message) Given(state string) *Message {

--- a/message/v4/asynchronous_message.go
+++ b/message/v4/asynchronous_message.go
@@ -238,6 +238,7 @@ func (p *AsynchronousPact) validateConfig() error {
 	}
 
 	p.messageserver = mockserver.NewMessageServer(p.config.Consumer, p.config.Provider)
+	p.messageserver.WithSpecificationVersion(mockserver.SPECIFICATION_VERSION_V4)
 
 	return nil
 }

--- a/message/v4/synchronous_message.go
+++ b/message/v4/synchronous_message.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/pact-foundation/pact-go/v2/internal/native"
+	mockserver "github.com/pact-foundation/pact-go/v2/internal/native"
 	logging "github.com/pact-foundation/pact-go/v2/log"
 	"github.com/pact-foundation/pact-go/v2/models"
 )
@@ -295,6 +296,7 @@ func (m *SynchronousPact) validateConfig() error {
 	}
 
 	m.mockserver = native.NewMessageServer(m.config.Consumer, m.config.Provider)
+	m.mockserver.WithSpecificationVersion(mockserver.SPECIFICATION_VERSION_V4)
 
 	return nil
 }


### PR DESCRIPTION
This ensures V4 asynchronous and synchronous messages have the correct specification version applied to them.