### PR TITLE
chore: update go versions

### DIFF
--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -10,31 +10,12 @@ on:
 jobs:
   golangci:
     name: lint
-    strategy:
-      fail-fast: false
-      matrix:
-        go-version: ["1.25", "1.26"]
-        os: [ubuntu-latest]
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-      - name: Install Go
-        uses: actions/setup-go@v6
+      - uses: actions/checkout@v5
+      - uses: actions/setup-go@v6
         with:
-          go-version: ${{ matrix.go-version }}
-      - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+          go-version: stable
+      - uses: golangci/golangci-lint-action@v9.2.0
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.64
-
-          # Optional: working directory, useful for monorepos
-          # working-directory: somedir
-
-          # Optional: golangci-lint command line arguments.
-          # ignore the lib.go file as it only contains cgo annotations
-          args: --exclude-files internal/native/lib.go --timeout 2m
-
-          # Optional: show only new issues if it's a pull request. The default value is `false`.
-          # only-new-issues: true
+          version: v2.11

--- a/.github/workflows/golangci-lint.yml
+++ b/.github/workflows/golangci-lint.yml
@@ -13,15 +13,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [
-                # 1.19.x, # Ended 06 Sep 2023
-                # 1.20.x, # Ended 06 Feb 2024
-                # 1.21.x, # Ended 13 Aug 2024
-                # 1.22.x, # Ended 11 Feb 2025
-                1.23.x,
-                1.24.x,
-                1.25.x,
-                ]
+        go-version: ["1.25", "1.26"]
         os: [ubuntu-latest]
     runs-on: ${{ matrix.os }}
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,18 +30,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        go-version: [ # https://endoflife.date/go
-                    # 1.17.x, # Ended 02 Aug 2022
-                    # 1.18.x, # Ended 01 Feb 2023
-                    # 1.19.x, # Ended 06 Sep 2023
-                    # 1.20.x, # Ended 06 Feb 2024
-                    # 1.21.x, # Ended 13 Aug 2024
-                    # 1.22.x, # Ended 11 Feb 2025
-                    1.23.x,
-                    1.24.x,
-                    1.25.x,
-                    ]
-        os: [ubuntu-latest, macos-13, macos-14, windows-latest]
+        go-version: ["1.25", "1.26"]
+        os: [ubuntu-latest, macos-latest, windows-latest]
     runs-on: ${{ matrix.os }}
     steps:
       - name: Checkout code
@@ -54,8 +44,6 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
-      - if: matrix.os == 'macos-14'
-        run: brew install protobuf
       - name: Test
         if: matrix.os == 'ubuntu-latest'
         run: APP_BRANCH=${APP_REF:11} DOCKER_GATEWAY_HOST=172.17.0.1 DOCKER_HOST_HTTP="http://172.17.0.1" make
@@ -90,32 +78,24 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, ubuntu-24.04-arm]
-        go-version: ["1.23", "1.24", "1.25"]
+        go-version: ["1.25", "1.26"]
         variant: [debian]
         experimental: [false]
         include:
           - variant: alpine
-            go-version: 1.23
+            go-version: 1.25
             experimental: true
             os: ubuntu-latest
           - variant: alpine
-            go-version: 1.24
+            go-version: 1.26
             experimental: true
             os: ubuntu-latest
           - variant: alpine
             go-version: 1.25
             experimental: true
-            os: ubuntu-latest
-          - variant: alpine
-            go-version: 1.23
-            experimental: true
             os: ubuntu-24.04-arm
           - variant: alpine
-            go-version: 1.24
-            experimental: true
-            os: ubuntu-24.04-arm
-          - variant: alpine
-            go-version: 1.25
+            go-version: 1.26
             experimental: true
             os: ubuntu-24.04-arm
     steps:

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,6 @@
+version: "2"
+linters:
+  exclusions:
+    paths:
+      # lib.go only contains cgo annotations
+      - internal/native/lib.go

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/pact-foundation/pact-go/v2
 
-go 1.23.0
-
-toolchain go1.24.5
+go 1.25.0
 
 require (
 	github.com/golang/protobuf v1.5.4


### PR DESCRIPTION
Also, while modifying the CI test matrix, took the opportunity to upgrade the macos runners.