### PR TITLE
fix: remove relative numeric size for message contents c interface

### DIFF
--- a/internal/native/message_server.go
+++ b/internal/native/message_server.go
@@ -502,11 +502,11 @@ func (m *Message) GetMessageResponseContents() ([][]byte, error) {
 		}
 
 		// Get Response body
-		len := C.pactffi_sync_message_get_response_contents_length(message, C.ulong(i))
+		len := C.pactffi_sync_message_get_response_contents_length(message, C.size_t(i))
 		if len == 0 {
 			return nil, errors.New("retrieved an empty message")
 		}
-		data := C.pactffi_sync_message_get_response_contents_bin(message, C.ulong(i))
+		data := C.pactffi_sync_message_get_response_contents_bin(message, C.size_t(i))
 		if data == nil {
 			return nil, errors.New("retrieved an empty pointer to the message contents")
 		}


### PR DESCRIPTION
Fixes #295 