### PR TITLE
fix: rename macos binaries due to naming change in v0.4.21 libpact_ffi

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,18 +102,18 @@ You can also keep the library versions up to date by running the `version.CheckV
 
 ### Manual
 
-Downlod the latest `Pact FFI Library` [library] for your OS, and install onto a standard library search path (we suggest: `/usr/local/lib` on OSX/Linux):
+Downlod the latest `Pact FFI Library` [library] for your OS, and install onto a standard library search path (we suggest: `/usr/local/lib` on MacOS/Linux):
 
 Ensure you have the correct extension for your OS:
 
-- For Mac OSX: `.dylib` (For M1 users, you need the `aarch64-apple-darwin` version)
+- For Mac OS: `.dylib` (For M1 users, you need the `aarch64` version) - ( Called `aarch64-apple-darwin` in version prior to v0.4.21 )
 - For Linux: `.so`
 - For Windows: `.dll`
 
 ```sh
-wget https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v0.1.2/libpact_ffi-osx-x86_64.dylib.gz
-gunzip libpact_ffi-osx-x86_64.dylib.gz
-mv libpact_ffi-osx-x86_64.dylib /usr/local/lib/libpact_ffi.dylib
+wget https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v0.4.21/libpact_ffi-macos-x86_64.dylib.gz
+gunzip libpact_ffi-macos-x86_64.dylib.gz
+mv libpact_ffi-macos-x86_64.dylib /usr/local/lib/libpact_ffi.dylib
 ```
 
 Test the installation:

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -74,11 +74,7 @@ func NewInstaller(opts ...installerConfig) (*Installer, error) {
 	case "amd64":
 		i.arch = x86_64
 	case "arm64":
-		if runtime.GOOS == "darwin" {
-			i.arch = osx_aarch64
-		} else {
-			i.arch = aarch64
-		}
+		i.arch = aarch64
 	default:
 		i.arch = x86_64
 		log.Println("[WARN] amd64 architecture not detected, defaulting to x86_64. Behaviour may be undefined")
@@ -236,9 +232,9 @@ func (i *Installer) downloadDependencies() error {
 }
 
 func (i *Installer) installDependencies() error {
-	if i.os == osx {
+	if i.os == macos {
 		for pkg, info := range packages {
-			log.Println("[INFO] setting install_name on library", info.libName, "for osx")
+			log.Println("[INFO] setting install_name on library", info.libName, "for macos")
 
 			dst, err := i.getLibDstForPackage(pkg)
 
@@ -246,7 +242,7 @@ func (i *Installer) installDependencies() error {
 				return err
 			}
 
-			err = setOSXInstallName(dst)
+			err = setMacOSInstallName(dst)
 
 			if err != nil {
 				return err
@@ -299,7 +295,7 @@ func (i *Installer) updateConfiguration(dst string, pkg string, info packageInfo
 	return i.config.writeConfig(c)
 }
 
-var setOSXInstallName = func(file string) error {
+var setMacOSInstallName = func(file string) error {
 	cmd := exec.Command("install_name_tool", "-id", file, file)
 	log.Println("[DEBUG] running command:", cmd)
 	stdoutStderr, err := cmd.CombinedOutput()
@@ -355,7 +351,7 @@ func (i *Installer) checkMusl() error {
 var downloadTemplate = "https://github.com/pact-foundation/pact-reference/releases/download/%s-v%s/%s-%s-%s.%s.gz"
 
 var supportedOSes = map[string]string{
-	"darwin": osx,
+	"darwin": macos,
 	windows:  windows,
 	linux:    linux,
 }
@@ -363,13 +359,13 @@ var supportedOSes = map[string]string{
 var osToExtension = map[string]string{
 	windows: "dll",
 	linux:   "so",
-	osx:     "dylib",
+	macos:   "dylib",
 }
 
 var osToLibName = map[string]string{
 	windows: "pact_ffi",
 	linux:   "libpact_ffi",
-	osx:     "libpact_ffi",
+	macos:   "libpact_ffi",
 }
 
 type packageInfo struct {
@@ -383,9 +379,8 @@ const (
 	downloadEnvVar = "PACT_GO_LIB_DOWNLOAD_PATH"
 	linux          = "linux"
 	windows        = "windows"
-	osx            = "osx"
+	macos          = "macos"
 	x86_64         = "x86_64"
-	osx_aarch64    = "aarch64-apple-darwin"
 	aarch64        = "aarch64"
 )
 

--- a/installer/installer_test.go
+++ b/installer/installer_test.go
@@ -44,21 +44,21 @@ func TestInstallerDownloader(t *testing.T) {
 				},
 			},
 			{
-				name: "ffi lib - osx x86",
+				name: "ffi lib - macos x86",
 				pkg:  FFIPackage,
-				want: fmt.Sprintf("https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v%s/libpact_ffi-osx-x86_64.dylib.gz", packages[FFIPackage].version),
+				want: fmt.Sprintf("https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v%s/libpact_ffi-macos-x86_64.dylib.gz", packages[FFIPackage].version),
 				test: Installer{
-					os:   osx,
+					os:   macos,
 					arch: x86_64,
 				},
 			},
 			{
-				name: "ffi lib - osx arm64",
+				name: "ffi lib - macos arm64",
 				pkg:  FFIPackage,
-				want: fmt.Sprintf("https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v%s/libpact_ffi-osx-aarch64-apple-darwin.dylib.gz", packages[FFIPackage].version),
+				want: fmt.Sprintf("https://github.com/pact-foundation/pact-reference/releases/download/libpact_ffi-v%s/libpact_ffi-macos-aarch64.dylib.gz", packages[FFIPackage].version),
 				test: Installer{
-					os:   osx,
-					arch: osx_aarch64,
+					os:   macos,
+					arch: aarch64,
 				},
 			},
 			{
@@ -127,7 +127,7 @@ func TestInstallerCheckInstallation(t *testing.T) {
 			downloader: &mockDownloader{},
 			hasher:     &mockHasher{},
 			config:     &mockConfiguration{},
-			os:         "osx",
+			os:         "macos",
 		}
 		err := i.CheckInstallation()
 
@@ -141,7 +141,7 @@ func TestInstallerCheckInstallation(t *testing.T) {
 			downloader: &mockDownloader{},
 			hasher:     &mockHasher{},
 			config:     &mockConfiguration{},
-			os:         "osx",
+			os:         "macos",
 		}
 
 		for pkg := range packages {
@@ -157,7 +157,7 @@ func TestInstallerCheckInstallation(t *testing.T) {
 
 func TestInstallerCheckPackageInstall(t *testing.T) {
 	t.Run("downloads and install dependencies when existing libraries aren't present", func(t *testing.T) {
-		defer restoreOSXInstallName()()
+		defer restoreMacOSInstallName()()
 		mockFs := afero.NewMemMapFs()
 
 		var i *Installer
@@ -174,7 +174,7 @@ func TestInstallerCheckPackageInstall(t *testing.T) {
 			},
 			hasher: &mockHasher{},
 			config: &mockConfiguration{},
-			os:     "osx",
+			os:     "macos",
 		}
 
 		err := i.CheckInstallation()
@@ -220,14 +220,14 @@ func (m *mockConfiguration) writeConfig(pactConfig) error {
 	return nil
 }
 
-func restoreOSXInstallName() func() {
-	old := setOSXInstallName
-	setOSXInstallName = func(string) error {
+func restoreMacOSInstallName() func() {
+	old := setMacOSInstallName
+	setMacOSInstallName = func(string) error {
 		return nil
 	}
 
 	return func() {
-		setOSXInstallName = old
+		setMacOSInstallName = old
 	}
 }
 


### PR DESCRIPTION
See release notes

https://github.com/pact-foundation/pact-reference/releases/tag/libpact_ffi-v0.4.21