### PR TITLE
fix: set install_name to absolute path for libpact_ffi.dylib (#345)

### DIFF
--- a/installer/installer.go
+++ b/installer/installer.go
@@ -236,7 +236,7 @@ func (i *Installer) installDependencies() error {
 				return err
 			}
 
-			err = setOSXInstallName(dst, info.libName)
+			err = setOSXInstallName(dst)
 
 			if err != nil {
 				return err
@@ -289,8 +289,9 @@ func (i *Installer) updateConfiguration(dst string, pkg string, info packageInfo
 	return i.config.writeConfig(c)
 }
 
-var setOSXInstallName = func(file string, lib string) error {
-	cmd := exec.Command("install_name_tool", "-id", fmt.Sprintf("%s.dylib", lib), file)
+var setOSXInstallName = func(file string) error {
+	cmd := exec.Command("install_name_tool", "-id", file, file)
+	log.Println("[DEBUG] running command:", cmd)
 	stdoutStderr, err := cmd.CombinedOutput()
 
 	if err != nil {

--- a/installer/installer_test.go
+++ b/installer/installer_test.go
@@ -212,7 +212,7 @@ func (m *mockConfiguration) writeConfig(pactConfig) error {
 
 func restoreOSXInstallName() func() {
 	old := setOSXInstallName
-	setOSXInstallName = func(string, string) error {
+	setOSXInstallName = func(string) error {
 		return nil
 	}
 


### PR DESCRIPTION
Addresses #345
Tested by running the install command with and without --libDir.
Verified that my project's pact test compile and run correctly after installing libpact_ffi.dylib via a freshly built `pact-go`.
Verified otool output matches full path.
E.g.
```
~/github/pact-go install-name-tool ≡
15:05:16 🐠 
build/pact-go -l DEBUG install --libDir /tmp/
2023/10/02 15:05:18 [INFO] set lib dir target to /tmp/
2023/10/02 15:05:18 [INFO] package libpact_ffi not found
2023/10/02 15:05:18 [INFO] downloading library from https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v0.4.5/libpact_ffi-osx-x86_64.dylib.gz to /tmp/libpact_ffi.dylib
&{}
2023/10/02 15:05:19 [DEBUG] obtaining hash for file /tmp/libpact_ffi.dylib
2023/10/02 15:05:19 [DEBUG] writing config {map[libpact_ffi:{libpact_ffi 0.4.5 5971854e21bf8b41db8b821a77caa268}]}
2023/10/02 15:05:19 [DEBUG] writing yaml config to file libraries:
  libpact_ffi:
    libname: libpact_ffi
    version: 0.4.5
    hash: 5971854e21bf8b41db8b821a77caa268

2023/10/02 15:05:19 [INFO] setting install_name on library libpact_ffi for osx
2023/10/02 15:05:19 [DEBUG] running command: /usr/bin/install_name_tool -id /tmp/libpact_ffi.dylib /tmp/libpact_ffi.dylib
2023/10/02 15:05:20 [DEBUG] output from command []
2023/10/02 15:05:20 [INFO] package libpact_ffi found
2023/10/02 15:05:20 [INFO] checking version 0.4.5 of libpact_ffi against semver constraint >= 0.4.0, < 1.0.0
2023/10/02 15:05:20 [DEBUG] 0.4.5 satisfies constraints 0.4.5 >= 0.4.0, < 1.0.0
2023/10/02 15:05:20 [INFO] package libpact_ffi is correctly installed
2023/10/02 15:05:20 [DEBUG] skip checking ffi version() call because FFI not loaded. This is expected when running the 'pact-go' command.

~/github/pact-go install-name-tool ≡
15:05:23 🐠 
otool -D /tmp/libpact_ffi.dylib
/tmp/libpact_ffi.dylib:
/tmp/libpact_ffi.dylib
```