### PR TITLE
fix: plugin verification panics due to missing SA_ONSTACK signal

### DIFF
--- a/internal/native/message_server.go
+++ b/internal/native/message_server.go
@@ -329,7 +329,8 @@ func (m *MessageServer) UsingPlugin(pluginName string, pluginVersion string) err
 	defer free(cPluginName)
 	cPluginVersion := C.CString(pluginVersion)
 	defer free(cPluginVersion)
-
+	
+	InstallSignalHandlers()
 	r := C.pactffi_using_plugin(m.messagePact.handle, cPluginName, cPluginVersion)
 
 	// 1 - A general panic was caught.

--- a/internal/native/mock_server.go
+++ b/internal/native/mock_server.go
@@ -555,6 +555,7 @@ func (m *MockServer) UsingPlugin(pluginName string, pluginVersion string) error 
 	cPluginVersion := C.CString(pluginVersion)
 	defer free(cPluginVersion)
 
+	InstallSignalHandlers()
 	r := C.pactffi_using_plugin(m.pact.handle, cPluginName, cPluginVersion)
 
 	// 1 - A general panic was caught.

--- a/internal/native/signal.go
+++ b/internal/native/signal.go
@@ -1,0 +1,87 @@
+//go:build cgo
+// +build cgo
+
+package native
+
+/*
+#if defined(__APPLE__) || defined(__linux__)
+// https://github.com/wailsapp/wails/pull/2152/files#diff-d4a0fa73df7b0ab971e550f95249e358b634836e925ace96f7400480916ac09e
+#include <errno.h>
+#include <signal.h>
+#include <stdio.h>
+#include <string.h>
+
+static void fix_signal(int signum)
+{
+    struct sigaction st;
+
+    if (sigaction(signum, NULL, &st) < 0) {
+        goto fix_signal_error;
+    }
+    st.sa_flags |= SA_ONSTACK;
+    if (sigaction(signum, &st,  NULL) < 0) {
+        goto fix_signal_error;
+    }
+    return;
+fix_signal_error:
+        fprintf(stderr, "error fixing handler for signal %d, please "
+                "report this issue to "
+                "https://github.com/pact-foundation/pact-go: %s\n",
+                signum, strerror(errno));
+}
+
+static void install_signal_handlers()
+{
+#if defined(SIGCHLD)
+    fix_signal(SIGCHLD);
+#endif
+#if defined(SIGHUP)
+    fix_signal(SIGHUP);
+#endif
+#if defined(SIGINT)
+    fix_signal(SIGINT);
+#endif
+#if defined(SIGQUIT)
+    fix_signal(SIGQUIT);
+#endif
+#if defined(SIGABRT)
+    fix_signal(SIGABRT);
+#endif
+#if defined(SIGFPE)
+    fix_signal(SIGFPE);
+#endif
+#if defined(SIGTERM)
+    fix_signal(SIGTERM);
+#endif
+#if defined(SIGBUS)
+    fix_signal(SIGBUS);
+#endif
+#if defined(SIGSEGV)
+    fix_signal(SIGSEGV);
+#endif
+#if defined(SIGXCPU)
+    fix_signal(SIGXCPU);
+#endif
+#if defined(SIGXFSZ)
+    fix_signal(SIGXFSZ);
+#endif
+}
+#else
+	static void install_signal_handlers()
+	{
+	}
+#endif
+*/
+import "C"
+import (
+	"os"
+	"runtime"
+)
+
+func InstallSignalHandlers() {
+	if os.Getenv("PACT_GO_INSTALL_SIGNAL_HANDLERS") != "0" {
+		if runtime.GOOS != "windows" {
+			C.install_signal_handlers()
+		}
+	}
+}

--- a/internal/native/verifier.go
+++ b/internal/native/verifier.go
@@ -226,7 +226,7 @@ func (v *Verifier) SetPublishOptions(providerVersion string, buildUrl string, pr
 
 func (v *Verifier) Execute() error {
 	// TODO: Validate
-
+	InstallSignalHandlers()
 	result := C.pactffi_verifier_execute(v.handle)
 
 	/// | Error | Description |


### PR DESCRIPTION
fixes #269 

yak shave and a half, bit of a write up and repro in the pact reference repo

https://github.com/pact-foundation/pact-reference/compare/master...YOU54F:pact-reference:issue/go_signals

tried building the ffi and csv plugin with musl 1.25, as 1.24 has a fix in it, similar to that referenced by Jason in the original issue for glibc.

 that didnt seem to solve the issue for me

we cant move to that new a version of glibc as we need to be compatible with older distroes, and i haven’t tested that out to see if it works.

some links from the yak shave

cgo onstack failures 

- https://github.com/wailsapp/wails/pull/2152/files#diff-d4a0fa73df7b0ab971e550f95249e358b634836e925ace96f7400480916ac09e
- https://github.com/golang/go/issues/51787
- https://www.openwall.com/lists/musl/2020/08/09/1
- https://www.openwall.com/lists/musl/2019/03/05/2
- https://github.com/cross-rs/cross/tree/v0.2.5
- https://github.com/golang/go/issues/39857
- https://github.com/golang/go/issues/18243
- https://github.com/golang/go/issues/19938
- https://groups.google.com/g/golang-nuts/c/lkpXBefIF1U


FYI https://git.musl-libc.org/cgit/musl/commit/?id=2e5fff43dd7fc808197744c67cca7908ac19bb4f switched musl to using the alt stack for internal signals and will be present in future releases starting with 1.2.4.

- https://github.com/rust-lang/rust/blob/cb93f92b84d34f4e84748848690359a54ed14df7/src/ci/docker/scripts/musl-toolchain.sh
- https://github.com/rust-lang/compiler-team/issues/572
- https://github.com/cross-rs/cross/pull/1346

note to self - if we can get this fix applied to purego project as well that would be ace, if not maybe adding the function into the pact_ffi lib so it could be called whether we are using cgo or not 🤔 