### PR TITLE
fix: ensure sync messages write metadata to both req & res

### DIFF
--- a/internal/native/message_server.go
+++ b/internal/native/message_server.go
@@ -166,6 +166,32 @@ func (m *Message) WithMetadata(valueOrMatcher map[string]string) *Message {
 
 	return m
 }
+func (m *Message) WithRequestMetadata(valueOrMatcher map[string]string) *Message {
+	for k, v := range valueOrMatcher {
+		cName := C.CString(k)
+		cValue := C.CString(v)
+
+		C.pactffi_with_metadata(m.handle, cName, cValue, 0)
+
+		free(cValue)
+		free(cName)
+	}
+
+	return m
+}
+func (m *Message) WithResponseMetadata(valueOrMatcher map[string]string) *Message {
+	for k, v := range valueOrMatcher {
+		cName := C.CString(k)
+		cValue := C.CString(v)
+
+		C.pactffi_with_metadata(m.handle, cName, cValue, 1)
+
+		free(cValue)
+		free(cName)
+	}
+
+	return m
+}
 
 func (m *Message) WithRequestBinaryContents(body []byte) *Message {
 	cHeader := C.CString("application/octet-stream")

--- a/message/v4/synchronous_message.go
+++ b/message/v4/synchronous_message.go
@@ -115,7 +115,7 @@ type SynchronousMessageWithRequestBuilder struct {
 // to go with the content
 // func (m *Message) WithMetadata(metadata MapMatcher) *Message {
 func (m *SynchronousMessageWithRequestBuilder) WithMetadata(metadata map[string]string) *SynchronousMessageWithRequestBuilder {
-	m.messageHandle.WithMetadata(metadata)
+	m.messageHandle.WithRequestMetadata(metadata)
 
 	return m
 }
@@ -164,7 +164,7 @@ type SynchronousMessageWithResponseBuilder struct {
 // to go with the content
 // func (m *Message) WithMetadata(metadata MapMatcher) *Message {
 func (m *SynchronousMessageWithResponseBuilder) WithMetadata(metadata map[string]string) *SynchronousMessageWithResponseBuilder {
-	m.messageHandle.WithMetadata(metadata)
+	m.messageHandle.WithResponseMetadata(metadata)
 
 	return m
 }

--- a/message/v4/synchronous_message_test.go
+++ b/message/v4/synchronous_message_test.go
@@ -15,18 +15,17 @@ func TestSyncTypeSystem_NoPlugin(t *testing.T) {
 	p, _ := NewSynchronousPact(Config{
 		Consumer: "consumer",
 		Provider: "provider",
-		PactDir:  "/tmp/",
 	})
 	// Sync - no plugin
 	err := p.AddSynchronousMessage("some description").
 		Given("some state").
 		WithRequest(func(r *SynchronousMessageWithRequestBuilder) {
 			r.WithJSONContent(map[string]string{"foo": "bar"})
-			r.WithMetadata(map[string]string{})
+			r.WithMetadata(map[string]string{"meta_request": "meta_request_data"})
 		}).
 		WithResponse(func(r *SynchronousMessageWithResponseBuilder) {
 			r.WithJSONContent(map[string]string{"foo": "bar"})
-			r.WithMetadata(map[string]string{})
+			r.WithMetadata(map[string]string{"meta_response": "meta_response_data"})
 		}).
 		ExecuteTest(t, func(m SynchronousMessage) error {
 			// In this scenario, we have no real transport, so we need to mock/handle both directions


### PR DESCRIPTION
Metadata is not being included in a synchronous v4 message interaction, as the function we are calling does not know which part (request or response) that metadata is being attached to.

The output of the v4 sync message test, post this change now shows

```
{
  "consumer": {
    "name": "consumer"
  },
  "interactions": [
    {
      "description": "some description",
      "pending": false,
      "providerStates": [
        {
          "name": "some state"
        }
      ],
      "request": {
        "contents": {
          "content": {
            "foo": "bar"
          },
          "contentType": "application/json",
          "encoded": false
        },
        "metadata": {
          "contentType": "application/json",
          "meta_request": "meta_request_data"
        }
      },
      "response": [
        {
          "contents": {
            "content": {
              "foo": "bar"
            },
            "contentType": "application/json",
            "encoded": false
          },
          "metadata": {
            "contentType": "application/json",
            "meta_response": "meta_response_data"
          }
        }
      ],
      "type": "Synchronous/Messages"
    }
  ],
  "metadata": {
    "pactRust": {
      "ffi": "0.4.23",
      "models": "1.2.5"
    },
    "pactSpecification": {
      "version": "4.0"
    }
  },
  "provider": {
    "name": "provider"
  }
}
```

it is worth noting that the value is expected to be json, and therefore we get the following warning with string values

```
2024-10-25T16:31:26.864750Z  WARN ThreadId(01) pact_ffi::mock_server::handles: Failed to parse metadata value 'meta_request_data' as JSON - expected value at line 1 column 1. Will treat it as string
2024-10-25T16:31:26.864972Z  WARN ThreadId(01) pact_ffi::mock_server::handles: Failed to parse metadata value 'meta_response_data' as JSON - expected value at line 1 column 1. Will treat it as string
PASS
ok      example.com/m   0.485s
```