### PR TITLE
chore(ci): test/release on go 1.20

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,9 +16,9 @@ jobs:
           fetch-depth: 0
       -
         name: Set up Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
-          go-version: 1.19
+          go-version: 1.20
       -
         name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v2

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,12 +25,12 @@ jobs:
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
       - name: Install Go
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-      - name: Checkout code
-        uses: actions/checkout@v2
       - name: Test
         run: APP_BRANCH=${APP_REF:11} DOCKER_GATEWAY_HOST=172.17.0.1 DOCKER_HOST_HTTP="http://172.17.0.1" make
       - name: Install goveralls

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,12 +16,17 @@ jobs:
   test:
     strategy:
       matrix:
-        go-version: [1.17.x, 1.18.x, 1.19.x]
+        go-version: [ # https://endoflife.date/go
+                    1.17.x, # Ended 02 Aug 2022
+                    1.18.x, # Ended 01 Feb 2023
+                    1.19.x, 
+                    1.20.x
+                    ]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Install Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
       - name: Checkout code


### PR DESCRIPTION
Relates to #312 

- Adds go 1.20 as latest supported version for testing
- Uses go 1.20 for release
- Adds notes around EOL versions

There is a note in the readme around go versions

> NOTE: If using Go 1.19 or later, you need to run go install instead 
> go install github.com/pact-foundation/pact-go/v2@2.x.x

It would be worth adding a nice compat/support table, and I've not we don't have a supported platform/arch list

Similar to 

**OS/Arch support**

| OS | AMD 64 | arm |
|----|---------|-----|
| Linux (glibc) | ✅  | ✅  |
| Mac | ✅  | ✅  |
| Windows | ✅  | ❌   |
| Linux (alpine) | 🔸 | 🔸 |

✅ = installs without build hooks, pre-built native library
🔸 = works, however, requires build hooks / runtime compilation or installation
❌ = not supported

from here

https://github.com/pact-foundation/pact-js/issues/899#issuecomment-1462945915

I'm sure we put this on the site somewhere but haven't checked yet
