### PR TITLE
docs(native): note ErrVerifierFailed and ErrVerifierFailedToRun are mutually exclusive

### DIFF
--- a/internal/native/verifier.go
+++ b/internal/native/verifier.go
@@ -53,6 +53,9 @@ var (
 	// ErrInvalidVerifierConfig indicates an issue configuring the verifier
 	ErrInvalidVerifierConfig = fmt.Errorf("configuration for the verifier was invalid and an unknown error occurred (this is most likely a defect in the framework)")
 
+	// ErrVerifierFailed and ErrVerifierFailedToRun are mutually exclusive: a
+	// single Verifier call returns one or the other, never both.
+	//
 	//ErrVerifierFailed is the standard error if a verification failed (e.g. beacause the pact verification was not successful)
 	ErrVerifierFailed = fmt.Errorf("the verifier failed to successfully verify the pacts, this indicates an issue with the provider API")
 	//ErrVerifierFailedToRun indicates the verification process was unable to run


### PR DESCRIPTION
## Summary

Two-line comment on the `internal/native` sentinel definitions noting that `ErrVerifierFailed` and `ErrVerifierFailedToRun` are mutually exclusive — a single Verifier call returns one or the other, never both wrapped together.

## Why

In #577 (released as v2.5.0) these sentinels were re-exported through the public `provider/` package so callers can discriminate verification mismatches from infrastructure errors via `errors.Is`. The natural worry for any such caller is whether `errors.Is(err, ErrVerifierFailed)` could silently swallow an `ErrVerifierFailedToRun` sibling reachable via a wrapped join.

Concretely, this is the swallow shape that worries a caller:

```go
// Hypothetical: pact-go wraps a multi-error in fmt.Errorf with %w.
err := fmt.Errorf("suite: %w", errors.Join(ErrVerifierFailed, ErrVerifierFailedToRun))

// errors.Is descends through the fmt.Errorf wrapper into the Join's children
// and matches ErrVerifierFailed. Caller swallows on "mismatch" — and silently
// drops the co-occurring ErrVerifierFailedToRun.
if errors.Is(err, ErrVerifierFailed) {
    // logged as a verification mismatch; the infrastructure failure is gone
}
```

Looking at the switch (`internal/native/verifier.go`, around the `case 1:` / `case 2:` blocks), it's clear today the two sentinels are mutually exclusive by construction — `case 1: → ErrVerifierFailed`, `case 2: → ErrVerifierFailedToRun`, never both. This comment just documents that invariant inline so future readers don't have to re-derive it from the switch each time they touch these constants.

No behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
