### PR TITLE
Ci/test x plat

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -1,0 +1,31 @@
+test: &TEST
+  test_script: make test
+
+linux_arm64_task:
+  env:
+    SKIP_PLUGIN_AVRO: "true"
+    matrix:
+      - VERSION: 1.19
+      - VERSION: 1.20
+      - VERSION: 1.21
+  # name: Tests (Go $VERSION)
+  arm_container:
+    image: golang:$VERSION
+  <<: *TEST
+
+macos_arm64_task:
+  macos_instance:
+    image: ghcr.io/cirruslabs/macos-ventura-base:latest
+  golang_pre_req_script: brew install go@$VERSION
+  cirrus_cli_pre_req_script: chmod +x scripts/*.sh
+  plugin_protobuf_pre_req_script: brew install protobuf
+  # plugin_avro_pre_req_script: brew install openjdk@17 && java --version
+  env:
+    PATH: "/opt/homebrew/opt/go@$VERSION/bin:$PATH" # Needed golang
+    # PATH: "/opt/homebrew/opt/openjdk@17/bin:$PATH" # Needed for Avro Plugin
+    SKIP_PLUGIN_AVRO: "true"
+    matrix:
+      - VERSION: 1.19
+      - VERSION: 1.20
+      - VERSION: 1.21
+  <<: *TEST

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,8 +76,4 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-      - run: make deps
-        if: runner.os != 'Windows'
-      - run: make clean
-      - run: make bin
       - run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -57,3 +57,27 @@ jobs:
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         parallel-finished: true
+
+  test-other-os:
+    strategy:
+      matrix:
+        go-version: [ # https://endoflife.date/go
+                    1.19.x, 
+                    1.20.x,
+                    1.21.x
+                    ]
+        os: [macos-latest,windows-latest]
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: ${{ matrix.go-version }}
+      - run: make deps
+        if: runner.os != 'Windows'
+      - run: make clean
+      - run: make bin
+      - run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,4 +76,8 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
+      - uses: actions/setup-java@v3 # Needed for the Avro example
+        with:
+          distribution: 'zulu'
+          java-version: '17'
       - run: make test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -76,8 +76,6 @@ jobs:
         uses: actions/setup-go@v4
         with:
           go-version: ${{ matrix.go-version }}
-      - uses: actions/setup-java@v3 # Needed for the Avro example
-        with:
-          distribution: 'zulu'
-          java-version: '17'
       - run: make test
+        env:
+          SKIP_PLUGIN_AVRO: true

--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,10 @@ TEST?=./...
 DOCKER_HOST_HTTP?="http://host.docker.internal"
 PACT_CLI="docker run --rm -v ${PWD}:${PWD} -e PACT_BROKER_BASE_URL=$(DOCKER_HOST_HTTP) -e PACT_BROKER_USERNAME -e PACT_BROKER_PASSWORD pactfoundation/pact-cli"
 
+ifeq ($(OS),Windows_NT)
+	EXT=.exe
+endif
+
 ci:: docker deps clean bin test pact
 
 # Run the ci target from a developer machine with the environment variables
@@ -43,10 +47,10 @@ deps: download_plugins
 download_plugins:
 	@echo "--- 🐿  Installing plugins"; \
 	./scripts/install-cli.sh
-	~/.pact/bin/pact-plugin-cli -y install https://github.com/pactflow/pact-protobuf-plugin/releases/tag/v-0.3.4
-	~/.pact/bin/pact-plugin-cli -y install https://github.com/pact-foundation/pact-plugins/releases/tag/csv-plugin-0.0.1
-	~/.pact/bin/pact-plugin-cli -y install https://github.com/mefellows/pact-matt-plugin/releases/tag/v0.0.9
-	~/.pact/bin/pact-plugin-cli -y install https://github.com/austek/pact-avro-plugin/releases/tag/v0.0.3
+	~/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/pactflow/pact-protobuf-plugin/releases/tag/v-0.3.4
+	~/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/pact-foundation/pact-plugins/releases/tag/csv-plugin-0.0.1
+	~/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/mefellows/pact-matt-plugin/releases/tag/v0.0.9
+	~/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/austek/pact-avro-plugin/releases/tag/v0.0.3
 
 cli:
 	@if [ ! -d pact/bin ]; then\

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,6 @@ PACT_CLI="docker run --rm -v ${PWD}:${PWD} -e PACT_BROKER_BASE_URL=$(DOCKER_HOST
 
 ifeq ($(OS),Windows_NT)
 	EXT=.exe
-	SKIP_PLUGIN_AVRO=true
 endif
 
 ci:: docker deps clean bin test pact
@@ -46,13 +45,15 @@ deps: download_plugins
 	cd -
 
 download_plugins:
-	@echo "--- 🐿  Installing plugins"; \
-	./scripts/install-cli.sh
-	$$HOME/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/pactflow/pact-protobuf-plugin/releases/tag/v-0.3.4
-	$$HOME/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/pact-foundation/pact-plugins/releases/tag/csv-plugin-0.0.1
-	$$HOME/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/mefellows/pact-matt-plugin/releases/tag/v0.0.9
-	if [ -z "$$SKIP_PLUGIN_AVRO" ]; then\
-		$$HOME/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/austek/pact-avro-plugin/releases/tag/v0.0.3; \
+	if [ -z $$SKIP_PLUGINS ]; then\
+		echo "--- 🐿  Installing plugins";\
+		./scripts/install-cli.sh;\
+		$$HOME/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/pactflow/pact-protobuf-plugin/releases/tag/v-0.3.4;\
+		$$HOME/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/you54f/pact-plugins/releases/tag/csv-plugin-0.0.4;\
+		$$HOME/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/mefellows/pact-matt-plugin/releases/tag/v0.0.9;\
+		if [ -z $$SKIP_PLUGIN_AVRO ]; then\
+			$$HOME/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/austek/pact-avro-plugin/releases/tag/v0.0.3; \
+		fi \
 	fi
 
 cli:

--- a/Makefile
+++ b/Makefile
@@ -47,10 +47,10 @@ deps: download_plugins
 download_plugins:
 	@echo "--- 🐿  Installing plugins"; \
 	./scripts/install-cli.sh
-	~/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/pactflow/pact-protobuf-plugin/releases/tag/v-0.3.4
-	~/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/pact-foundation/pact-plugins/releases/tag/csv-plugin-0.0.1
-	~/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/mefellows/pact-matt-plugin/releases/tag/v0.0.9
-	~/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/austek/pact-avro-plugin/releases/tag/v0.0.3
+	$$HOME/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/pactflow/pact-protobuf-plugin/releases/tag/v-0.3.4
+	$$HOME/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/pact-foundation/pact-plugins/releases/tag/csv-plugin-0.0.1
+	$$HOME/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/mefellows/pact-matt-plugin/releases/tag/v0.0.9
+	$$HOME/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/austek/pact-avro-plugin/releases/tag/v0.0.3
 
 cli:
 	@if [ ! -d pact/bin ]; then\

--- a/Makefile
+++ b/Makefile
@@ -7,6 +7,7 @@ PACT_CLI="docker run --rm -v ${PWD}:${PWD} -e PACT_BROKER_BASE_URL=$(DOCKER_HOST
 
 ifeq ($(OS),Windows_NT)
 	EXT=.exe
+	SKIP_PLUGIN_AVRO=true
 endif
 
 ci:: docker deps clean bin test pact
@@ -50,7 +51,9 @@ download_plugins:
 	$$HOME/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/pactflow/pact-protobuf-plugin/releases/tag/v-0.3.4
 	$$HOME/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/pact-foundation/pact-plugins/releases/tag/csv-plugin-0.0.1
 	$$HOME/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/mefellows/pact-matt-plugin/releases/tag/v0.0.9
-	$$HOME/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/austek/pact-avro-plugin/releases/tag/v0.0.3
+	if [ -z "$$SKIP_PLUGIN_AVRO" ]; then\
+		$$HOME/.pact/bin/pact-plugin-cli$(EXT) -y install https://github.com/austek/pact-avro-plugin/releases/tag/v0.0.3; \
+	fi
 
 cli:
 	@if [ ! -d pact/bin ]; then\

--- a/command/root.go
+++ b/command/root.go
@@ -3,7 +3,7 @@ package command
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 
@@ -50,6 +50,6 @@ func setLogLevel(verbose bool, level string) {
 	log.SetOutput(filter)
 
 	if !verbose {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 }

--- a/command/root_test.go
+++ b/command/root_test.go
@@ -1,7 +1,7 @@
 package command
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -55,7 +55,7 @@ func captureOutput(action func()) string {
 	action()
 
 	w.Close()
-	out, _ := ioutil.ReadAll(r)
+	out, _ := io.ReadAll(r)
 	os.Stderr = rescueStderr
 
 	return strings.TrimSpace(string(out))

--- a/doc.go
+++ b/doc.go
@@ -207,7 +207,7 @@ An example route using the standard Go http package might look like this:
     // Retrieve the Provider State
     var state types.ProviderState
 
-    body, _ := ioutil.ReadAll(req.Body)
+    body, _ := io.ReadAll(req.Body)
     req.Body.Close()
     json.Unmarshal(body, &state)
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3"
 
 services:
   httpbin:
-    image: kennethreitz/httpbin
+    image: kong/httpbin # https://github.com/Kong/httpbin
     ports:
       - "8000:80"
 

--- a/examples/avro/avro_consumer_test.go
+++ b/examples/avro/avro_consumer_test.go
@@ -5,7 +5,7 @@ package avro
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -82,7 +82,7 @@ func callServiceHTTP(msc consumer.MockServerConfig) (*User, error) {
 		return nil, err
 	}
 
-	bytes, err := ioutil.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
 
 	if err != nil {
 		return nil, err

--- a/examples/avro/codec.go
+++ b/examples/avro/codec.go
@@ -1,13 +1,13 @@
 package avro
 
 import (
-	"io/ioutil"
-
+	
+	"os"
 	"github.com/linkedin/goavro/v2"
 )
 
 func getCodec() *goavro.Codec {
-	schema, err := ioutil.ReadFile("user.avsc")
+	schema, err := os.ReadFile("user.avsc")
 	if err != nil {
 		panic(err)
 	}

--- a/examples/consumer_v2_test.go
+++ b/examples/consumer_v2_test.go
@@ -6,7 +6,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -188,7 +188,7 @@ var rawTest = func(query string) func(config consumer.MockServerConfig) error {
 				Path:     "/foobar",
 				RawQuery: query,
 			},
-			Body:   ioutil.NopCloser(strings.NewReader(`{"id": 27, "name":"billy", "lastName":"sampson", "datetime":"2021-01-01T08:00:45"}`)),
+			Body:   io.NopCloser(strings.NewReader(`{"id": 27, "name":"billy", "lastName":"sampson", "datetime":"2021-01-01T08:00:45"}`)),
 			Header: make(http.Header),
 		}
 

--- a/examples/grpc/routeguide/server/server.go
+++ b/examples/grpc/routeguide/server/server.go
@@ -28,7 +28,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"log"
 	"math"
 	"net"
@@ -155,7 +155,7 @@ func (s *routeGuideServer) loadFeatures(filePath string) {
 	var data []byte
 	if filePath != "" {
 		var err error
-		data, err = ioutil.ReadFile(filePath)
+		data, err = os.ReadFile(filePath)
 		if err != nil {
 			log.Fatalf("Failed to load default features: %v", err)
 		}

--- a/examples/pacts/AvroConsumer-AvroProvider.json
+++ b/examples/pacts/AvroConsumer-AvroProvider.json
@@ -1,0 +1,81 @@
+{
+  "consumer": {
+    "name": "AvroConsumer"
+  },
+  "interactions": [
+    {
+      "description": "A request to do get some Avro stuff",
+      "pending": false,
+      "pluginConfiguration": {
+        "avro": {
+          "record": "User",
+          "schemaKey": "1184dbf3292cee8bc7390762dd15fc52"
+        }
+      },
+      "request": {
+        "method": "GET",
+        "path": "/avro"
+      },
+      "response": {
+        "body": {
+          "content": "AghtYXR0",
+          "contentType": "avro/binary;record=User",
+          "contentTypeHint": "BINARY",
+          "encoded": "base64"
+        },
+        "headers": {
+          "content-type": [
+            "avro/binary"
+          ]
+        },
+        "matchingRules": {
+          "body": {
+            "$.id": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "number"
+                }
+              ]
+            },
+            "$.username": {
+              "combine": "AND",
+              "matchers": [
+                {
+                  "match": "notEmpty"
+                }
+              ]
+            }
+          }
+        },
+        "status": 200
+      },
+      "transport": "http",
+      "type": "Synchronous/HTTP"
+    }
+  ],
+  "metadata": {
+    "pactRust": {
+      "ffi": "0.4.5",
+      "mockserver": "1.1.1",
+      "models": "1.1.2"
+    },
+    "pactSpecification": {
+      "version": "4.0"
+    },
+    "plugins": [
+      {
+        "configuration": {
+          "1184dbf3292cee8bc7390762dd15fc52": {
+            "avroSchema": "{\"type\":\"record\",\"name\":\"User\",\"namespace\":\"io.pact\",\"fields\":[{\"name\":\"id\",\"type\":\"long\"},{\"name\":\"username\",\"type\":\"string\"}]}"
+          }
+        },
+        "name": "avro",
+        "version": "0.0.4"
+      }
+    ]
+  },
+  "provider": {
+    "name": "AvroProvider"
+  }
+}

--- a/examples/pacts/MattConsumer-MattProvider.json
+++ b/examples/pacts/MattConsumer-MattProvider.json
@@ -5,7 +5,6 @@
   "interactions": [
     {
       "description": "A request to do a matt",
-      "key": "c544877c9301bb17",
       "pending": false,
       "request": {
         "body": {
@@ -42,9 +41,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.3.18",
-      "mockserver": "0.9.8",
-      "models": "1.0.2"
+      "ffi": "0.4.5",
+      "mockserver": "1.1.1",
+      "models": "1.1.2"
     },
     "pactSpecification": {
       "version": "4.0"
@@ -53,7 +52,7 @@
       {
         "configuration": {},
         "name": "matt",
-        "version": "0.0.7"
+        "version": "0.0.9"
       }
     ]
   },

--- a/examples/pacts/PactGoProductAPIConsumer-PactGoProductAPI.json
+++ b/examples/pacts/PactGoProductAPIConsumer-PactGoProductAPI.json
@@ -36,9 +36,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.3.18",
-      "mockserver": "0.9.8",
-      "models": "1.0.2"
+      "ffi": "0.4.5",
+      "mockserver": "1.1.1",
+      "models": "1.1.2"
     },
     "pactSpecification": {
       "version": "2.0.0"

--- a/examples/pacts/PactGoV2Consumer-V2Provider.json
+++ b/examples/pacts/PactGoV2Consumer-V2Provider.json
@@ -88,9 +88,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.3.18",
-      "mockserver": "0.9.8",
-      "models": "1.0.2"
+      "ffi": "0.4.5",
+      "mockserver": "1.1.1",
+      "models": "1.1.2"
     },
     "pactSpecification": {
       "version": "2.0.0"

--- a/examples/pacts/PactGoV2ConsumerAllInOne-V2Provider.json
+++ b/examples/pacts/PactGoV2ConsumerAllInOne-V2Provider.json
@@ -72,9 +72,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.3.18",
-      "mockserver": "0.9.8",
-      "models": "1.0.2"
+      "ffi": "0.4.5",
+      "mockserver": "1.1.1",
+      "models": "1.1.2"
     },
     "pactSpecification": {
       "version": "2.0.0"

--- a/examples/pacts/PactGoV2ConsumerMatch-V2ProviderMatch.json
+++ b/examples/pacts/PactGoV2ConsumerMatch-V2ProviderMatch.json
@@ -84,9 +84,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.3.18",
-      "mockserver": "0.9.8",
-      "models": "1.0.2"
+      "ffi": "0.4.5",
+      "mockserver": "1.1.1",
+      "models": "1.1.2"
     },
     "pactSpecification": {
       "version": "2.0.0"

--- a/examples/pacts/PactGoV3Consumer-V3Provider.json
+++ b/examples/pacts/PactGoV3Consumer-V3Provider.json
@@ -278,9 +278,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.3.18",
-      "mockserver": "0.9.8",
-      "models": "1.0.2"
+      "ffi": "0.4.5",
+      "mockserver": "1.1.1",
+      "models": "1.1.2"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/examples/pacts/PactGoV3MessageConsumer-V3MessageProvider.json
+++ b/examples/pacts/PactGoV3MessageConsumer-V3MessageProvider.json
@@ -48,8 +48,8 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.3.18",
-      "models": "1.0.2"
+      "ffi": "0.4.5",
+      "models": "1.1.2"
     },
     "pactSpecification": {
       "version": "3.0.0"

--- a/examples/pacts/PactGoV4Consumer-V4Provider.json
+++ b/examples/pacts/PactGoV4Consumer-V4Provider.json
@@ -5,7 +5,6 @@
   "interactions": [
     {
       "description": "A request to do a foo",
-      "key": "723d6c7144f49156",
       "pending": false,
       "providerStates": [
         {
@@ -296,9 +295,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.3.18",
-      "mockserver": "0.9.8",
-      "models": "1.0.2"
+      "ffi": "0.4.5",
+      "mockserver": "1.1.1",
+      "models": "1.1.2"
     },
     "pactSpecification": {
       "version": "4.0"

--- a/examples/pacts/matttcpconsumer-matttcpprovider.json
+++ b/examples/pacts/matttcpconsumer-matttcpprovider.json
@@ -5,7 +5,6 @@
   "interactions": [
     {
       "description": "Matt message",
-      "key": "1d2254a9979327d8",
       "pending": false,
       "providerStates": [
         {
@@ -36,9 +35,9 @@
   ],
   "metadata": {
     "pactRust": {
-      "ffi": "0.3.18",
-      "mockserver": "0.9.8",
-      "models": "1.0.2"
+      "ffi": "0.4.5",
+      "mockserver": "1.1.1",
+      "models": "1.1.2"
     },
     "pactSpecification": {
       "version": "4.0"
@@ -47,7 +46,7 @@
       {
         "configuration": {},
         "name": "matt",
-        "version": "0.0.7"
+        "version": "0.0.9"
       }
     ]
   },

--- a/examples/pacts/protobufmessageconsumer-protobufmessageprovider.json
+++ b/examples/pacts/protobufmessageconsumer-protobufmessageprovider.json
@@ -1,106 +1,69 @@
 {
   "consumer": {
-    "name": "grpcconsumer"
+    "name": "protobufmessageconsumer"
   },
   "interactions": [
     {
-      "description": "Route guide - GetFeature",
+      "contents": {
+        "content": "CghCaWcgVHJlZRIGCLQBEMgB",
+        "contentType": "application/protobuf;message=Feature",
+        "contentTypeHint": "BINARY",
+        "encoded": "base64"
+      },
+      "description": "feature message",
       "interactionMarkup": {
         "markup": "```protobuf\nmessage Feature {\n    string name = 1;\n    message .routeguide.Point location = 2;\n}\n```\n",
         "markupType": "COMMON_MARK"
+      },
+      "matchingRules": {
+        "body": {
+          "$.location.latitude": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "number"
+              }
+            ]
+          },
+          "$.location.longitude": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "number"
+              }
+            ]
+          },
+          "$.name": {
+            "combine": "AND",
+            "matchers": [
+              {
+                "match": "notEmpty"
+              }
+            ]
+          }
+        }
+      },
+      "metadata": {
+        "contentType": "application/protobuf;message=Feature"
       },
       "pending": false,
       "pluginConfiguration": {
         "protobuf": {
           "descriptorKey": "32f7898819c9f3ece72c5f9de784d705",
-          "service": "RouteGuide/GetFeature"
+          "message": "Feature"
         }
       },
       "providerStates": [
         {
-          "name": "feature 'Big Tree' exists"
+          "name": "the world exists"
         }
       ],
-      "request": {
-        "contents": {
-          "content": "CLQBEMgB",
-          "contentType": "application/protobuf;message=Point",
-          "contentTypeHint": "BINARY",
-          "encoded": "base64"
-        },
-        "matchingRules": {
-          "body": {
-            "$.latitude": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "number"
-                }
-              ]
-            },
-            "$.longitude": {
-              "combine": "AND",
-              "matchers": [
-                {
-                  "match": "number"
-                }
-              ]
-            }
-          }
-        },
-        "metadata": {
-          "contentType": "application/protobuf;message=Point"
-        }
-      },
-      "response": [
-        {
-          "contents": {
-            "content": "CghCaWcgVHJlZRIGCLQBEMgB",
-            "contentType": "application/protobuf;message=Feature",
-            "contentTypeHint": "BINARY",
-            "encoded": "base64"
-          },
-          "matchingRules": {
-            "body": {
-              "$.location.latitude": {
-                "combine": "AND",
-                "matchers": [
-                  {
-                    "match": "number"
-                  }
-                ]
-              },
-              "$.location.longitude": {
-                "combine": "AND",
-                "matchers": [
-                  {
-                    "match": "number"
-                  }
-                ]
-              },
-              "$.name": {
-                "combine": "AND",
-                "matchers": [
-                  {
-                    "match": "notEmpty"
-                  }
-                ]
-              }
-            }
-          },
-          "metadata": {
-            "contentType": "application/protobuf;message=Feature"
-          }
-        }
-      ],
-      "transport": "grpc",
-      "type": "Synchronous/Messages"
+      "type": "Asynchronous/Messages"
     }
   ],
   "metadata": {
     "pactRust": {
       "ffi": "0.4.5",
-      "mockserver": "1.1.1",
       "models": "1.1.2"
     },
     "pactSpecification": {
@@ -120,6 +83,6 @@
     ]
   },
   "provider": {
-    "name": "grpcprovider"
+    "name": "protobufmessageprovider"
   }
 }

--- a/examples/plugin/consumer_plugin_test.go
+++ b/examples/plugin/consumer_plugin_test.go
@@ -6,7 +6,7 @@ package plugin
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -99,7 +99,7 @@ func callMattServiceHTTP(msc consumer.MockServerConfig, message string) (string,
 			Scheme: "http",
 			Path:   "/matt",
 		},
-		Body:   ioutil.NopCloser(strings.NewReader(generateMattMessage(message))),
+		Body:   io.NopCloser(strings.NewReader(generateMattMessage(message))),
 		Header: make(http.Header),
 	}
 
@@ -111,7 +111,7 @@ func callMattServiceHTTP(msc consumer.MockServerConfig, message string) (string,
 		return "", err
 	}
 
-	bytes, err := ioutil.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
 
 	if err != nil {
 		return "", err

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -5,7 +5,6 @@ package installer
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -443,7 +442,7 @@ func (configuration) readConfig() pactConfig {
 		Libraries: map[string]packageMetadata{},
 	}
 
-	bytes, err := ioutil.ReadFile(pactConfigPath)
+	bytes, err := os.ReadFile(pactConfigPath)
 	if err != nil {
 		log.Println("[DEBUG] error reading file", pactConfigPath, "error: ", err)
 		return c
@@ -473,7 +472,7 @@ func (configuration) writeConfig(c pactConfig) error {
 	}
 	log.Println("[DEBUG] writing yaml config to file", string(bytes))
 
-	return ioutil.WriteFile(pactConfigPath, bytes, 0644)
+	return os.WriteFile(pactConfigPath, bytes, 0644)
 }
 
 type hasher interface {

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -289,7 +289,7 @@ func (i *Installer) updateConfiguration(dst string, pkg string, info packageInfo
 }
 
 var setOSXInstallName = func(file string, lib string) error {
-	cmd := exec.Command("install_name_tool", "-id", fmt.Sprintf("%s.dylib", lib), file)
+	cmd := exec.Command("install_name_tool", "-id", file, file)
 	stdoutStderr, err := cmd.CombinedOutput()
 
 	if err != nil {

--- a/internal/native/message_server_test.go
+++ b/internal/native/message_server_test.go
@@ -6,9 +6,9 @@ import (
 	context "context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	l "log"
+	"io"
 	"os"
+	l"log"
 	"testing"
 	"time"
 
@@ -21,7 +21,7 @@ import (
 )
 
 func TestHandleBasedMessageTestsWithString(t *testing.T) {
-	tmpPactFolder, err := ioutil.TempDir("", "pact-go")
+	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
 	assert.NoError(t, err)
 	s := NewMessageServer("test-message-consumer", "test-message-provider")
 
@@ -48,7 +48,7 @@ func TestHandleBasedMessageTestsWithString(t *testing.T) {
 }
 
 func TestHandleBasedMessageTestsWithJSON(t *testing.T) {
-	tmpPactFolder, err := ioutil.TempDir("", "pact-go")
+	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
 	assert.NoError(t, err)
 	s := NewMessageServer("test-message-consumer", "test-message-provider")
 
@@ -82,7 +82,7 @@ func TestHandleBasedMessageTestsWithJSON(t *testing.T) {
 }
 
 func TestHandleBasedMessageTestsWithBinary(t *testing.T) {
-	tmpPactFolder, err := ioutil.TempDir("", "pact-go")
+	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
 	assert.NoError(t, err)
 
 	s := NewMessageServer("test-binarymessage-consumer", "test-binarymessage-provider").
@@ -116,7 +116,7 @@ func TestHandleBasedMessageTestsWithBinary(t *testing.T) {
 	// Extract binary payload, base 64 decode it, unzip it
 	r, err := gzip.NewReader(bytes.NewReader(body))
 	assert.NoError(t, err)
-	result, _ := ioutil.ReadAll(r)
+	result, _ := io.ReadAll(r)
 
 	assert.Equal(t, encodedMessage, string(result))
 
@@ -281,7 +281,7 @@ func TestGetPluginAsyncMessageContentsAsBytes(t *testing.T) {
 }
 
 func TestGrpcPluginInteraction(t *testing.T) {
-	tmpPactFolder, err := ioutil.TempDir("", "pact-go")
+	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
 	assert.NoError(t, err)
 	_ = log.SetLogLevel("TRACE")
 

--- a/internal/native/mock_server_test.go
+++ b/internal/native/mock_server_test.go
@@ -2,7 +2,7 @@ package native
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -58,7 +58,7 @@ func TestMockServer_MismatchesFail(t *testing.T) {
 }
 
 func TestMockServer_VerifySuccess(t *testing.T) {
-	tmpPactFolder, err := ioutil.TempDir("", "pact-go")
+	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
 	assert.NoError(t, err)
 
 	m := MockServer{}
@@ -81,7 +81,7 @@ func TestMockServer_VerifySuccess(t *testing.T) {
 }
 
 func TestMockServer_VerifyFail(t *testing.T) {
-	tmpPactFolder, err := ioutil.TempDir("", "pact-go")
+	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
 	assert.NoError(t, err)
 	m := MockServer{}
 	port, _ := m.CreateMockServer(pactSimple, "0.0.0.0:0", false)
@@ -97,7 +97,7 @@ func TestMockServer_VerifyFail(t *testing.T) {
 }
 
 func TestMockServer_WritePactfile(t *testing.T) {
-	tmpPactFolder, err := ioutil.TempDir("", "pact-go")
+	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
 	assert.NoError(t, err)
 
 	m := MockServer{}
@@ -126,7 +126,7 @@ func TestVersion(t *testing.T) {
 }
 
 func TestHandleBasedHTTPTests(t *testing.T) {
-	tmpPactFolder, err := ioutil.TempDir("", "pact-go")
+	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
 	assert.NoError(t, err)
 
 	m := NewHTTPPact("test-http-consumer", "test-http-provider")
@@ -165,7 +165,7 @@ func TestHandleBasedHTTPTests(t *testing.T) {
 }
 
 func TestPluginInteraction(t *testing.T) {
-	tmpPactFolder, err := ioutil.TempDir("", "pact-go")
+	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
 	assert.NoError(t, err)
 	_ = log.SetLogLevel("trace")
 
@@ -202,7 +202,7 @@ func TestPluginInteraction(t *testing.T) {
 	res, err := http.Get(fmt.Sprintf("http://0.0.0.0:%d/protobuf", port))
 	assert.NoError(t, err)
 
-	bytes, err := ioutil.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
 	assert.NoError(t, err)
 
 	initPluginRequest := &InitPluginRequest{}

--- a/message/v4/asynchronous_message_test.go
+++ b/message/v4/asynchronous_message_test.go
@@ -64,7 +64,7 @@ func TestAsyncTypeSystem(t *testing.T) {
 		ExpectsToReceive("some csv content").
 		UsingPlugin(PluginConfig{
 			Plugin:  "csv",
-			Version: "0.0.1",
+			Version: "0.0.3",
 		}).
 		WithContents(csvInteraction, "text/csv").
 		// StartTransport("notarealtransport", "127.0.0.1", nil).

--- a/message/verifier.go
+++ b/message/verifier.go
@@ -3,7 +3,7 @@ package message
 import (
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 
@@ -58,7 +58,7 @@ func CreateMessageHandler(messageHandlers Handlers) proxy.Middleware {
 
 				// Extract message
 				var message messageVerificationHandlerRequest
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				r.Body.Close()
 				log.Printf("[TRACE] message verification handler received request: %+s, %s", body, r.URL.Path)
 

--- a/provider/verifier.go
+++ b/provider/verifier.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -231,7 +230,7 @@ func getStateFromRequest(r *http.Request) (stateHandlerAction, error) {
 	}
 
 	// Body is consumed above, need to put it back after ;P
-	r.Body = ioutil.NopCloser(strings.NewReader(buf.String()))
+	r.Body = io.NopCloser(strings.NewReader(buf.String()))
 	log.Println("[TRACE] getStateFromRequest received raw input", buf.String())
 
 	err = json.Unmarshal([]byte(buf.String()), &state)
@@ -263,7 +262,7 @@ func stateHandlerMiddleware(stateHandlers models.StateHandlers, afterEach Hook) 
 				_, _ = io.ReadAll(tr)
 
 				// Body is consumed above, need to put it back after ;P
-				r.Body = ioutil.NopCloser(strings.NewReader(buf.String()))
+				r.Body = io.NopCloser(strings.NewReader(buf.String()))
 				log.Println("[TRACE] state handler received raw input", buf.String())
 
 				err := json.Unmarshal([]byte(buf.String()), &state)

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -9,6 +9,10 @@ set -e # Needed for Windows bash, which doesn't read the shebang
 
 function detect_osarch() {
     case $(uname -sm) in
+        'Linux aarch64')
+            os='linux'
+            arch='aarch64'
+            ;;
         'Linux x86_64')
             os='linux'
             arch='x86_64'


### PR DESCRIPTION
This PR address lint errors introduced by #347 

Also looks to test the Pact Go V2 project on windows and macos in GHA, and on arm64 hardware for linux/macos.

This also recreates the issue noted in #345 and goes some way towards #297 

I need to pull out the changes from https://github.com/pact-foundation/pact-go/pull/351/commits/9738a2b8dd2a1774985a89357faa123da1b998d1 but just thought I would stick this as a draft, in case people are wondering the golang-lintci is failing