### PR TITLE
Issue/pact ref 336

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ pact-provider-verifier
 _*
 *.log
 pact-go
+examples/pacts
 pacts
 logs
 tmp

--- a/Makefile
+++ b/Makefile
@@ -45,7 +45,7 @@ download_plugins:
 	./scripts/install-cli.sh
 	~/.pact/bin/pact-plugin-cli -y install https://github.com/pactflow/pact-protobuf-plugin/releases/tag/v-0.3.8
 	~/.pact/bin/pact-plugin-cli -y install https://github.com/pact-foundation/pact-plugins/releases/tag/csv-plugin-0.0.1
-	~/.pact/bin/pact-plugin-cli -y install https://github.com/mefellows/pact-matt-plugin/releases/tag/v0.0.9
+	~/.pact/bin/pact-plugin-cli -y install https://github.com/you54f/pact-matt-plugin/releases/tag/v0.1.0
 	~/.pact/bin/pact-plugin-cli -y install https://github.com/austek/pact-avro-plugin/releases/tag/v0.0.3
 
 cli:

--- a/examples/plugin/consumer_plugin_test.go
+++ b/examples/plugin/consumer_plugin_test.go
@@ -42,7 +42,7 @@ func TestHTTPPlugin(t *testing.T) {
 		UponReceiving("A request to do a matt").
 		UsingPlugin(consumer.PluginConfig{
 			Plugin:  "matt",
-			Version: "0.0.9",
+			Version: "0.1.0",
 		}).
 		WithRequest("POST", "/matt", func(req *consumer.V4InteractionWithPluginRequestBuilder) {
 			req.PluginContents("application/matt", mattRequest)
@@ -74,7 +74,7 @@ func TestTCPPlugin(t *testing.T) {
 		Given("the world exists").
 		UsingPlugin(message.PluginConfig{
 			Plugin:  "matt",
-			Version: "0.0.9",
+			Version: "0.1.0",
 		}).
 		WithContents(mattMessage, "application/matt").
 		StartTransport("matt", "127.0.0.1", nil). // For plugin tests, we can't assume if a transport is needed, so this is optional

--- a/examples/plugin/provider_plugin_test.go
+++ b/examples/plugin/provider_plugin_test.go
@@ -41,7 +41,7 @@ func TestPluginProvider(t *testing.T) {
 		// Provider:        "provider",
 		PactFiles: []string{
 			filepath.ToSlash(fmt.Sprintf("%s/MattConsumer-MattProvider.json", pactDir)),
-			// filepath.ToSlash(fmt.Sprintf("%s/matttcpconsumer-matttcpprovider.json", pactDir)),
+			filepath.ToSlash(fmt.Sprintf("%s/matttcpconsumer-matttcpprovider.json", pactDir)),
 		},
 		Transports: []provider.Transport{
 			provider.Transport{

--- a/examples/plugin/provider_plugin_test.go
+++ b/examples/plugin/provider_plugin_test.go
@@ -41,7 +41,7 @@ func TestPluginProvider(t *testing.T) {
 		// Provider:        "provider",
 		PactFiles: []string{
 			filepath.ToSlash(fmt.Sprintf("%s/MattConsumer-MattProvider.json", pactDir)),
-			filepath.ToSlash(fmt.Sprintf("%s/matttcpconsumer-matttcpprovider.json", pactDir)),
+			// filepath.ToSlash(fmt.Sprintf("%s/matttcpconsumer-matttcpprovider.json", pactDir)),
 		},
 		Transports: []provider.Transport{
 			provider.Transport{

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -381,7 +381,7 @@ const (
 var packages = map[string]packageInfo{
 	FFIPackage: {
 		libName:     "libpact_ffi",
-		version:     "0.4.5",
+		version:     "0.4.13",
 		semverRange: ">= 0.4.0, < 1.0.0",
 	},
 }


### PR DESCRIPTION
Fix for https://github.com/pact-foundation/pact-reference/issues/366

Plugin PR's raised here

- https://github.com/mefellows/pact-matt-plugin/pull/1
- https://github.com/mefellows/pact-matt-plugin/pull/2

Once above are merged, will want the plugin download location reverting back to the source [mefellows](https://github.com/mefellows/pact-matt-plugin) repo over my fork

Note also updates Pact FFI to 0.4.13 from 0.4.5.