### PR TITLE
feat: support publish pacts with branch for v1.x

### DIFF
--- a/types/publish_request.go
+++ b/types/publish_request.go
@@ -29,6 +29,11 @@ type PublishRequest struct {
 	// e.g. "production", "master" and "development" are some common examples.
 	Tags []string
 
+	// Branches are used to identify which pacts a provider should verify using 
+	// consumer version selectors, associating the consumer API version with 
+	// a branch. This supersedes tags. https://docs.pact.io/pact_broker/branches 
+	Branch string
+
 	// Verbose increases verbosity of output
 	// Deprecated
 	Verbose bool
@@ -69,6 +74,10 @@ func (p *PublishRequest) Validate() error {
 
 	if p.BrokerToken != "" {
 		p.Args = append(p.Args, "--broker-token", p.BrokerToken)
+	}
+
+	if p.Branch != "" {
+		p.Args = append(p.Args, "--branch", p.Branch)
 	}
 
 	if p.ConsumerVersion == "" {


### PR DESCRIPTION
Small change to pact v1.x to support publishing pacts with branches.

I was updating the pact-go-workshop and wanted to get it to the latest of pact-go v1, with the supported workflow of branches over tags, and recording deployments, over using tags for environments, before migrating over to pact-go v2.

Tested locally

```
🕙12:57:56 ❯ make publish
--- 📝 Publishing Pacts
go run consumer/client/pact/publish.go
Publishing Pact files to broker /Users/yousaf.nabi/dev/pact-foundation/pact-workshop-go/pacts test.pactflow.io
2024/01/19 12:58:33 [INFO] Updated GoAdminService version 1.0.0 with branch master
2024/01/19 12:58:33 [INFO] Pact successfully republished for GoAdminService version 1.0.0 and provider GoUserService with no content changes.
2024/01/19 12:58:33 [INFO]   View the published pact at https://test.pactflow.io/pacts/provider/GoUserService/consumer/GoAdminService/version/1.0.0
2024/01/19 12:58:33 [INFO]   Events detected: contract_published
2024/01/19 12:58:33 [INFO]   No enabled webhooks found for the detected events

Pact contract publishing complete!

```