### PR TITLE
ci(deps): update golangci-lint ci build to pass on v1.x.x branch

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -2,22 +2,35 @@ name: golangci-lint
 on:
   push:
     tags:
-      - v*
+      - v1*
     branches:
-      - master
-      - main
+      - v1.x.x
   pull_request:
 jobs:
   golangci:
     name: lint
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        go-version: [
+                1.17.x, 
+                1.18.x,
+                # 1.19.x
+                ]
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v2
+      - name: Checkout code
+        uses: actions/checkout@v3
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v2
+        uses: golangci/golangci-lint-action@v3
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.29
+          # version: v1.29
+          version: v1.53
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,11 +22,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Test
         run: GIT_BRANCH=${GIT_REF:11} DOCKER_GATEWAY_HOST=172.17.0.1 DOCKER_HOST_HTTP="http://172.17.0.1" make
       - name: Install goveralls


### PR DESCRIPTION
- Updates golanglint-ci such that it now passes.
- Targets v1.x.x branch and v1* release tags, rather than main/master which is now for v2
- Updates other actions tags (checkout and setup-go) to latest


Notes: Appveyor build has failed for circa three years, so will be looked at in a separate PR