### PR TITLE
fix: don't use defer in a loop

### DIFF
--- a/internal/native/message_server.go
+++ b/internal/native/message_server.go
@@ -121,20 +121,18 @@ func (m *Message) GivenWithParameter(state string, params map[string]interface{}
 	defer free(cState)
 
 	if len(params) == 0 {
-		cState := C.CString(state)
-		defer free(cState)
-
 		C.pactffi_given(m.handle, cState)
 	} else {
 		for k, v := range params {
 			cKey := C.CString(k)
-			defer free(cKey)
+
 			param := stringFromInterface(v)
 			cValue := C.CString(param)
-			defer free(cValue)
 
 			C.pactffi_given_with_param(m.handle, cState, cKey, cValue)
 
+			free(cValue)
+			free(cKey)
 		}
 	}
 
@@ -152,18 +150,18 @@ func (m *Message) ExpectsToReceive(description string) *Message {
 
 func (m *Message) WithMetadata(valueOrMatcher map[string]string) *Message {
 	for k, v := range valueOrMatcher {
-
 		cName := C.CString(k)
-		defer free(cName)
 
 		// TODO: check if matching rules allowed here
 		// value := stringFromInterface(v)
 		// fmt.Printf("withheaders, sending: %+v \n\n", value)
 		// cValue := C.CString(value)
 		cValue := C.CString(v)
-		defer free(cValue)
 
 		C.pactffi_message_with_metadata(m.handle, cName, cValue)
+
+		free(cValue)
+		free(cName)
 	}
 
 	return m
@@ -237,7 +235,7 @@ func (m *MessageServer) UsingPlugin(pluginName string, pluginVersion string) err
 	defer free(cPluginName)
 	cPluginVersion := C.CString(pluginVersion)
 	defer free(cPluginVersion)
-	
+
 	r := C.pactffi_using_plugin(m.messagePact.handle, cPluginName, cPluginVersion)
 	InstallSignalHandlers()
 

--- a/internal/native/mock_server.go
+++ b/internal/native/mock_server.go
@@ -500,13 +500,13 @@ func (i *Interaction) GivenWithParameter(state string, params map[string]interfa
 
 	for k, v := range params {
 		cKey := C.CString(k)
-		defer free(cKey)
 		param := stringFromInterface(v)
 		cValue := C.CString(param)
-		defer free(cValue)
 
 		C.pactffi_given_with_param(i.handle, cState, cKey, cValue)
 
+		free(cValue)
+		free(cKey)
 	}
 
 	return i
@@ -535,18 +535,18 @@ func (i *Interaction) WithResponseHeaders(valueOrMatcher map[string][]interface{
 
 func (i *Interaction) withHeaders(part interactionPart, valueOrMatcher map[string][]interface{}) *Interaction {
 	for k, v := range valueOrMatcher {
-
 		cName := C.CString(k)
-		defer free(cName)
 
 		for _, header := range v {
 			value := stringFromInterface(header)
 			cValue := C.CString(value)
-			defer free(cValue)
 
 			C.pactffi_with_header_v2(i.handle, C.int(part), cName, C.ulong(0), cValue)
+
+			free(cValue)
 		}
 
+		free(cName)
 	}
 
 	return i
@@ -554,17 +554,18 @@ func (i *Interaction) withHeaders(part interactionPart, valueOrMatcher map[strin
 
 func (i *Interaction) WithQuery(valueOrMatcher map[string][]interface{}) *Interaction {
 	for k, values := range valueOrMatcher {
-
 		cName := C.CString(k)
-		defer free(cName)
 
 		for idx, v := range values {
 			value := stringFromInterface(v)
 			cValue := C.CString(value)
-			defer free(cValue)
 
 			C.pactffi_with_query_parameter_v2(i.handle, cName, C.ulong(idx), cValue)
+
+			free(cValue)
 		}
+
+		free(cName)
 	}
 
 	return i


### PR DESCRIPTION
These changes fixes a crash in tests when using `WithCompleteRequest() or `WithCompleteResponse()` with multiple headers.

```
unexpected fault address 0x1d4c860
fatal error: fault
[signal SIGSEGV: segmentation violation code=0x2 addr=0x1d4c860 pc=0x4a28fd]

goroutine 14 gp=0xc0003c28c0 m=3 mp=0xc00009d008 [running]:
runtime.throw({0x1e99d7e?, 0xc000111f80?})
	GOROOT/src/runtime/panic.go:1023 +0x5c fp=0xc0000eb660 sp=0xc0000eb630 pc=0x46cd7c
runtime.sigpanic()
	GOROOT/src/runtime/signal_unix.go:895 +0x285 fp=0xc0000eb6c0 sp=0xc0000eb660 pc=0x487265
runtime/internal/atomic.casPointer(0x1d4c860?, 0x46c765?, 0x46b700?)
	GOROOT/src/runtime/atomic_pointer.go:63 +0x3d fp=0xc0000eb6e0 sp=0xc0000eb6c0 pc=0x4a28fd
runtime/internal/atomic.(*UnsafePointer).CompareAndSwap(...)
	GOROOT/src/runtime/internal/atomic/types.go:512
runtime/internal/atomic.(*Pointer[...]).CompareAndSwap(...)
	GOROOT/src/runtime/internal/atomic/types.go:570
runtime.deferconvert(0xc0000edc88)
	GOROOT/src/runtime/panic.go:436 +0x77 fp=0xc0000eb720 sp=0xc0000eb6e0 pc=0x46b777
runtime.(*_panic).nextDefer(0xc0000eb768)
	GOROOT/src/runtime/panic.go:879 +0x125 fp=0xc0000eb750 sp=0xc0000eb720 pc=0x46c765
runtime.deferreturn()
	GOROOT/src/runtime/panic.go:598 +0x68 fp=0xc0000eb7e0 sp=0xc0000eb750 pc=0x46be08
github.com/pact-foundation/pact-go/v2/internal/native.(*Interaction).withHeaders(0xc00043034c, 0x0, 0xc0000ebc60)
	github.com/pact-foundation/pact-go/v2/internal/native/mock_server.go:709 +0x1ec fp=0xc0000eb8d0 sp=0xc0000eb7e0 pc=0xf6d60c
github.com/pact-foundation/pact-go/v2/internal/native.(*Interaction).WithRequestHeaders(...)
	github.com/pact-foundation/pact-go/v2/internal/native/mock_server.go:686
github.com/pact-foundation/pact-go/v2/consumer.(*Interaction).WithCompleteRequest(0xc00011e198, {{0x1e98bce, 0x3}, {0x20178c8, 0x2010de0}, 0x0, 0xc0004441e0, {0x0, 0x0}})
	github.com/pact-foundation/pact-go/v2/consumer/interaction.go:31 +0x3ec fp=0xc0000ebd00 sp=0xc0000eb8d0 pc=0xf7678c
github.com/pact-foundation/pact-go/v2/consumer.(*V4UnconfiguredInteraction).WithCompleteRequest(...)
	github.com/pact-foundation/pact-go/v2/consumer/http_v4.go:97
```