### PR TITLE
Chore/golint deprecations

### DIFF
--- a/command/root.go
+++ b/command/root.go
@@ -3,7 +3,7 @@ package command
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 
@@ -50,6 +50,6 @@ func setLogLevel(verbose bool, level string) {
 	log.SetOutput(filter)
 
 	if !verbose {
-		log.SetOutput(ioutil.Discard)
+		log.SetOutput(io.Discard)
 	}
 }

--- a/command/root_test.go
+++ b/command/root_test.go
@@ -1,7 +1,7 @@
 package command
 
 import (
-	"io/ioutil"
+	"io"
 	"log"
 	"os"
 	"strings"
@@ -55,7 +55,7 @@ func captureOutput(action func()) string {
 	action()
 
 	w.Close()
-	out, _ := ioutil.ReadAll(r)
+	out, _ := io.ReadAll(r)
 	os.Stderr = rescueStderr
 
 	return strings.TrimSpace(string(out))

--- a/doc.go
+++ b/doc.go
@@ -207,7 +207,7 @@ An example route using the standard Go http package might look like this:
     // Retrieve the Provider State
     var state types.ProviderState
 
-    body, _ := ioutil.ReadAll(req.Body)
+    body, _ := io.ReadAll(req.Body)
     req.Body.Close()
     json.Unmarshal(body, &state)
 

--- a/examples/avro/avro_consumer_test.go
+++ b/examples/avro/avro_consumer_test.go
@@ -5,7 +5,7 @@ package avro
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"os"
@@ -82,7 +82,7 @@ func callServiceHTTP(msc consumer.MockServerConfig) (*User, error) {
 		return nil, err
 	}
 
-	bytes, err := ioutil.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
 
 	if err != nil {
 		return nil, err

--- a/examples/avro/codec.go
+++ b/examples/avro/codec.go
@@ -1,13 +1,13 @@
 package avro
 
 import (
-	"io/ioutil"
-
+	
+	"os"
 	"github.com/linkedin/goavro/v2"
 )
 
 func getCodec() *goavro.Codec {
-	schema, err := ioutil.ReadFile("user.avsc")
+	schema, err := os.ReadFile("user.avsc")
 	if err != nil {
 		panic(err)
 	}

--- a/examples/consumer_v2_test.go
+++ b/examples/consumer_v2_test.go
@@ -6,7 +6,7 @@ package main
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"net/url"
 	"strings"
@@ -188,7 +188,7 @@ var rawTest = func(query string) func(config consumer.MockServerConfig) error {
 				Path:     "/foobar",
 				RawQuery: query,
 			},
-			Body:   ioutil.NopCloser(strings.NewReader(`{"id": 27, "name":"billy", "lastName":"sampson", "datetime":"2021-01-01T08:00:45"}`)),
+			Body:   io.NopCloser(strings.NewReader(`{"id": 27, "name":"billy", "lastName":"sampson", "datetime":"2021-01-01T08:00:45"}`)),
 			Header: make(http.Header),
 		}
 

--- a/examples/grpc/routeguide/server/server.go
+++ b/examples/grpc/routeguide/server/server.go
@@ -28,7 +28,7 @@ import (
 	"flag"
 	"fmt"
 	"io"
-	"io/ioutil"
+	"os"
 	"log"
 	"math"
 	"net"
@@ -155,7 +155,7 @@ func (s *routeGuideServer) loadFeatures(filePath string) {
 	var data []byte
 	if filePath != "" {
 		var err error
-		data, err = ioutil.ReadFile(filePath)
+		data, err = os.ReadFile(filePath)
 		if err != nil {
 			log.Fatalf("Failed to load default features: %v", err)
 		}

--- a/examples/plugin/consumer_plugin_test.go
+++ b/examples/plugin/consumer_plugin_test.go
@@ -6,7 +6,7 @@ package plugin
 import (
 	"bufio"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -99,7 +99,7 @@ func callMattServiceHTTP(msc consumer.MockServerConfig, message string) (string,
 			Scheme: "http",
 			Path:   "/matt",
 		},
-		Body:   ioutil.NopCloser(strings.NewReader(generateMattMessage(message))),
+		Body:   io.NopCloser(strings.NewReader(generateMattMessage(message))),
 		Header: make(http.Header),
 	}
 
@@ -111,7 +111,7 @@ func callMattServiceHTTP(msc consumer.MockServerConfig, message string) (string,
 		return "", err
 	}
 
-	bytes, err := ioutil.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
 
 	if err != nil {
 		return "", err

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -5,7 +5,6 @@ package installer
 import (
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"os"
 	"os/exec"
@@ -443,7 +442,7 @@ func (configuration) readConfig() pactConfig {
 		Libraries: map[string]packageMetadata{},
 	}
 
-	bytes, err := ioutil.ReadFile(pactConfigPath)
+	bytes, err := os.ReadFile(pactConfigPath)
 	if err != nil {
 		log.Println("[DEBUG] error reading file", pactConfigPath, "error: ", err)
 		return c
@@ -473,7 +472,7 @@ func (configuration) writeConfig(c pactConfig) error {
 	}
 	log.Println("[DEBUG] writing yaml config to file", string(bytes))
 
-	return ioutil.WriteFile(pactConfigPath, bytes, 0644)
+	return os.WriteFile(pactConfigPath, bytes, 0644)
 }
 
 type hasher interface {

--- a/installer/installer_test.go
+++ b/installer/installer_test.go
@@ -79,7 +79,7 @@ func TestInstallerDownloader(t *testing.T) {
 			return nil
 		})
 
-		i.downloadDependencies() // This will actually error on the "chmod" if the file doesn't exist
+		_ = i.downloadDependencies() // This will actually error on the "chmod" if the file doesn't exist
 
 		assert.True(t, mock.called)
 	})

--- a/internal/native/message_server_test.go
+++ b/internal/native/message_server_test.go
@@ -6,9 +6,9 @@ import (
 	context "context"
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
-	l "log"
+	"io"
 	"os"
+	l"log"
 	"testing"
 	"time"
 
@@ -21,7 +21,7 @@ import (
 )
 
 func TestHandleBasedMessageTestsWithString(t *testing.T) {
-	tmpPactFolder, err := ioutil.TempDir("", "pact-go")
+	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
 	assert.NoError(t, err)
 	s := NewMessageServer("test-message-consumer", "test-message-provider")
 
@@ -48,7 +48,7 @@ func TestHandleBasedMessageTestsWithString(t *testing.T) {
 }
 
 func TestHandleBasedMessageTestsWithJSON(t *testing.T) {
-	tmpPactFolder, err := ioutil.TempDir("", "pact-go")
+	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
 	assert.NoError(t, err)
 	s := NewMessageServer("test-message-consumer", "test-message-provider")
 
@@ -82,7 +82,7 @@ func TestHandleBasedMessageTestsWithJSON(t *testing.T) {
 }
 
 func TestHandleBasedMessageTestsWithBinary(t *testing.T) {
-	tmpPactFolder, err := ioutil.TempDir("", "pact-go")
+	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
 	assert.NoError(t, err)
 
 	s := NewMessageServer("test-binarymessage-consumer", "test-binarymessage-provider").
@@ -116,7 +116,7 @@ func TestHandleBasedMessageTestsWithBinary(t *testing.T) {
 	// Extract binary payload, base 64 decode it, unzip it
 	r, err := gzip.NewReader(bytes.NewReader(body))
 	assert.NoError(t, err)
-	result, _ := ioutil.ReadAll(r)
+	result, _ := io.ReadAll(r)
 
 	assert.Equal(t, encodedMessage, string(result))
 
@@ -281,7 +281,7 @@ func TestGetPluginAsyncMessageContentsAsBytes(t *testing.T) {
 }
 
 func TestGrpcPluginInteraction(t *testing.T) {
-	tmpPactFolder, err := ioutil.TempDir("", "pact-go")
+	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
 	assert.NoError(t, err)
 	_ = log.SetLogLevel("TRACE")
 

--- a/internal/native/mock_server_test.go
+++ b/internal/native/mock_server_test.go
@@ -2,7 +2,7 @@ package native
 
 import (
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net/http"
 	"os"
 	"testing"
@@ -58,7 +58,7 @@ func TestMockServer_MismatchesFail(t *testing.T) {
 }
 
 func TestMockServer_VerifySuccess(t *testing.T) {
-	tmpPactFolder, err := ioutil.TempDir("", "pact-go")
+	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
 	assert.NoError(t, err)
 
 	m := MockServer{}
@@ -81,7 +81,7 @@ func TestMockServer_VerifySuccess(t *testing.T) {
 }
 
 func TestMockServer_VerifyFail(t *testing.T) {
-	tmpPactFolder, err := ioutil.TempDir("", "pact-go")
+	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
 	assert.NoError(t, err)
 	m := MockServer{}
 	port, _ := m.CreateMockServer(pactSimple, "0.0.0.0:0", false)
@@ -97,7 +97,7 @@ func TestMockServer_VerifyFail(t *testing.T) {
 }
 
 func TestMockServer_WritePactfile(t *testing.T) {
-	tmpPactFolder, err := ioutil.TempDir("", "pact-go")
+	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
 	assert.NoError(t, err)
 
 	m := MockServer{}
@@ -126,7 +126,7 @@ func TestVersion(t *testing.T) {
 }
 
 func TestHandleBasedHTTPTests(t *testing.T) {
-	tmpPactFolder, err := ioutil.TempDir("", "pact-go")
+	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
 	assert.NoError(t, err)
 
 	m := NewHTTPPact("test-http-consumer", "test-http-provider")
@@ -165,7 +165,7 @@ func TestHandleBasedHTTPTests(t *testing.T) {
 }
 
 func TestPluginInteraction(t *testing.T) {
-	tmpPactFolder, err := ioutil.TempDir("", "pact-go")
+	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
 	assert.NoError(t, err)
 	_ = log.SetLogLevel("trace")
 
@@ -202,7 +202,7 @@ func TestPluginInteraction(t *testing.T) {
 	res, err := http.Get(fmt.Sprintf("http://0.0.0.0:%d/protobuf", port))
 	assert.NoError(t, err)
 
-	bytes, err := ioutil.ReadAll(res.Body)
+	bytes, err := io.ReadAll(res.Body)
 	assert.NoError(t, err)
 
 	initPluginRequest := &InitPluginRequest{}

--- a/message/v4/asynchronous_message_test.go
+++ b/message/v4/asynchronous_message_test.go
@@ -64,7 +64,7 @@ func TestAsyncTypeSystem(t *testing.T) {
 		ExpectsToReceive("some csv content").
 		UsingPlugin(PluginConfig{
 			Plugin:  "csv",
-			Version: "0.0.1",
+			Version: "0.0.3",
 		}).
 		WithContents(csvInteraction, "text/csv").
 		// StartTransport("notarealtransport", "127.0.0.1", nil).

--- a/message/verifier.go
+++ b/message/verifier.go
@@ -3,7 +3,7 @@ package message
 import (
 	"encoding/base64"
 	"encoding/json"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 
@@ -58,7 +58,7 @@ func CreateMessageHandler(messageHandlers Handlers) proxy.Middleware {
 
 				// Extract message
 				var message messageVerificationHandlerRequest
-				body, err := ioutil.ReadAll(r.Body)
+				body, err := io.ReadAll(r.Body)
 				r.Body.Close()
 				log.Printf("[TRACE] message verification handler received request: %+s, %s", body, r.URL.Path)
 

--- a/provider/verifier.go
+++ b/provider/verifier.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"log"
 	"net"
 	"net/http"
@@ -231,7 +230,7 @@ func getStateFromRequest(r *http.Request) (stateHandlerAction, error) {
 	}
 
 	// Body is consumed above, need to put it back after ;P
-	r.Body = ioutil.NopCloser(strings.NewReader(buf.String()))
+	r.Body = io.NopCloser(strings.NewReader(buf.String()))
 	log.Println("[TRACE] getStateFromRequest received raw input", buf.String())
 
 	err = json.Unmarshal([]byte(buf.String()), &state)
@@ -263,7 +262,7 @@ func stateHandlerMiddleware(stateHandlers models.StateHandlers, afterEach Hook) 
 				_, _ = io.ReadAll(tr)
 
 				// Body is consumed above, need to put it back after ;P
-				r.Body = ioutil.NopCloser(strings.NewReader(buf.String()))
+				r.Body = io.NopCloser(strings.NewReader(buf.String()))
 				log.Println("[TRACE] state handler received raw input", buf.String())
 
 				err := json.Unmarshal([]byte(buf.String()), &state)


### PR DESCRIPTION
I'm not sure if this is _actually_ a breaking change for users of golang < 1.17 as part of updating the `go.mod` file in #347 

Feel free to clean up the commit history for an appropriate changelog :)