### PR TITLE
Fix/update pact ffi 0.4.21

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -14,9 +14,10 @@ jobs:
       fail-fast: false
       matrix:
         go-version: [
-                1.19.x,
-                1.20.x,
+                # 1.19.x, # Ended 06 Sep 2023
+                1.20.x, # Ended 06 Feb 2024
                 1.21.x,
+                1.22.x,
                 ]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ env:
 jobs:
   test:
     strategy:
+      fail-fast: false
       matrix:
         go-version: [ # https://endoflife.date/go
                     # 1.17.x, # Ended 02 Aug 2022

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,9 +19,10 @@ jobs:
         go-version: [ # https://endoflife.date/go
                     # 1.17.x, # Ended 02 Aug 2022
                     # 1.18.x, # Ended 01 Feb 2023
-                    1.19.x, 
-                    1.20.x,
-                    1.21.x
+                    # 1.19.x, # Ended 06 Sep 2023
+                    1.20.x, # Ended 06 Feb 2024
+                    1.21.x,
+                    1.22.x,
                     ]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -54,7 +54,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished
-      uses: coverallsapp/github-action@master
+      uses: coverallsapp/github-action@main
       with:
         github-token: ${{ secrets.GITHUB_TOKEN }}
         parallel-finished: true

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,10 @@ TEST?=./...
 .DEFAULT_GOAL := ci
 DOCKER_HOST_HTTP?="http://host.docker.internal"
 PACT_CLI="docker run --rm -v ${PWD}:${PWD} -e PACT_BROKER_BASE_URL=$(DOCKER_HOST_HTTP) -e PACT_BROKER_USERNAME -e PACT_BROKER_PASSWORD pactfoundation/pact-cli"
+PLUGIN_PACT_PROTOBUF_VERSION=0.3.15
+PLUGIN_PACT_CSV_VERSION=0.0.6
+PLUGIN_PACT_MATT_VERSION=0.1.1
+PLUGIN_PACT_AVRO_VERSION=0.0.5
 
 ci:: docker deps clean bin test pact
 
@@ -42,11 +46,35 @@ deps: download_plugins
 
 download_plugins:
 	@echo "--- 🐿  Installing plugins"; \
-	./scripts/install-cli.sh
-	~/.pact/bin/pact-plugin-cli -y install https://github.com/pactflow/pact-protobuf-plugin/releases/tag/v-0.3.13
-	~/.pact/bin/pact-plugin-cli -y install https://github.com/pact-foundation/pact-plugins/releases/tag/csv-plugin-0.0.1
-	~/.pact/bin/pact-plugin-cli -y install https://github.com/mefellows/pact-matt-plugin/releases/tag/v0.0.9
-	~/.pact/bin/pact-plugin-cli -y install https://github.com/austek/pact-avro-plugin/releases/tag/v0.0.3
+	if [ -z $$SKIP_PLUGINS ]; then\
+		if [ ! -f ~/.pact/bin/pact-plugin-cli ]; then \
+			./scripts/install-cli.sh; \
+		else \
+			echo "--- 🐿  Pact CLI already installed"; \
+		fi; \
+		if [ ! -f ~/.pact/plugins/protobuf-$(PLUGIN_PACT_PROTOBUF_VERSION)/pact-protobuf-plugin ]; then \
+			~/.pact/bin/pact-plugin-cli -y install https://github.com/pactflow/pact-protobuf-plugin/releases/tag/v-$(PLUGIN_PACT_PROTOBUF_VERSION); \
+		else \
+			echo "--- 🐿  Pact protobuf-$(PLUGIN_PACT_PROTOBUF_VERSION) already installed"; \
+		fi; \
+		if [ ! -f ~/.pact/plugins/csv-$(PLUGIN_PACT_CSV_VERSION)/pact-csv-plugin ]; then \
+			~/.pact/bin/pact-plugin-cli -y install https://github.com/pact-foundation/pact-plugins/releases/tag/csv-plugin-$(PLUGIN_PACT_CSV_VERSION); \
+		else \
+			echo "--- 🐿  Pact csv-$(PLUGIN_PACT_CSV_VERSION) already installed"; \
+		fi; \
+		if [ ! -f ~/.pact/plugins/matt-$(PLUGIN_PACT_MATT_VERSION)/matt ]; then \
+			~/.pact/bin/pact-plugin-cli -y install https://github.com/mefellows/pact-matt-plugin/releases/tag/v$(PLUGIN_PACT_MATT_VERSION); \
+		else \
+			echo "--- 🐿  Pact matt-$(PLUGIN_PACT_MATT_VERSION) already installed"; \
+		fi; \
+		if [ -z $$SKIP_PLUGIN_AVRO ]; then\
+			if [ ! -f ~/.pact/plugins/avro-$(PLUGIN_PACT_AVRO_VERSION)/bin/pact-avro-plugin ]; then \
+				~/.pact/bin/pact-plugin-cli -y install https://github.com/austek/pact-avro-plugin/releases/tag/v$(PLUGIN_PACT_AVRO_VERSION); \
+			else \
+				echo "--- 🐿  Pact avro-$(PLUGIN_PACT_AVRO_VERSION) already installed"; \
+			fi; \
+		fi; \
+	fi
 
 cli:
 	@if [ ! -d pact/bin ]; then\
@@ -56,7 +84,7 @@ cli:
 
 install: bin
 	echo "--- 🐿 Installing Pact FFI dependencies"
-	./build/pact-go	 -l DEBUG install --libDir /tmp
+	./build/pact-go -l DEBUG install --libDir /tmp
 
 pact: clean install docker
 	@echo "--- 🔨 Running Pact examples"

--- a/consumer/http_v4_test.go
+++ b/consumer/http_v4_test.go
@@ -58,7 +58,7 @@ func TestHttpV4TypeSystem(t *testing.T) {
 		UponReceiving("some scenario").
 		UsingPlugin(PluginConfig{
 			Plugin:  "protobuf",
-			Version: "0.3.13",
+			Version: "0.3.15",
 		}).
 		WithRequest("GET", "/").
 		// WithRequest("GET", "/", func(b *V4InteractionWithPluginRequestBuilder) {

--- a/examples/avro/avro_consumer_test.go
+++ b/examples/avro/avro_consumer_test.go
@@ -45,7 +45,7 @@ func TestAvroHTTP(t *testing.T) {
 		UponReceiving("A request to do get some Avro stuff").
 		UsingPlugin(consumer.PluginConfig{
 			Plugin:  "avro",
-			Version: "0.0.3",
+			Version: "0.0.5",
 		}).
 		WithRequest("GET", "/avro").
 		WillRespondWith(200, func(res *consumer.V4InteractionWithPluginResponseBuilder) {

--- a/examples/grpc/grpc_consumer_test.go
+++ b/examples/grpc/grpc_consumer_test.go
@@ -52,7 +52,7 @@ func TestGetFeatureSuccess(t *testing.T) {
 		Given("feature 'Big Tree' exists").
 		UsingPlugin(message.PluginConfig{
 			Plugin:  "protobuf",
-			Version: "0.3.13",
+			Version: "0.3.15",
 		}).
 		WithContents(grpcInteraction, "application/protobuf").
 		StartTransport("grpc", "127.0.0.1", nil). // For plugin tests, we can't assume if a transport is needed, so this is optional
@@ -122,7 +122,7 @@ func TestGetFeatureError(t *testing.T) {
 		Given("feature does not exist at -1, -1").
 		UsingPlugin(message.PluginConfig{
 			Plugin:  "protobuf",
-			Version: "0.3.13",
+			Version: "0.3.15",
 		}).
 		WithContents(grpcInteraction, "application/protobuf").
 		StartTransport("grpc", "127.0.0.1", nil). // For plugin tests, we can't assume if a transport is needed, so this is optional
@@ -193,7 +193,7 @@ func TestSaveFeature(t *testing.T) {
 		Given("feature does not exist at -1, -1").
 		UsingPlugin(message.PluginConfig{
 			Plugin:  "protobuf",
-			Version: "0.3.13",
+			Version: "0.3.15",
 		}).
 		WithContents(grpcInteraction, "application/protobuf").
 		StartTransport("grpc", "127.0.0.1", nil). // For plugin tests, we can't assume if a transport is needed, so this is optional

--- a/examples/plugin/consumer_plugin_test.go
+++ b/examples/plugin/consumer_plugin_test.go
@@ -42,7 +42,7 @@ func TestHTTPPlugin(t *testing.T) {
 		UponReceiving("A request to do a matt").
 		UsingPlugin(consumer.PluginConfig{
 			Plugin:  "matt",
-			Version: "0.0.9",
+			Version: "0.1.1",
 		}).
 		WithRequest("POST", "/matt", func(req *consumer.V4InteractionWithPluginRequestBuilder) {
 			req.PluginContents("application/matt", mattRequest)
@@ -74,7 +74,7 @@ func TestTCPPlugin(t *testing.T) {
 		Given("the world exists").
 		UsingPlugin(message.PluginConfig{
 			Plugin:  "matt",
-			Version: "0.0.9",
+			Version: "0.1.1",
 		}).
 		WithContents(mattMessage, "application/matt").
 		StartTransport("matt", "127.0.0.1", nil). // For plugin tests, we can't assume if a transport is needed, so this is optional

--- a/examples/protobuf-message/protobuf_consumer_test.go
+++ b/examples/protobuf-message/protobuf_consumer_test.go
@@ -42,7 +42,7 @@ func TestPluginMessageConsumer(t *testing.T) {
 		ExpectsToReceive("feature message").
 		UsingPlugin(message.PluginConfig{
 			Plugin:  "protobuf",
-			Version: "0.3.13",
+			Version: "0.3.15",
 		}).
 		WithContents(protoMessage, "application/protobuf").
 		ExecuteTest(t, func(m message.AsynchronousMessage) error {

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -392,7 +392,7 @@ const (
 var packages = map[string]packageInfo{
 	FFIPackage: {
 		libName:     "libpact_ffi",
-		version:     "0.4.20",
+		version:     "0.4.21",
 		semverRange: ">= 0.4.0, < 1.0.0",
 	},
 }

--- a/internal/native/message_server_test.go
+++ b/internal/native/message_server_test.go
@@ -211,7 +211,7 @@ func TestGetPluginSyncMessageContentsAsBytes(t *testing.T) {
 	m := NewMessageServer("test-message-consumer", "test-message-provider")
 
 	// Protobuf plugin test
-	err := m.UsingPlugin("protobuf", "0.3.13")
+	err := m.UsingPlugin("protobuf", "0.3.15")
 	assert.NoError(t, err)
 
 	i := m.NewSyncMessageInteraction("grpc interaction")
@@ -268,7 +268,7 @@ func TestGetPluginSyncMessageContentsAsBytes_EmptyResponse(t *testing.T) {
 	m := NewMessageServer("test-message-consumer", "test-message-provider")
 
 	// Protobuf plugin test
-	err := m.UsingPlugin("protobuf", "0.3.13")
+	err := m.UsingPlugin("protobuf", "0.3.15")
 	assert.NoError(t, err)
 
 	i := m.NewSyncMessageInteraction("grpc interaction")
@@ -314,7 +314,7 @@ func TestGetPluginAsyncMessageContentsAsBytes(t *testing.T) {
 	m := NewMessageServer("test-message-consumer", "test-message-provider")
 
 	// Protobuf plugin test
-	_ = m.UsingPlugin("protobuf", "0.3.13")
+	_ = m.UsingPlugin("protobuf", "0.3.15")
 
 	i := m.NewAsyncMessageInteraction("grpc interaction")
 
@@ -354,7 +354,7 @@ func TestGrpcPluginInteraction(t *testing.T) {
 	m := NewMessageServer("test-message-consumer", "test-message-provider")
 
 	// Protobuf plugin test
-	_ = m.UsingPlugin("protobuf", "0.3.13")
+	_ = m.UsingPlugin("protobuf", "0.3.15")
 
 	i := m.NewSyncMessageInteraction("grpc interaction")
 
@@ -431,7 +431,7 @@ func TestGrpcPluginInteraction_ErrorResponse(t *testing.T) {
 	m := NewMessageServer("test-message-consumer", "test-message-provider")
 
 	// Protobuf plugin test
-	_ = m.UsingPlugin("protobuf", "0.3.13")
+	_ = m.UsingPlugin("protobuf", "0.3.15")
 
 	i := m.NewSyncMessageInteraction("grpc interaction")
 

--- a/internal/native/mock_server_test.go
+++ b/internal/native/mock_server_test.go
@@ -172,7 +172,7 @@ func TestPluginInteraction(t *testing.T) {
 	m := NewHTTPPact("test-plugin-consumer", "test-plugin-provider")
 
 	// Protobuf plugin test
-	_ = m.UsingPlugin("protobuf", "0.0.3")
+	_ = m.UsingPlugin("protobuf", "0.3.15")
 	m.WithSpecificationVersion(SPECIFICATION_VERSION_V4)
 
 	i := m.NewInteraction("some plugin interaction")

--- a/message/v4/asynchronous_message_test.go
+++ b/message/v4/asynchronous_message_test.go
@@ -64,7 +64,7 @@ func TestAsyncTypeSystem(t *testing.T) {
 		ExpectsToReceive("some csv content").
 		UsingPlugin(PluginConfig{
 			Plugin:  "csv",
-			Version: "0.0.3",
+			Version: "0.0.6",
 		}).
 		WithContents(csvInteraction, "text/csv").
 		// StartTransport("notarealtransport", "127.0.0.1", nil).

--- a/message/v4/synchronous_message_test.go
+++ b/message/v4/synchronous_message_test.go
@@ -105,7 +105,7 @@ func TestSyncTypeSystem(t *testing.T) {
 		Given("some state").
 		UsingPlugin(PluginConfig{
 			Plugin:  "protobuf",
-			Version: "0.3.13",
+			Version: "0.3.15",
 		}).
 		WithContents(grpcInteraction, "application/protobuf").
 		StartTransport("grpc", "127.0.0.1", nil). // For plugin tests, we can't assume if a transport is needed, so this is optional
@@ -128,7 +128,7 @@ func TestSyncTypeSystem(t *testing.T) {
 		Given("some state").
 		UsingPlugin(PluginConfig{
 			Plugin:  "protobuf",
-			Version: "0.3.13",
+			Version: "0.3.15",
 		}).
 		WithContents(grpcInteraction, "application/protobuf").
 		StartTransport("grpc", "127.0.0.1", nil). // For plugin tests, we can't assume if a transport is needed, so this is optional

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -13,6 +13,10 @@ function detect_osarch() {
             os='linux'
             arch='x86_64'
             ;;
+        'Linux aarch64')
+            os='linux'
+            arch='aarch64'
+            ;;
         'Darwin x86' | 'Darwin x86_64')
             os='osx'
             arch='x86_64'
@@ -44,6 +48,7 @@ if [ ! -f ~/.pact/bin/pact-plugin-cli ]; then
     echo "        Downloading from: ${DOWNLOAD_LOCATION}"
     curl -L -o ~/.pact/bin/pact-plugin-cli-${os}-${arch}.gz "${DOWNLOAD_LOCATION}"
     echo "        Downloaded $(file ~/.pact/bin/pact-plugin-cli-${os}-${arch}.gz)"
-    gunzip -N -f ~/.pact/bin/pact-plugin-cli-${os}-${arch}.gz
+    gunzip -f ~/.pact/bin/pact-plugin-cli-${os}-${arch}.gz
+    mv ~/.pact/bin/pact-plugin-cli-${os}-${arch} ~/.pact/bin/pact-plugin-cli
     chmod +x ~/.pact/bin/pact-plugin-cli
 fi

--- a/scripts/install-cli.sh
+++ b/scripts/install-cli.sh
@@ -38,7 +38,7 @@ function detect_osarch() {
 }
 
 
-VERSION="0.1.0"
+VERSION="0.1.2"
 detect_osarch
 
 if [ ! -f ~/.pact/bin/pact-plugin-cli ]; then


### PR DESCRIPTION
- updates libpact_ffi to 0.4.21
- updates all plugin deps to latest versions
- update ci action deps to avoid deprecation warnings
- test on latest supported golang version (1.22.x)

note: fail fast due to sporadic seg faults