### PR TITLE
Add function to expose the NativeLibPath

### DIFF
--- a/installer/installer.go
+++ b/installer/installer.go
@@ -23,6 +23,16 @@ import (
 	"github.com/spf13/afero"
 )
 
+// NativeLibPath returns the absolute path to the go package used to link to the native rust library
+func NativeLibPath() string {
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		return ""
+	}
+	pactRoot := filepath.Dir(filepath.Dir(file))
+	return filepath.Join(pactRoot, "internal", "native")
+}
+
 // Installer is used to check the Pact Go installation is setup correctly, and can automatically install
 // packages if required
 type Installer struct {

--- a/installer/installer_test.go
+++ b/installer/installer_test.go
@@ -4,11 +4,22 @@ package installer
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"testing"
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
 )
+
+func TestNativeLibPath(t *testing.T) {
+	lib := NativeLibPath()
+
+	libFilePath := filepath.Join(lib, "lib.go")
+	file, err := os.ReadFile(libFilePath)
+	assert.NoError(t, err)
+	assert.Contains(t, string(file), "-lpact_ffi")
+}
 
 // 1. Be able to specify the path of the binary in advance
 // 2. Check if the correct versions of the libs are present???


### PR DESCRIPTION
Not sure if you want this in, but I was using pact on Windows and there the default path "user/local/lib" is most likely never right. I am using TDM GCC which is installed at `C:\TDM-GCC-64\bin`.

With the powershell `Get-Command` it is possible to detect the install path and put the library in there directly which is a better default on Windows I guess since otherwsie one would set this path manually.