### PR TITLE
chore(ci): test Docker images in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -50,8 +50,21 @@ jobs:
           path: ~/.pact/plugins/**/plugin.log
         if: ${{ always() }}
 
+  test-containers:
+    runs-on: ubuntu-latest
+    name: ${{ matrix.go-version }}-test-container
+    strategy:
+      fail-fast: false
+      matrix:
+        go-version: ["1.20", "1.21", "1.22"]
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Test dockerfile 
+        run: make docker_test_all
+
   finish:
-    needs: test
+    needs: [test,test-containers]
     runs-on: ubuntu-latest
     steps:
     - name: Coveralls Finished

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,9 @@
-FROM golang:1.22.5
+ARG VERSION=latest
+FROM golang:${VERSION}
 
-# Install pact ruby standalone binaries
-RUN curl -LO https://github.com/pact-foundation/pact-ruby-standalone/releases/download/v2.0.3/pact-2.0.3-linux-x86_64.tar.gz; \
-    tar -C /usr/local -xzf pact-2.0.3-linux-x86_64.tar.gz; \
-    rm pact-2.0.3-linux-x86_64.tar.gz
-
-ENV PATH /usr/local/pact/bin:$PATH
-
+RUN apt-get update && apt-get install -y openjdk-17-jre file protobuf-compiler
 COPY . /go/src/github.com/pact-foundation/pact-go
 
 WORKDIR /go/src/github.com/pact-foundation/pact-go
+
+CMD ["make", "test"]

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,7 @@ PLUGIN_PACT_CSV_VERSION=0.0.6
 PLUGIN_PACT_MATT_VERSION=0.1.1
 PLUGIN_PACT_AVRO_VERSION=0.0.5
 
+GO_VERSION?=1.22
 ci:: docker deps clean bin test pact
 
 # Run the ci target from a developer machine with the environment variables
@@ -30,6 +31,27 @@ fake_pact:
 docker:
 	@echo "--- 🛠 Starting docker"
 	docker-compose up -d
+
+docker_build:
+	docker build -f Dockerfile --build-arg GO_VERSION=${GO_VERSION} -t pactfoundation/pact-go-test .
+docker_test: docker_build
+	docker run \
+		-e LOG_LEVEL=INFO \
+		--rm \
+		pactfoundation/pact-go-test \
+		/bin/sh -c "make test"
+docker_pact: docker_build
+	docker run \
+		-e LOG_LEVEL=INFO \
+		--rm \
+		pactfoundation/pact-go-test \
+		/bin/sh -c "make pact_local"
+docker_test_all: docker_build
+	docker run \
+		-e LOG_LEVEL=INFO \
+		--rm \
+		pactfoundation/pact-go-test \
+		/bin/sh -c "make test && make pact_local"
 
 bin:
 	go build -o build/pact-go

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-version: "3"
-
 services:
   httpbin:
-    image: kennethreitz/httpbin
+    image: kong/httpbin # https://github.com/Kong/httpbin
     ports:
       - "8000:80"
 
@@ -18,7 +16,7 @@ services:
       POSTGRES_DB: postgres
 
   broker_app:
-    image: pactfoundation/pact-broker:latest-multi
+    image: pactfoundation/pact-broker:latest
     links:
       - postgres
     ports:


### PR DESCRIPTION
## Maintainer Conveniences

- Updates Dockerfile
  - Dockerfile was relevant for pact-go v1, now updated and tested as part of CI
- Inability to use Docker in MacOS / Windows, means to run Pact Broker based tests, we need to use a hosted broker. This poses challenges for external contributors and the sharing of secrets, as using shared credentials in plain-text although convenient for our demo env, isn't best practise for actual end user use.
  - Provide a `make pact_local` command that skips publishing of pacts, and via setting `SKIP_PUBLISH` controls the provider verification test to either run a local or pact broker based verification. The publish code path is still covered by the linux runner. (there is probably a more elegant way of conditionally setting the values rather than a large if / else block