### PR TITLE
chore: update pactfoundation/pact-broker over dius broker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
 FROM golang:1.10.1
 
 # Install pact ruby standalone binaries
-RUN curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v1.37.0/pact-1.37.0-linux-x86_64.tar.gz; \
-    tar -C /usr/local -xzf pact-1.37.0-linux-x86_64.tar.gz; \
-    rm pact-1.37.0-linux-x86_64.tar.gz
+RUN curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v2.0.3/pact-2.0.3-linux-x86_64.tar.gz; \
+    tar -C /usr/local -xzf pact-2.0.3-linux-x86_64.tar.gz; \
+    rm pact-2.0.3-linux-x86_64.tar.gz
 
 ENV PATH /usr/local/pact/bin:$PATH
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -33,7 +33,7 @@ services:
     # The Pact Broker provides a healthcheck endpoint which we will use to wait
     # for it to become available before starting up
     healthcheck:
-      test: [ "CMD", "wget", "-q", "--tries=1", "--spider", "http://pactbroker:pactbroker@localhost:9292/diagnostic/status/heartbeat" ]
+      test: [ "CMD", "wget", "-q", "--tries=1", "--spider", "http://pact_workshop:pact_workshop@localhost:9292/diagnostic/status/heartbeat" ]
       interval: 1s
       timeout: 2s
       retries: 5

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,11 +18,11 @@ services:
       POSTGRES_DB: postgres
 
   broker_app:
-    image: dius/pact-broker
+    image: pactfoundation/pact-broker:latest-multi
     links:
       - postgres
     ports:
-      - 80:80
+      - 80:9292
     environment:
       PACT_BROKER_BASIC_AUTH_USERNAME: pact_workshop
       PACT_BROKER_BASIC_AUTH_PASSWORD: pact_workshop
@@ -30,3 +30,13 @@ services:
       PACT_BROKER_DATABASE_PASSWORD: password
       PACT_BROKER_DATABASE_HOST: postgres
       PACT_BROKER_DATABASE_NAME: postgres
+    # The Pact Broker provides a healthcheck endpoint which we will use to wait
+    # for it to become available before starting up
+    healthcheck:
+      test: [ "CMD", "wget", "-q", "--tries=1", "--spider", "http://pactbroker:pactbroker@localhost:9292/diagnostic/status/heartbeat" ]
+      interval: 1s
+      timeout: 2s
+      retries: 5
+    depends_on:
+      postgres:
+        condition: service_healthy


### PR DESCRIPTION
- Use the latest pactfoundation/pact-broker
- Use the `latest-multi` image to help those out on arm64
- Adds a healthcheck to ensure everything is sweet when starting up
- Update pact-ruby-standalone in docker image to latest