### PR TITLE
chore(deps)!: require minimum go version 1.22

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -16,8 +16,9 @@ jobs:
         go-version: [
                 # 1.19.x, # Ended 06 Sep 2023
                 # 1.20.x, # Ended 06 Feb 2024
-                1.21.x,
+                # 1.21.x, # Ended 13 Aug 2024
                 1.22.x,
+                1.23.x,
                 ]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -34,14 +34,14 @@ jobs:
         with:
           # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
           # version: v1.29
-          version: v1.55
+          version: v1.63
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir
 
           # Optional: golangci-lint command line arguments.
           # ignore the lib.go file as it only contains cgo annotations
-          args: --skip-files internal/native/lib.go --timeout 2m
+          args: --exclude-files internal/native/lib.go --timeout 2m
 
           # Optional: show only new issues if it's a pull request. The default value is `false`.
           # only-new-issues: true

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,8 +29,9 @@ jobs:
                     # 1.18.x, # Ended 01 Feb 2023
                     # 1.19.x, # Ended 06 Sep 2023
                     # 1.20.x, # Ended 06 Feb 2024
-                    1.21.x,
+                    # 1.21.x, # Ended 13 Aug 2024
                     1.22.x,
+                    1.23.x,
                     ]
         os: [ubuntu-latest, macos-13, macos-14, windows-latest]
     runs-on: ${{ matrix.os }}
@@ -79,7 +80,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: ["1.21", "1.22"]
+        go-version: ["1.22", "1.23"]
     steps:
       - uses: actions/checkout@v4
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/pact-foundation/pact-go/v2
 
-go 1.21
+go 1.22
 
 require (
 	github.com/golang/protobuf v1.5.4

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -464,7 +464,7 @@ type configuration struct{}
 func getConfigPath() string {
 	user, err := user.Current()
 	if err != nil {
-		log.Fatalf(err.Error())
+		log.Fatalf("%v", err)
 	}
 
 	return path.Join(user.HomeDir, ".pact", "pact-go.yml")


### PR DESCRIPTION
go 1.21 is eol as of 13 Aug 2024 and go-grpc 1.68.0 requires 1.22