### PR TITLE
ci: add workflow to update on pact-ffi-released events

### DIFF
--- a/.github/workflows/update-ffi.yml
+++ b/.github/workflows/update-ffi.yml
@@ -1,0 +1,21 @@
+name: Update Pact FFI Library
+
+on:
+  repository_dispatch:
+    types:
+      - pact-ffi-released
+
+jobs:
+  update:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+
+    - run: |
+        git config --global user.email "${GITHUB_ACTOR}@users.noreply.github.com"
+        git config --global user.name "${GITHUB_ACTOR}"
+        git config pull.ff only
+
+    - run: script/create-pr-to-update-pact-ffi.sh ${{ github.event.client_payload.version }}
+      env:
+        GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}'

--- a/scripts/create-pr-to-update-pact-ffi.sh
+++ b/scripts/create-pr-to-update-pact-ffi.sh
@@ -1,0 +1,27 @@
+#!/bin/sh
+
+set -e
+
+: "${1?Please supply the pact-ffi version to upgrade to}"
+
+FFI_VERSION=$1
+TYPE=${2:-fix}
+DASHERISED_VERSION=$(echo "${FFI_VERSION}" | sed 's/\./\-/g')
+BRANCH_NAME="chore/upgrade-to-pact-ffi-${DASHERISED_VERSION}"
+
+git checkout master
+git checkout installer/installer.go
+git pull origin master
+
+git checkout -b ${BRANCH_NAME}
+
+cat installer/installer.go | sed "s/version:.*/version:     \"${FFI_VERSION}\",/" > tmp-install
+mv tmp-install installer/installer.go
+
+git add installer/installer.go
+git commit -m "${TYPE}: update pact-ffi to ${FFI_VERSION}"
+git push --set-upstream origin ${BRANCH_NAME}
+
+gh pr create --title "${TYPE}: update pact-ffi to ${FFI_VERSION}" --fill
+
+git checkout master

--- a/scripts/dispatch-ffi-released.sh
+++ b/scripts/dispatch-ffi-released.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+# Script to trigger an update of the pact ffi from pact-foundation/pact-reference to listening repos
+# Requires a Github API token with repo scope stored in the
+# environment variable GITHUB_ACCESS_TOKEN_FOR_PF_RELEASES
+
+: "${GITHUB_ACCESS_TOKEN_FOR_PF_RELEASES:?Please set environment variable GITHUB_ACCESS_TOKEN_FOR_PF_RELEASES}"
+
+if [ -n "$1" ]; then
+  name="\"${1}\""
+else
+  echo "name not provided as first param"
+  exit 1
+fi
+
+if [ -n "$2" ]; then
+  version="\"${2}\""
+else
+  echo "name not provided as second param"
+  exit 1
+fi
+
+repository_slug=$(git remote get-url origin | cut -d':' -f2 | sed 's/\.git//')
+
+output=$(curl -v https://api.github.com/repos/${repository_slug}/dispatches \
+      -H 'Accept: application/vnd.github.everest-preview+json' \
+      -H "Authorization: Bearer $GITHUB_ACCESS_TOKEN_FOR_PF_RELEASES" \
+      -d "{\"event_type\": \"pact-ffi-released\", \"client_payload\": {\"name\": ${name}, \"version\" : ${version}}}" 2>&1)
+
+if  ! echo "${output}" | grep "HTTP\/.* 204" > /dev/null; then
+  echo "$output" | sed  "s/${GITHUB_ACCESS_TOKEN_FOR_PF_RELEASES}/********/g"
+  echo "Failed to trigger update"
+  exit 1
+else
+  echo "Update workflow triggered"
+fi
+
+echo "See https://github.com/${repository_slug}/actions?query=workflow%3A%22Update+Pact+FFI+Library%22"


### PR DESCRIPTION
Aim:- Provide a CI workflow, that can be triggered on release of the Pact FFI library.

Relates to https://github.com/pact-foundation/pact-reference/issues/375 , specifically `Trigger dependant client libraries workflows to raise PR's`

This change borrows from the existing update workflow on release of the pact-ruby-standalone.

- release trigger 
    - https://github.com/pact-foundation/pact-ruby-standalone/blob/3cecd6dce82922697f1ba2a3ccdabdaebdb54be9/.github/workflows/release.yml#L46-L63

## Places to change (outside this repo)

1. Release point in Pact-reference project 
    1.  https://github.com/pact-foundation/pact-reference/blob/fc33ad23e78698ecf1fb55eedb7dc228f96def17/.github/workflows/release.yml#L74-L81
1. Example Release
    1. https://github.com/pact-foundation/pact-reference/releases/tag/libpact_ffi-v0.4.14 
 
 ## Points to note
 
 Our ci workflow for verification `.github/workflows/test.yml` is not triggered by updates. See [related issue](https://github.com/peter-evans/create-pull-request/issues/48) and [workarounds](https://github.com/peter-evans/create-pull-request/blob/main/docs/concepts-guidelines.md#triggering-further-workflow-runs) 
 
 _Note:_ - the above issue is long-standing from the existing updates, at least from my quick scan of the test runs, I couldn't see triggered when the ruby core was updated, bar those triggered manually from the UI against the branch
 
 There are a couple of workarounds that are probably feasible. first one probably preferred at the moment as we get a visual cue somewhere outside of the actions/email notifications. The triggering repo (pact-reference) won't get a notification back regarding the failing status of a build in pact-js where it was triggered by a bot or a human
 
 - close PR and reopen from UI
 - have the update workflow that is initially triggered, run the tests as part of its workflow