### PR TITLE
ci: add windows runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,7 +25,7 @@ jobs:
                     1.21.x,
                     1.22.x,
                     ]
-        os: [ubuntu-latest, macos-12, macos-14]
+        os: [ubuntu-latest, macos-12, macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -43,6 +43,15 @@ jobs:
       - name: Test
         if: matrix.os == 'ubuntu-latest'
         run: APP_BRANCH=${APP_REF:11} DOCKER_GATEWAY_HOST=172.17.0.1 DOCKER_HOST_HTTP="http://172.17.0.1" make
+      - name: Set CGO_LDFLAGS / pact_ffi lib on PATH
+        if: matrix.os == 'windows-latest'
+        run: |
+          "CGO_LDFLAGS=-L$env:TMP" >> $env:GITHUB_ENV
+          "$env:TMP" >> $env:GITHUB_PATH
+      - name: Skip Avro plugin  & test (windows)
+        if: matrix.os == 'windows-latest'
+        run: |
+          "SKIP_PLUGIN_AVRO=1" >> $env:GITHUB_ENV
       - name: Test (unit)
         if: matrix.os != 'ubuntu-latest'
         run: make test
@@ -50,8 +59,10 @@ jobs:
         if: matrix.os != 'ubuntu-latest'
         run: make pact_local
       - name: Install goveralls
+        if: matrix.os != 'windows-latest'
         run: go install github.com/mattn/goveralls@latest
       - name: Send coverage
+        if: matrix.os != 'windows-latest'
         run: goveralls -coverprofile=coverage.txt -service=github -parallel
       - uses: actions/upload-artifact@v4
         with:

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,10 @@ PLUGIN_PACT_AVRO_VERSION=0.0.5
 
 GO_VERSION?=1.22
 ci:: docker deps clean bin test pact
+PACT_DOWNLOAD_DIR=/tmp
+ifeq ($(OS),Windows_NT)
+	PACT_DOWNLOAD_DIR=$$TMP
+endif
 
 # Run the ci target from a developer machine with the environment variables
 # set as if it was on Travis CI.
@@ -61,10 +65,6 @@ clean:
 	rm -rf build output dist examples/pacts
 
 deps: download_plugins
-	@echo "--- 🐿  Fetching build dependencies "
-	cd /tmp; \
-	go install github.com/mitchellh/gox@latest; \
-	cd -
 
 download_plugins:
 	@echo "--- 🐿  Installing plugins"; \
@@ -106,7 +106,7 @@ cli:
 
 install: bin
 	echo "--- 🐿 Installing Pact FFI dependencies"
-	./build/pact-go -l DEBUG install --libDir /tmp
+	./build/pact-go -l DEBUG install --libDir $(PACT_DOWNLOAD_DIR)
 
 pact: clean install docker
 	@echo "--- 🔨 Running Pact examples"

--- a/consumer/http_v4_test.go
+++ b/consumer/http_v4_test.go
@@ -3,6 +3,7 @@ package consumer
 import (
 	"fmt"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/pact-foundation/pact-go/v2/matchers"
@@ -51,7 +52,7 @@ func TestHttpV4TypeSystem(t *testing.T) {
 	assert.Error(t, err)
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/pact_plugin.proto", dir)
+	path := fmt.Sprintf("%s/pact_plugin.proto", strings.ReplaceAll(dir, "\\", "/"))
 
 	err = p.AddInteraction().
 		Given("some state").

--- a/examples/avro/avro_consumer_test.go
+++ b/examples/avro/avro_consumer_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/pact-foundation/pact-go/v2/consumer"
@@ -21,17 +22,18 @@ import (
 var dir, _ = os.Getwd()
 
 func TestAvroHTTP(t *testing.T) {
-	mockProvider, err := consumer.NewV4Pact(consumer.MockHTTPProviderConfig{
-		Consumer: "AvroConsumer",
-		Provider: "AvroProvider",
-		PactDir:  filepath.ToSlash(fmt.Sprintf("%s/../pacts", dir)),
-	})
-	assert.NoError(t, err)
+	if os.Getenv("SKIP_PLUGIN_AVRO") != "1" {
+		mockProvider, err := consumer.NewV4Pact(consumer.MockHTTPProviderConfig{
+			Consumer: "AvroConsumer",
+			Provider: "AvroProvider",
+			PactDir:  filepath.ToSlash(fmt.Sprintf("%s/../pacts", dir)),
+		})
+		assert.NoError(t, err)
 
-	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/user.avsc", dir)
+		dir, _ := os.Getwd()
+		path := fmt.Sprintf("%s/user.avsc", strings.ReplaceAll(dir, "\\", "/"))
 
-	avroResponse := `{
+		avroResponse := `{
 		"pact:avro": "` + path + `",
 		"pact:record-name": "User",
 		"pact:content-type": "avro/binary",
@@ -39,27 +41,28 @@ func TestAvroHTTP(t *testing.T) {
 		"username": "notEmpty('matt')"
 	}`
 
-	// Set up our expected interactions.
-	err = mockProvider.
-		AddInteraction().
-		UponReceiving("A request to do get some Avro stuff").
-		UsingPlugin(consumer.PluginConfig{
-			Plugin:  "avro",
-			Version: "0.0.5",
-		}).
-		WithRequest("GET", "/avro").
-		WillRespondWith(200, func(res *consumer.V4InteractionWithPluginResponseBuilder) {
-			res.PluginContents("avro/binary", avroResponse)
-		}).
-		ExecuteTest(t, func(msc consumer.MockServerConfig) error {
-			resp, err := callServiceHTTP(msc)
+		// Set up our expected interactions.
+		err = mockProvider.
+			AddInteraction().
+			UponReceiving("A request to do get some Avro stuff").
+			UsingPlugin(consumer.PluginConfig{
+				Plugin:  "avro",
+				Version: "0.0.5",
+			}).
+			WithRequest("GET", "/avro").
+			WillRespondWith(200, func(res *consumer.V4InteractionWithPluginResponseBuilder) {
+				res.PluginContents("avro/binary", avroResponse)
+			}).
+			ExecuteTest(t, func(msc consumer.MockServerConfig) error {
+				resp, err := callServiceHTTP(msc)
 
-			assert.Equal(t, int64(1), resp.ID)
-			assert.Equal(t, "matt", resp.Username) // ??????!
+				assert.Equal(t, int64(1), resp.ID)
+				assert.Equal(t, "matt", resp.Username) // ??????!
 
-			return err
-		})
-	assert.NoError(t, err)
+				return err
+			})
+		assert.NoError(t, err)
+	}
 }
 
 func callServiceHTTP(msc consumer.MockServerConfig) (*User, error) {

--- a/examples/avro/avro_provider_test.go
+++ b/examples/avro/avro_provider_test.go
@@ -21,23 +21,25 @@ var dir, _ = os.Getwd()
 var pactDir = fmt.Sprintf("%s/../pacts", dir)
 
 func TestAvroHTTPProvider(t *testing.T) {
-	httpPort, _ := utils.GetFreePort()
+	if os.Getenv("SKIP_PLUGIN_AVRO") != "1" {
+		httpPort, _ := utils.GetFreePort()
 
-	// Start provider API in the background
-	go startHTTPProvider(httpPort)
+		// Start provider API in the background
+		go startHTTPProvider(httpPort)
 
-	verifier := provider.NewVerifier()
+		verifier := provider.NewVerifier()
 
-	// Verify the Provider with local Pact Files
-	err := verifier.VerifyProvider(t, provider.VerifyRequest{
-		ProviderBaseURL: fmt.Sprintf("http://127.0.0.1:%d", httpPort),
-		Provider:        "AvroProvider",
-		PactFiles: []string{
-			filepath.ToSlash(fmt.Sprintf("%s/AvroConsumer-AvroProvider.json", pactDir)),
-		},
-	})
+		// Verify the Provider with local Pact Files
+		err := verifier.VerifyProvider(t, provider.VerifyRequest{
+			ProviderBaseURL: fmt.Sprintf("http://127.0.0.1:%d", httpPort),
+			Provider:        "AvroProvider",
+			PactFiles: []string{
+				filepath.ToSlash(fmt.Sprintf("%s/AvroConsumer-AvroProvider.json", pactDir)),
+			},
+		})
 
-	assert.NoError(t, err)
+		assert.NoError(t, err)
+	}
 }
 
 func startHTTPProvider(port int) {

--- a/examples/grpc/grpc_consumer_test.go
+++ b/examples/grpc/grpc_consumer_test.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -29,7 +30,7 @@ func TestGetFeatureSuccess(t *testing.T) {
 	log.SetLogLevel("DEBUG")
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/routeguide/route_guide.proto", dir)
+	path := fmt.Sprintf("%s/routeguide/route_guide.proto", strings.ReplaceAll(dir, "\\", "/"))
 
 	grpcInteraction := `{
 		"pact:proto": "` + path + `",
@@ -102,7 +103,7 @@ func TestGetFeatureError(t *testing.T) {
 	})
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/routeguide/route_guide.proto", dir)
+	path := fmt.Sprintf("%s/routeguide/route_guide.proto", strings.ReplaceAll(dir, "\\", "/"))
 
 	grpcInteraction := `{
 		"pact:proto": "` + path + `",
@@ -167,7 +168,7 @@ func TestSaveFeature(t *testing.T) {
 	log.SetLogLevel("INFO")
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/routeguide/route_guide.proto", dir)
+	path := fmt.Sprintf("%s/routeguide/route_guide.proto", strings.ReplaceAll(dir, "\\", "/"))
 
 	grpcInteraction := `{
 		"pact:proto": "` + path + `",

--- a/examples/protobuf-message/protobuf_consumer_test.go
+++ b/examples/protobuf-message/protobuf_consumer_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	message "github.com/pact-foundation/pact-go/v2/message/v4"
@@ -23,7 +24,7 @@ func TestPluginMessageConsumer(t *testing.T) {
 	})
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/../grpc/routeguide/route_guide.proto", dir)
+	path := fmt.Sprintf("%s/../grpc/routeguide/route_guide.proto", strings.ReplaceAll(dir, "\\", "/"))
 
 	protoMessage := `{
 		"pact:proto": "` + path + `",

--- a/internal/native/c_types_unix.go
+++ b/internal/native/c_types_unix.go
@@ -1,0 +1,7 @@
+//go:build darwin || linux
+
+package native
+
+import "C"
+
+type CUlong = C.ulong

--- a/internal/native/c_types_win.go
+++ b/internal/native/c_types_win.go
@@ -1,0 +1,7 @@
+//go:build windows
+
+package native
+
+import "C"
+
+type CUlong = C.ulonglong

--- a/internal/native/message_server.go
+++ b/internal/native/message_server.go
@@ -172,7 +172,7 @@ func (m *Message) WithRequestBinaryContents(body []byte) *Message {
 	defer free(cHeader)
 
 	// TODO: handle response
-	res := C.pactffi_with_binary_file(m.handle, C.int(INTERACTION_PART_REQUEST), cHeader, (*C.uchar)(unsafe.Pointer(&body[0])), C.ulong(len(body)))
+	res := C.pactffi_with_binary_file(m.handle, C.int(INTERACTION_PART_REQUEST), cHeader, (*C.uchar)(unsafe.Pointer(&body[0])), CUlong(len(body)))
 
 	log.Println("[DEBUG] WithRequestBinaryContents - pactffi_with_binary_file returned", bool(res))
 
@@ -183,7 +183,7 @@ func (m *Message) WithRequestBinaryContentType(contentType string, body []byte) 
 	defer free(cHeader)
 
 	// TODO: handle response
-	res := C.pactffi_with_binary_file(m.handle, C.int(INTERACTION_PART_REQUEST), cHeader, (*C.uchar)(unsafe.Pointer(&body[0])), C.ulong(len(body)))
+	res := C.pactffi_with_binary_file(m.handle, C.int(INTERACTION_PART_REQUEST), cHeader, (*C.uchar)(unsafe.Pointer(&body[0])), CUlong(len(body)))
 
 	log.Println("[DEBUG] WithRequestBinaryContents - pactffi_with_binary_file returned", res)
 
@@ -203,7 +203,7 @@ func (m *Message) WithResponseBinaryContents(body []byte) *Message {
 	defer free(cHeader)
 
 	// TODO: handle response
-	C.pactffi_with_binary_file(m.handle, C.int(INTERACTION_PART_RESPONSE), cHeader, (*C.uchar)(unsafe.Pointer(&body[0])), C.ulong(len(body)))
+	C.pactffi_with_binary_file(m.handle, C.int(INTERACTION_PART_RESPONSE), cHeader, (*C.uchar)(unsafe.Pointer(&body[0])), CUlong(len(body)))
 
 	return m
 }

--- a/internal/native/message_server_test.go
+++ b/internal/native/message_server_test.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	l "log"
 	"os"
+	"strings"
 	"testing"
 	"time"
 
@@ -218,7 +219,7 @@ func TestGetPluginSyncMessageContentsAsBytes(t *testing.T) {
 	i := m.NewSyncMessageInteraction("grpc interaction")
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/pact_plugin.proto", dir)
+	path := fmt.Sprintf("%s/pact_plugin.proto", strings.ReplaceAll(dir, "\\", "/"))
 
 	grpcInteraction := `{
 			"pact:proto": "` + path + `",
@@ -276,7 +277,7 @@ func TestGetPluginSyncMessageContentsAsBytes_EmptyResponse(t *testing.T) {
 	i := m.NewSyncMessageInteraction("grpc interaction")
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/pact_plugin.proto", dir)
+	path := fmt.Sprintf("%s/pact_plugin.proto", strings.ReplaceAll(dir, "\\", "/"))
 
 	grpcInteraction := `{
 			"pact:proto": "` + path + `",
@@ -322,7 +323,7 @@ func TestGetPluginAsyncMessageContentsAsBytes(t *testing.T) {
 	i := m.NewAsyncMessageInteraction("grpc interaction")
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/pact_plugin.proto", dir)
+	path := fmt.Sprintf("%s/pact_plugin.proto", strings.ReplaceAll(dir, "\\", "/"))
 
 	protobufInteraction := `{
 			"pact:proto": "` + path + `",
@@ -363,7 +364,7 @@ func TestGrpcPluginInteraction(t *testing.T) {
 	i := m.NewSyncMessageInteraction("grpc interaction")
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/pact_plugin.proto", dir)
+	path := fmt.Sprintf("%s/pact_plugin.proto", strings.ReplaceAll(dir, "\\", "/"))
 
 	grpcInteraction := `{
 			"pact:proto": "` + path + `",
@@ -441,7 +442,7 @@ func TestGrpcPluginInteraction_ErrorResponse(t *testing.T) {
 	i := m.NewSyncMessageInteraction("grpc interaction")
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/pact_plugin.proto", dir)
+	path := fmt.Sprintf("%s/pact_plugin.proto", strings.ReplaceAll(dir, "\\", "/"))
 
 	grpcInteraction := `{
 			"pact:proto": "` + path + `",

--- a/internal/native/mock_server.go
+++ b/internal/native/mock_server.go
@@ -541,7 +541,7 @@ func (i *Interaction) withHeaders(part interactionPart, valueOrMatcher map[strin
 			value := stringFromInterface(header)
 			cValue := C.CString(value)
 
-			C.pactffi_with_header_v2(i.handle, C.int(part), cName, C.ulong(0), cValue)
+			C.pactffi_with_header_v2(i.handle, C.int(part), cName, CUlong(0), cValue)
 
 			free(cValue)
 		}
@@ -560,7 +560,7 @@ func (i *Interaction) WithQuery(valueOrMatcher map[string][]interface{}) *Intera
 			value := stringFromInterface(v)
 			cValue := C.CString(value)
 
-			C.pactffi_with_query_parameter_v2(i.handle, cName, C.ulong(idx), cValue)
+			C.pactffi_with_query_parameter_v2(i.handle, cName, CUlong(idx), cValue)
 
 			free(cValue)
 		}
@@ -616,7 +616,7 @@ func (i *Interaction) withBinaryBody(contentType string, body []byte, part inter
 	cHeader := C.CString(contentType)
 	defer free(cHeader)
 
-	C.pactffi_with_binary_file(i.handle, C.int(part), cHeader, (*C.uchar)(unsafe.Pointer(&body[0])), C.ulong(len(body)))
+	C.pactffi_with_binary_file(i.handle, C.int(part), cHeader, (*C.uchar)(unsafe.Pointer(&body[0])), CUlong(len(body)))
 
 	return i
 }

--- a/internal/native/mock_server_test.go
+++ b/internal/native/mock_server_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"strings"
 	"testing"
 
 	"github.com/pact-foundation/pact-go/v2/log"
@@ -179,7 +180,7 @@ func TestPluginInteraction(t *testing.T) {
 	i := m.NewInteraction("some plugin interaction")
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/pact_plugin.proto", dir)
+	path := fmt.Sprintf("%s/pact_plugin.proto", strings.ReplaceAll(dir, "\\", "/"))
 
 	protobufInteraction := `{
 			"pact:proto": "` + path + `",

--- a/message/v4/asynchronous_message_test.go
+++ b/message/v4/asynchronous_message_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+// Sync - no plugin
 func TestAsyncTypeSystem(t *testing.T) {
 	p, _ := NewAsynchronousPact(Config{
 		Consumer: "asyncconsumer",
@@ -20,7 +21,6 @@ func TestAsyncTypeSystem(t *testing.T) {
 		Foo string `json:"foo"`
 	}
 
-	// Sync - no plugin
 	err := p.AddAsynchronousMessage().
 		Given("some state").
 		Given("another state").
@@ -38,8 +38,11 @@ func TestAsyncTypeSystem(t *testing.T) {
 
 	assert.NoError(t, err)
 
-	// Sync - with plugin, but no transport
-	// TODO: ExecuteTest has been disabled for now, because it's not very useful
+}
+
+// Sync - with plugin, but no transport
+// TODO: ExecuteTest has been disabled for now, because it's not very useful
+func TestAsyncTypeSystem_CsvPlugin_Matcher(t *testing.T) {
 	csvInteraction := `{
 		"request.path": "/reports/report002.csv",
 		"response.status": "200",
@@ -52,14 +55,14 @@ func TestAsyncTypeSystem(t *testing.T) {
 		}
 	}`
 
-	p, _ = NewAsynchronousPact(Config{
+	p, _ := NewAsynchronousPact(Config{
 		Consumer: "asyncconsumer",
 		Provider: "asyncprovider",
 		PactDir:  "/tmp/",
 	})
 
 	// TODO: enable when there is a transport for async to test!
-	err = p.AddAsynchronousMessage().
+	err := p.AddAsynchronousMessage().
 		Given("some state").
 		ExpectsToReceive("some csv content").
 		UsingPlugin(PluginConfig{

--- a/scripts/build.ps1
+++ b/scripts/build.ps1
@@ -1,0 +1,66 @@
+$pactDir = $env:USERPROFILE + "\.pact"
+$pactBinDir = $pactDir + "\bin"
+$exitCode = 0
+
+# go build -buildvcs=false -o build/pact-go.exe
+go build -o build/pact-go.exe
+if ($LastExitCode -ne 0) {
+  Write-Host "ERROR: Failed to build pact-go"
+  $exitCode=1
+}
+
+./build/pact-go.exe -l DEBUG install --libDir $env:TMP
+if ($LastExitCode -ne 0) {
+  Write-Host "ERROR: Failed to install pact-go library to $env:TMP"
+  $exitCode=1
+}
+
+# Install CLI Tools
+if (!(Test-Path -Path $pactBinDir\pact-plugin-cli.exe)) {
+Write-Host "--> Creating ${pactDir}"
+New-Item -Force -ItemType Directory $pactDir
+New-Item -Force -ItemType Directory $pactBinDir
+
+Write-Host "--> Downloading Pact plugin CLI tools"
+$downloadDir = $env:TEMP
+$pactPluginCliVersion = "0.1.2"
+$url = "https://github.com/pact-foundation/pact-plugins/releases/download/pact-plugin-cli-v${pactPluginCliVersion}/pact-plugin-cli-windows-x86_64.exe.gz"
+
+Write-Host "Downloading $url"
+$gz = "$downloadDir\pact-plugin-cli-windows-x86_64.exe.gz"
+if (Test-Path "$gz") {
+  Remove-Item $gz
+}
+
+$downloader = new-object System.Net.WebClient
+$downloader.DownloadFile($url, $gz)
+
+Write-Host "Extracting $gz"
+Add-Type -AssemblyName System.IO.Compression.FileSystem
+gzip -d $gz
+Move-Item "$downloadDir\pact-plugin-cli-windows-x86_64.exe" "$pactBinDir\pact-plugin-cli.exe"
+}
+
+Write-Host "--> Adding pact binaries to path"
+$env:PATH += ";$pactBinDir"
+Write-Host $env:PATH
+Get-ChildItem $pactBinDir
+Write-Host "Added pact binaries to path"
+
+pact-plugin-cli.exe --version
+if ($LastExitCode -ne 0) {
+  Write-Host "ERROR: Failed to install pact-plugin-cli"
+  $exitCode=1
+}
+
+pact-plugin-cli.exe -y install https://github.com/mefellows/pact-matt-plugin/releases/tag/v0.1.1 --skip-if-installed
+if ($LastExitCode -ne 0) {
+  Write-Host "ERROR: Failed to install pact-matt-plugin"
+  $exitCode=1
+}
+
+Write-Host "Done!"
+if ($exitCode -ne 0) {
+  Write-Host "--> Build failed, exiting"
+  Exit $exitCode
+}

--- a/scripts/examples_consumer.ps1
+++ b/scripts/examples_consumer.ps1
@@ -1,0 +1,15 @@
+$exitCode = 0
+# Run integration tests
+Write-Host "--> Testing E2E examples"
+Write-Host "Running consumer tests"
+go test -v -tags=consumer -count=1 github.com/pact-foundation/pact-go/v2/examples/...
+if ($LastExitCode -ne 0) {
+  Write-Host "ERROR: E2E Consumer Tests failed, logging failure"
+  $exitCode=1
+}
+
+Write-Host "Done!"
+if ($exitCode -ne 0) {
+  Write-Host "--> Build failed, exiting"
+  Exit $exitCode
+}

--- a/scripts/examples_provider.ps1
+++ b/scripts/examples_provider.ps1
@@ -1,0 +1,15 @@
+$exitCode = 0
+Write-Host "--> Testing E2E examples"
+Write-Host "Running provider tests"
+$env:SKIP_PUBLISH='true'
+go test -v -timeout=30s -tags=provider -count=1 github.com/pact-foundation/pact-go/v2/examples/...
+if ($LastExitCode -ne 0) {
+  Write-Host "ERROR: E2E Provider Tests failed, logging failure"
+  $exitCode=1
+}
+
+Write-Host "Done!"
+if ($exitCode -ne 0) {
+  Write-Host "--> Build failed, exiting"
+  Exit $exitCode
+}

--- a/scripts/unit.ps1
+++ b/scripts/unit.ps1
@@ -1,0 +1,20 @@
+$exitCode = 0
+
+# Run unit tests
+Write-Host "--> Running unit tests"
+$packages = go list -buildvcs=false ./... |  Where-Object {$_ -inotmatch 'vendor'} | Where-Object {$_ -inotmatch 'examples'}
+
+foreach ($package in $packages) {
+  Write-Host "Running tests for $package"
+  go test -race -v $package
+  if ($LastExitCode -ne 0) {
+    Write-Host "ERROR: Test failed, logging failure"
+    $exitCode=1
+  }
+}
+
+Write-Host "Done!"
+if ($exitCode -ne 0) {
+  Write-Host "--> Build failed, exiting"
+  Exit $exitCode
+}


### PR DESCRIPTION
- Added Windows x86_64 GitHub Action Runner

## Caveats

- gRPC tests for windows require backslashes escaping, or forward slashes in path to proto file. Can we cater for this in the pact-protobuf-plugin?
- Avro plugin tests are skipped on windows
  - `avro` plugin fails to run at point of install time via `pact-plugin-cli`
    - See https://github.com/pact-foundation/pact-plugins/issues/68
  - ~all plugins fail to cleanly shutdown after execution, and they can only be closed externally via the task manager. This is causing tests to fail in GitHub actions.~ Fixed by https://github.com/pact-foundation/pact-plugins/pull/67