### PR TITLE
fix: zombie plugin processes

### DIFF
--- a/consumer/http.go
+++ b/consumer/http.go
@@ -178,6 +178,7 @@ func (p *httpMockProvider) ExecuteTest(t *testing.T, integrationTest func(MockSe
 // Clear state between tests
 func (p *httpMockProvider) reset() {
 	p.mockserver.CleanupMockServer(p.config.Port)
+	p.mockserver.CleanupPlugins()
 	p.config.Port = 0
 	err := p.configure()
 	if err != nil {

--- a/internal/native/message_server.go
+++ b/internal/native/message_server.go
@@ -330,8 +330,8 @@ func (m *MessageServer) UsingPlugin(pluginName string, pluginVersion string) err
 	cPluginVersion := C.CString(pluginVersion)
 	defer free(cPluginVersion)
 	
-	InstallSignalHandlers()
 	r := C.pactffi_using_plugin(m.messagePact.handle, cPluginName, cPluginVersion)
+	InstallSignalHandlers()
 
 	// 1 - A general panic was caught.
 	// 2 - Failed to load the plugin.

--- a/internal/native/message_server_test.go
+++ b/internal/native/message_server_test.go
@@ -211,6 +211,7 @@ func TestGetPluginSyncMessageContentsAsBytes(t *testing.T) {
 	m := NewMessageServer("test-message-consumer", "test-message-provider")
 
 	// Protobuf plugin test
+	defer m.CleanupPlugins()
 	err := m.UsingPlugin("protobuf", "0.3.15")
 	assert.NoError(t, err)
 
@@ -268,6 +269,7 @@ func TestGetPluginSyncMessageContentsAsBytes_EmptyResponse(t *testing.T) {
 	m := NewMessageServer("test-message-consumer", "test-message-provider")
 
 	// Protobuf plugin test
+	defer m.CleanupPlugins()
 	err := m.UsingPlugin("protobuf", "0.3.15")
 	assert.NoError(t, err)
 
@@ -314,6 +316,7 @@ func TestGetPluginAsyncMessageContentsAsBytes(t *testing.T) {
 	m := NewMessageServer("test-message-consumer", "test-message-provider")
 
 	// Protobuf plugin test
+	defer m.CleanupPlugins()
 	_ = m.UsingPlugin("protobuf", "0.3.15")
 
 	i := m.NewAsyncMessageInteraction("grpc interaction")
@@ -354,6 +357,7 @@ func TestGrpcPluginInteraction(t *testing.T) {
 	m := NewMessageServer("test-message-consumer", "test-message-provider")
 
 	// Protobuf plugin test
+	defer m.CleanupPlugins()
 	_ = m.UsingPlugin("protobuf", "0.3.15")
 
 	i := m.NewSyncMessageInteraction("grpc interaction")
@@ -431,6 +435,7 @@ func TestGrpcPluginInteraction_ErrorResponse(t *testing.T) {
 	m := NewMessageServer("test-message-consumer", "test-message-provider")
 
 	// Protobuf plugin test
+	defer m.CleanupPlugins()
 	_ = m.UsingPlugin("protobuf", "0.3.15")
 
 	i := m.NewSyncMessageInteraction("grpc interaction")

--- a/internal/native/mock_server.go
+++ b/internal/native/mock_server.go
@@ -555,8 +555,8 @@ func (m *MockServer) UsingPlugin(pluginName string, pluginVersion string) error 
 	cPluginVersion := C.CString(pluginVersion)
 	defer free(cPluginVersion)
 
-	InstallSignalHandlers()
 	r := C.pactffi_using_plugin(m.pact.handle, cPluginName, cPluginVersion)
+	InstallSignalHandlers()
 
 	// 1 - A general panic was caught.
 	// 2 - Failed to load the plugin.

--- a/internal/native/mock_server_test.go
+++ b/internal/native/mock_server_test.go
@@ -172,6 +172,7 @@ func TestPluginInteraction(t *testing.T) {
 	m := NewHTTPPact("test-plugin-consumer", "test-plugin-provider")
 
 	// Protobuf plugin test
+	defer m.CleanupPlugins()
 	_ = m.UsingPlugin("protobuf", "0.3.15")
 	m.WithSpecificationVersion(SPECIFICATION_VERSION_V4)
 

--- a/message/v4/asynchronous_message.go
+++ b/message/v4/asynchronous_message.go
@@ -94,6 +94,7 @@ type AsynchronousMessageWithPluginContents struct {
 }
 
 func (s *AsynchronousMessageWithPluginContents) ExecuteTest(t *testing.T, integrationTest func(m AsynchronousMessage) error) error {
+	defer s.rootBuilder.pact.messageserver.CleanupPlugins()
 	message, err := getAsynchronousMessageWithReifiedContents(s.rootBuilder.messageHandle, s.rootBuilder.Type)
 	if err != nil {
 		return err
@@ -105,8 +106,6 @@ func (s *AsynchronousMessageWithPluginContents) ExecuteTest(t *testing.T, integr
 	if err != nil {
 		return err
 	}
-
-	s.rootBuilder.pact.messageserver.CleanupPlugins()
 
 	return s.rootBuilder.pact.messageserver.WritePactFile(s.rootBuilder.pact.config.PactDir, false)
 }
@@ -133,12 +132,12 @@ type AsynchronousMessageWithTransport struct {
 }
 
 func (s *AsynchronousMessageWithTransport) ExecuteTest(t *testing.T, integrationTest func(tc TransportConfig, m AsynchronousMessage) error) error {
+	defer s.rootBuilder.pact.messageserver.CleanupMockServer(s.transport.Port)
+	defer s.rootBuilder.pact.messageserver.CleanupPlugins()
 	message, err := getAsynchronousMessageWithReifiedContents(s.rootBuilder.messageHandle, s.rootBuilder.Type)
 	if err != nil {
 		return err
 	}
-
-	defer s.rootBuilder.pact.messageserver.CleanupMockServer(s.transport.Port)
 
 	err = integrationTest(s.transport, message)
 

--- a/message/v4/synchronous_message.go
+++ b/message/v4/synchronous_message.go
@@ -208,6 +208,7 @@ type SynchronousMessageWithPluginContents struct {
 // Will cleanup interactions between tests within a suite
 // and write the pact file if successful
 func (m *SynchronousMessageWithPluginContents) ExecuteTest(t *testing.T, integrationTest func(m SynchronousMessage) error) error {
+	defer m.pact.mockserver.CleanupPlugins()
 	message, err := getSynchronousMessageWithContents(m.messageHandle)
 	if err != nil {
 		return err
@@ -246,12 +247,12 @@ type SynchronousMessageWithTransport struct {
 }
 
 func (s *SynchronousMessageWithTransport) ExecuteTest(t *testing.T, integrationTest func(tc TransportConfig, m SynchronousMessage) error) error {
+	defer s.pact.mockserver.CleanupMockServer(s.transport.Port)
+	defer s.pact.mockserver.CleanupPlugins()
 	message, err := getSynchronousMessageWithContents(s.messageHandle)
 	if err != nil {
 		return err
 	}
-
-	defer s.pact.mockserver.CleanupMockServer(s.transport.Port)
 
 	err = integrationTest(s.transport, message)
 
@@ -266,8 +267,6 @@ func (s *SynchronousMessageWithTransport) ExecuteTest(t *testing.T, integrationT
 	if err != nil {
 		return err
 	}
-
-	s.pact.mockserver.CleanupPlugins()
 
 	return s.pact.mockserver.WritePactFileForServer(s.transport.Port, s.pact.config.PactDir, false)
 }

--- a/provider/verify_request.go
+++ b/provider/verify_request.go
@@ -300,8 +300,8 @@ func (v *VerifyRequest) Verify(handle *native.Verifier, writer outputWriter) err
 		handle.SetProviderState(v.ProviderStatesSetupURL, true, true)
 	}
 
-	res := handle.Execute()
 	defer handle.Shutdown()
+	res := handle.Execute()
 
 	return res
 }


### PR DESCRIPTION
If I run the test suite with `make test` - I get zombie plugin processes left in my shell


```
  PID TTY           TIME CMD
 1537 ttys001    0:01.26 /bin/zsh -il
 1770 ttys002    0:00.03 login -fp saf
 1772 ttys002    0:00.43 -zsh
29027 ttys007    0:00.61 /bin/zsh -il
12917 ttys014    0:00.15 /Users/saf/.pact/plugins/protobuf-0.3.15/pact-protobuf-plugin
13757 ttys014    0:00.00 /Users/saf/.pact/plugins/csv-0.0.6/pact-csv-plugin
13797 ttys014    0:00.26 /Users/saf/.pact/plugins/protobuf-0.3.15/pact-protobuf-plugin
14159 ttys014    0:00.00 ps -a
50964 ttys014    0:02.13 /bin/zsh -il
```

After this fix, everything still passes, and I don't have any zombie processes

```
  PID TTY           TIME CMD
 1537 ttys001    0:01.26 /bin/zsh -il
 1770 ttys002    0:00.03 login -fp saf
 1772 ttys002    0:00.43 -zsh
29027 ttys007    0:00.61 /bin/zsh -il
12504 ttys014    0:00.00 ps -a
50964 ttys014    0:02.08 /bin/zsh -il
```