### PR TITLE
feat: add pact go client lib version to pact

### DIFF
--- a/consumer/http.go
+++ b/consumer/http.go
@@ -22,6 +22,7 @@ import (
 	"unicode"
 	"unicode/utf8"
 
+	"github.com/pact-foundation/pact-go/v2/command"
 	"github.com/pact-foundation/pact-go/v2/internal/native"
 	logging "github.com/pact-foundation/pact-go/v2/log"
 	"github.com/pact-foundation/pact-go/v2/models"
@@ -112,6 +113,7 @@ func (p *httpMockProvider) configure() error {
 	}
 
 	p.mockserver = native.NewHTTPPact(p.config.Consumer, p.config.Provider)
+	p.mockserver.WithMetadata("pact-go", "version", strings.TrimPrefix(command.Version, "v"))
 	switch p.specificationVersion {
 	case models.V2:
 		p.mockserver.WithSpecificationVersion(native.SPECIFICATION_VERSION_V2)

--- a/message/v3/asynchronous_message.go
+++ b/message/v3/asynchronous_message.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/pact-foundation/pact-go/v2/command"
 	"github.com/pact-foundation/pact-go/v2/internal/native"
 	mockserver "github.com/pact-foundation/pact-go/v2/internal/native"
 	logging "github.com/pact-foundation/pact-go/v2/log"
@@ -164,6 +166,7 @@ func (p *AsynchronousPact) validateConfig() error {
 	}
 
 	p.messageserver = mockserver.NewMessageServer(p.config.Consumer, p.config.Provider)
+	p.messageserver.WithMetadata("pact-go", "version", strings.TrimPrefix(command.Version, "v"))
 
 	return nil
 }

--- a/message/v4/asynchronous_message.go
+++ b/message/v4/asynchronous_message.go
@@ -7,8 +7,10 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
+	"strings"
 	"testing"
 
+	"github.com/pact-foundation/pact-go/v2/command"
 	"github.com/pact-foundation/pact-go/v2/internal/native"
 	mockserver "github.com/pact-foundation/pact-go/v2/internal/native"
 	logging "github.com/pact-foundation/pact-go/v2/log"
@@ -246,6 +248,7 @@ func (p *AsynchronousPact) validateConfig() error {
 
 	p.messageserver = mockserver.NewMessageServer(p.config.Consumer, p.config.Provider)
 	p.messageserver.WithSpecificationVersion(mockserver.SPECIFICATION_VERSION_V4)
+	p.messageserver.WithMetadata("pact-go", "version", strings.TrimPrefix(command.Version, "v"))
 
 	return nil
 }

--- a/message/v4/synchronous_message.go
+++ b/message/v4/synchronous_message.go
@@ -5,8 +5,10 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
+	"github.com/pact-foundation/pact-go/v2/command"
 	"github.com/pact-foundation/pact-go/v2/internal/native"
 	mockserver "github.com/pact-foundation/pact-go/v2/internal/native"
 	logging "github.com/pact-foundation/pact-go/v2/log"
@@ -302,6 +304,7 @@ func (m *SynchronousPact) validateConfig() error {
 
 	m.mockserver = native.NewMessageServer(m.config.Consumer, m.config.Provider)
 	m.mockserver.WithSpecificationVersion(mockserver.SPECIFICATION_VERSION_V4)
+	m.mockserver.WithMetadata("pact-go", "version", strings.TrimPrefix(command.Version, "v"))
 
 	return nil
 }

--- a/provider/verifier.go
+++ b/provider/verifier.go
@@ -40,7 +40,7 @@ func NewVerifier() *Verifier {
 	native.Init(string(logging.LogLevel()))
 
 	return &Verifier{
-		handle: native.NewVerifier("pact-go", command.Version),
+		handle: native.NewVerifier("pact-go", strings.TrimPrefix(command.Version, "v")),
 	}
 
 }


### PR DESCRIPTION
example metadata

```json
  "metadata": {
    "pact-go": {
      "version": "2.1.0"
    },
    "pactRust": {
      "ffi": "0.4.26",
      "models": "1.2.7"
    },
    "pactSpecification": {
      "version": "4.0"
    }
  }
  ```
  Works as per pact-js
  
  https://github.com/search?q=repo%3Apact-foundation%2Fpact-js%20this.pact.addMetadata&type=code
  
  note, for pact-js, we may want to also write pact-js-core library version as well
  
  
  noted when investigating #499