### PR TITLE
feat(provider): expose verifier error sentinels for errors.Is discrimination

### DIFF
--- a/provider/errors.go
+++ b/provider/errors.go
@@ -1,0 +1,21 @@
+package provider
+
+import "github.com/pact-foundation/pact-go/v2/internal/native"
+
+// Sentinel errors returned by Verifier.VerifyProvider so callers can
+// discriminate between a verification mismatch and an infrastructure failure
+// of the verifier itself. Pact-go publishes verification results to the broker
+// before returning ErrVerificationFailed (when PublishVerificationResults is
+// enabled), so callers that gate via can-i-merge / can-i-deploy can choose to
+// treat verification mismatches as non-fatal at the test step.
+var (
+	// ErrVerificationFailed is returned when one or more consumer pact
+	// verifications did not match the provider's responses. Verification
+	// results are published to the broker before this error is returned.
+	ErrVerificationFailed = native.ErrVerifierFailed
+
+	// ErrVerifierFailedToRun is returned when the verifier could not execute
+	// at all — typically an infrastructure, configuration, or framework
+	// problem. No verification results were published.
+	ErrVerifierFailedToRun = native.ErrVerifierFailedToRun
+)

--- a/provider/errors_test.go
+++ b/provider/errors_test.go
@@ -1,0 +1,42 @@
+package provider
+
+import (
+	"errors"
+	"fmt"
+	"testing"
+
+	"github.com/pact-foundation/pact-go/v2/internal/native"
+)
+
+// TestErrVerificationFailed_IsNativeSentinel guards the re-export: the
+// public provider.ErrVerificationFailed must remain identical to the
+// internal/native sentinel so callers can use errors.Is to discriminate
+// the error returned by Verifier.VerifyProvider.
+func TestErrVerificationFailed_IsNativeSentinel(t *testing.T) {
+	if !errors.Is(ErrVerificationFailed, native.ErrVerifierFailed) {
+		t.Errorf("ErrVerificationFailed must be the same sentinel as internal/native.ErrVerifierFailed")
+	}
+	if !errors.Is(ErrVerifierFailedToRun, native.ErrVerifierFailedToRun) {
+		t.Errorf("ErrVerifierFailedToRun must be the same sentinel as internal/native.ErrVerifierFailedToRun")
+	}
+}
+
+// TestErrVerificationFailed_DiscriminatesFromGenericError makes sure the
+// sentinels are not confused with arbitrary error values.
+func TestErrVerificationFailed_DiscriminatesFromGenericError(t *testing.T) {
+	generic := fmt.Errorf("something else broke")
+	if errors.Is(generic, ErrVerificationFailed) {
+		t.Error("generic error should not match ErrVerificationFailed")
+	}
+	if errors.Is(generic, ErrVerifierFailedToRun) {
+		t.Error("generic error should not match ErrVerifierFailedToRun")
+	}
+}
+
+// TestErrVerificationFailed_DistinctFromEachOther ensures the two sentinels
+// are not interchangeable.
+func TestErrVerificationFailed_DistinctFromEachOther(t *testing.T) {
+	if errors.Is(ErrVerificationFailed, ErrVerifierFailedToRun) {
+		t.Error("ErrVerificationFailed and ErrVerifierFailedToRun must be distinct")
+	}
+}


### PR DESCRIPTION
## Summary

Re-export the existing `internal/native` error sentinels through the public `provider` package so callers of `Verifier.VerifyProvider` can use `errors.Is` to discriminate between a verification mismatch and an infrastructure failure of the verifier itself.

Two new public symbols, both aliased to the existing internal sentinels:

```go
// provider/errors.go
var (
    ErrVerificationFailed   = native.ErrVerifierFailed        // result == 1
    ErrVerifierFailedToRun  = native.ErrVerifierFailedToRun   // result == 2
)
```

No behavior change. No new error paths. The `Verifier.VerifyProvider` method already returns these sentinels today (via `internal/native`); this PR just makes them callable from outside the module.

## Motivation

We run pact-go inside a contract-testing pipeline that gates on `can-i-merge` / `can-i-deploy` against a Pact Broker. In that setup, a verification mismatch is **not** something we want to fail the test step on — the broker has already recorded the result, and the gates downstream have richer matrix-wide visibility than a single CI run does.

But an infrastructure failure (verifier panic, broker auth failure, malformed config) absolutely should fail loudly: there's no result published, nothing to gate on, and the test pipeline is the only place that catches it.

Today there's no way to tell those two cases apart from outside the module — both surface as `error` from `VerifyProvider`, and the typed sentinels are locked inside `internal/native`. Callers either fail on everything or swallow everything.

After this change:

```go
err := verifier.VerifyProvider(t, request)
switch {
case errors.Is(err, provider.ErrVerificationFailed):
    // mismatch — broker has the record, downstream gates will decide
    t.Logf("verification mismatch (non-fatal): %v", err)
case err != nil:
    // infra failure — fail loudly
    t.Fatal(err)
}
```

## Why re-export rather than promote

The existing sentinels in `internal/native` are doing the right job. Moving them out of `internal/native` would be a larger surface change and would touch the internal verifier dispatch. Re-exporting via aliases keeps `internal/native` as the single source of truth and gives external callers a stable, discoverable API in the `provider` package where the rest of the verifier-facing types live.

The naming on the public side (`ErrVerificationFailed` vs the internal `ErrVerifierFailed`) is the only delta — `ErrVerificationFailed` reads more naturally next to `VerifyProvider`, and the doc comments are explicit about which case each one represents.

## Tests

Three small guard tests in `provider/errors_test.go`:

1. The public sentinels are identical to the internal ones (guards against accidental re-shadowing).
2. They don't match arbitrary errors.
3. The two sentinels are distinct from each other.

## Backwards compatibility

Pure addition. No existing exports change. `Verifier.VerifyProvider` returns the same `error` values it does today — callers that don't care about discrimination keep working unchanged.
