### PR TITLE
Adding Missing Param in Consumer test docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ func TestUserAPIClient(t *testing.T) {
 		WithBodyMatch(&User{})
 
 	// Act: test our API client behaves correctly
-	err = mockProvider.ExecuteTest(func(config MockServerConfig) error {
+	err = mockProvider.ExecuteTest(t, func(config MockServerConfig) error {
 		// Initialise the API client and point it at the Pact mock server
 		// Pact spins up a dedicated mock server for each test
 		client := newClient(config.Host, config.Port)


### PR DESCRIPTION
Adding the missing first param on the V2HTTPMockProvider.ExecuteTest() call it should be t (*testing.T)