### PR TITLE
Pact CLI Install Path

### DIFF
--- a/client/service.go
+++ b/client/service.go
@@ -17,7 +17,7 @@ import (
 // Service is a process wrapper for 3rd party binaries. It will spawn an instance
 // of the binary and manage the life-cycle and IO of the process.
 type Service interface {
-	Setup()
+	Setup(pactCLIDir string)
 	Stop(pid int) (bool, error)
 	List() map[int]*exec.Cmd
 	Command() *exec.Cmd

--- a/client/service_test.go
+++ b/client/service_test.go
@@ -19,7 +19,7 @@ func createServiceManager() *ServiceManager {
 		Args: cs,
 		Env:  env,
 	}
-	mgr.Setup()
+	mgr.Setup("")
 	return mgr
 }
 

--- a/dsl/client.go
+++ b/dsl/client.go
@@ -70,11 +70,11 @@ type PactClient struct {
 }
 
 // newClient creates a new Pact client manager with the provided services
-func newClient(mockServiceManager client.Service, verificationServiceManager client.Service, messageServiceManager client.Service, publishServiceManager client.Service) *PactClient {
-	mockServiceManager.Setup()
-	verificationServiceManager.Setup()
-	messageServiceManager.Setup()
-	publishServiceManager.Setup()
+func newClient(pactCLIDir string, mockServiceManager client.Service, verificationServiceManager client.Service, messageServiceManager client.Service, publishServiceManager client.Service) *PactClient {
+	mockServiceManager.Setup(pactCLIDir)
+	verificationServiceManager.Setup(pactCLIDir)
+	messageServiceManager.Setup(pactCLIDir)
+	publishServiceManager.Setup(pactCLIDir)
 
 	return &PactClient{
 		pactMockSvcManager:     mockServiceManager,
@@ -86,8 +86,8 @@ func newClient(mockServiceManager client.Service, verificationServiceManager cli
 }
 
 // NewClient creates a new Pact client manager with defaults
-func NewClient() *PactClient {
-	return newClient(&client.MockService{}, &client.VerificationService{}, &client.MessageService{}, &client.PublishService{})
+func NewClient(pactCLIDir string) *PactClient {
+	return newClient(pactCLIDir, &client.MockService{}, &client.VerificationService{}, &client.MessageService{}, &client.PublishService{})
 }
 
 // StartServer starts a remote Pact Mock Server.

--- a/dsl/client_test.go
+++ b/dsl/client_test.go
@@ -229,7 +229,7 @@ func createMockClient(success bool) (*PactClient, *ServiceMock) {
 		}
 	}()
 
-	d := newClient(svc, svc, svc, svc)
+	d := newClient("", svc, svc, svc, svc)
 	d.TimeoutDuration = 100 * time.Millisecond
 	return d, svc
 }

--- a/dsl/pact.go
+++ b/dsl/pact.go
@@ -32,6 +32,9 @@ type Pact struct {
 	// Current server for the consumer.
 	Server *types.MockServer
 
+	// Directory of Pactflow standalone CLI (blank if CLI is installed on system)
+	PactCLIDir string
+
 	// Pact RPC Client.
 	pactClient Client
 
@@ -158,7 +161,7 @@ func (p *Pact) Setup(startMockServer bool) *Pact {
 	}
 
 	if p.pactClient == nil {
-		c := NewClient()
+		c := NewClient(p.PactCLIDir)
 		c.TimeoutDuration = p.ClientTimeout
 		p.pactClient = c
 	}

--- a/dsl/publish.go
+++ b/dsl/publish.go
@@ -25,6 +25,9 @@ type PactName struct {
 
 // Publisher is the API to send Pact files to a Pact Broker.
 type Publisher struct {
+	// Directory of Pactflow standalone CLI (blank if CLI is installed on system)
+	PactCLIDir string
+
 	pactClient Client
 
 	// Log levels.
@@ -40,7 +43,7 @@ func (p *Publisher) Publish(request types.PublishRequest) error {
 	log.Println("[DEBUG] pact publisher: publish pact")
 
 	if p.pactClient == nil {
-		c := NewClient()
+		c := NewClient(p.PactCLIDir)
 		p.pactClient = c
 	}
 

--- a/dsl/service_mock.go
+++ b/dsl/service_mock.go
@@ -25,7 +25,7 @@ type ServiceMock struct {
 }
 
 // Setup the Management services.
-func (s *ServiceMock) Setup() {
+func (s *ServiceMock) Setup(pactCLIDir string) {
 	s.ServicesSetupCalled = true
 }
 


### PR DESCRIPTION
Adding ability to specify path to Pact CLI for systems where the CLI can't easily be installed