### PR TITLE
fix: install signal handlers should occur after plugins started

### DIFF
--- a/internal/native/message_server.go
+++ b/internal/native/message_server.go
@@ -330,8 +330,8 @@ func (m *MessageServer) UsingPlugin(pluginName string, pluginVersion string) err
 	cPluginVersion := C.CString(pluginVersion)
 	defer free(cPluginVersion)
 	
-	InstallSignalHandlers()
 	r := C.pactffi_using_plugin(m.messagePact.handle, cPluginName, cPluginVersion)
+	InstallSignalHandlers()
 
 	// 1 - A general panic was caught.
 	// 2 - Failed to load the plugin.

--- a/internal/native/mock_server.go
+++ b/internal/native/mock_server.go
@@ -555,8 +555,8 @@ func (m *MockServer) UsingPlugin(pluginName string, pluginVersion string) error 
 	cPluginVersion := C.CString(pluginVersion)
 	defer free(cPluginVersion)
 
-	InstallSignalHandlers()
 	r := C.pactffi_using_plugin(m.pact.handle, cPluginName, cPluginVersion)
+	InstallSignalHandlers()
 
 	// 1 - A general panic was caught.
 	// 2 - Failed to load the plugin.


### PR DESCRIPTION
After splitting out a large PR of changes to apply #432 - I noted that I had previously applied the installed signal handlers, after the ffi framework has started the plugins.

Due to this, we are still encountering the issues in the project. Here is one on the mock server side

```
2024-07-03T20:13:07.907144Z DEBUG ThreadId(01) pact_models::pact: Writing new pact file to "/home/runner/work/pact-go/pact-go/examples/protobuf-message/../pacts/protobufmessageconsumer-protobufmessageprovider.json"
signal 17 received but handler not on signal stack
mp.gsignal stack [0xc000008000 0xc000010000], mp.g0 stack [0x7ffc7df38600 0x7ffc7ef37610], sp=0xc0000db398
fatal error: non-Go code set up signal handler without SA_ONSTACK flag
```

I actually wonder if on the verifier side, we will catch it in the pactffi_verifier_execute function, or if we need to actually install the signal handlers after this is called, discovering any required plugins from the pact sources, starting them. Then install the signal handlers, all before the pactffi_verifier_execute function returns.

I am going to test out a hypothesis in the pact-plugin-driver, but for now this appears to be pretty resiliant with multiple runs.

I'll be adding an additional PR with 

- Dockerfile
- MacOS

and following on from that Windows support, however that is blocked as I have an issue with plugins failed to shutdown cleanly