### PR TITLE
feat(provider): add SoftFail mode for downstream-gated verification

### DIFF
--- a/provider/verifier.go
+++ b/provider/verifier.go
@@ -2,6 +2,7 @@ package provider
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log"
@@ -172,6 +173,16 @@ func (v *Verifier) verifyProviderRaw(request VerifyRequest, writer outputWriter)
 // VerifyProvider accepts an instance of `*testing.T`
 // running the provider verification with granular test reporting and
 // automatic failure reporting for nice, simple tests.
+//
+// The subtest "Provider pact verification" renders as:
+//   - PASS when verification succeeded;
+//   - SKIP (with the underlying error in the skip message) when
+//     request.SoftFail is true AND the error is a verification mismatch
+//     (errors.Is(err, ErrVerifierFailed)) — i.e. a downstream gate owns
+//     the authoritative compatibility decision;
+//   - FAIL otherwise — strict mode for any error, or soft-fail mode when
+//     the verifier itself could not produce a result (infrastructure
+//     error, panic, etc.).
 func (v *Verifier) VerifyProvider(t *testing.T, request VerifyRequest) error {
 	err := v.verifyProviderRaw(request, t)
 
@@ -179,7 +190,18 @@ func (v *Verifier) VerifyProvider(t *testing.T, request VerifyRequest) error {
 	// runTestCases(t, res)
 
 	t.Run("Provider pact verification", func(t *testing.T) {
-		if err != nil {
+		switch {
+		case err == nil:
+			// PASS — verification succeeded.
+		case request.SoftFail && errors.Is(err, native.ErrVerifierFailed):
+			// Soft-fail mode + verification mismatch: render as SKIP so the
+			// test framework does not propagate failure. The caller is
+			// responsible for gating elsewhere (e.g. broker can-i-merge).
+			t.Skipf("pact verification failed (soft-fail enabled, broker has the record): %v", err)
+		default:
+			// Strict mode + any error, OR soft-fail mode + infrastructure
+			// error: fail loudly. Infrastructure errors signal the verifier
+			// could not produce a result for downstream gates to act on.
 			t.Error(err)
 		}
 	})

--- a/provider/verify_request.go
+++ b/provider/verify_request.go
@@ -112,6 +112,23 @@ type VerifyRequest struct {
 	// PublishVerificationResults to the Pact Broker.
 	PublishVerificationResults bool
 
+	// SoftFail, when true, renders a verification mismatch (one or more
+	// consumer expectations not satisfied by the provider, returned by the
+	// verifier as ErrVerifierFailed) as a SKIPped subtest rather than a
+	// failed one. Use when the caller has a downstream gate — e.g. a Pact
+	// Broker can-i-merge / can-i-deploy check — that owns the authoritative
+	// compatibility decision, and local CI failure on the mismatch would
+	// duplicate or contradict that gate.
+	//
+	// Infrastructure errors (ErrVerifierFailedToRun, panics, broker auth
+	// failures, etc.) always fail the subtest regardless of this flag —
+	// they signal that the verifier could not produce a result for the
+	// downstream gate to act on.
+	//
+	// Default false preserves existing behavior: any verifier error fails
+	// the subtest.
+	SoftFail bool
+
 	// ProviderVersion is the semantical version of the Provider API.
 	ProviderVersion string
 


### PR DESCRIPTION
## Summary

Add `VerifyRequest.SoftFail` to let callers render verification mismatches as a SKIPped subtest instead of a failed one when a downstream gate (e.g. a Pact Broker `can-i-merge` / `can-i-deploy` check) owns the authoritative compatibility decision.

## Motivation

Callers wrapping pact-go in a larger contract-testing system commonly want this contract:

> Mismatches should be recorded to the broker (so the broker's matrix gates can act on them downstream) but should NOT fail the local `go test` step, because the downstream gates are authoritative and a local fail would either duplicate that signal or contradict it during coordinated rollouts.

Today, the only way to achieve this is at the shell layer (turning off `set -o pipefail` around `go test`), which silences **everything**, including:

- Verifier panics
- Broker connection failures
- Auth errors
- Configuration errors

That makes "tests didn't actually run but CI is green" a common silent failure mode. We want suppression to be **scoped to verification mismatches only** — infrastructure failures should still fail loudly.

This PR provides that scope via a per-request flag.

## API

A single new bool field on `VerifyRequest`:

```go
type VerifyRequest struct {
    // ... existing fields ...
    FailIfNoPactsFound         bool
    PublishVerificationResults bool
    SoftFail                   bool  // ← new
}
```

`SoftFail` sits next to the other per-request behavior toggles. Default `false` preserves existing behavior — no caller currently using pact-go sees any change.

## Behavior matrix

| `SoftFail` | Verifier result | Subtest outcome |
|---|---|---|
| `false` (default) | nil | PASS |
| `false` | `ErrVerifierFailed` (mismatch) | FAIL |
| `false` | `ErrVerifierFailedToRun` (infra) | FAIL |
| `true` | nil | PASS |
| `true` | `ErrVerifierFailed` (mismatch) | **SKIP** with the error in the skip message |
| `true` | `ErrVerifierFailedToRun` (infra) | FAIL |
| `true` | anything else (panic-wrapped, joined, unknown) | FAIL |

Discrimination uses `errors.Is(err, native.ErrVerifierFailed)`, leveraging the mutual-exclusivity invariant of the two verifier sentinels documented in #579.

## Implementation

Two-file change. `provider/verify_request.go` gets the new field with a thorough doc comment. `provider/verifier.go` switches the existing `if err != nil { t.Error(err) }` body of the subtest to a 3-way switch:

```go
t.Run("Provider pact verification", func(t *testing.T) {
    switch {
    case err == nil:
        // PASS — verification succeeded.
    case request.SoftFail && errors.Is(err, native.ErrVerifierFailed):
        t.Skipf("pact verification failed (soft-fail enabled, broker has the record): %v", err)
    default:
        t.Error(err)
    }
})
```

## Why SKIP (not PASS) for the soft-fail mismatch case

Go's stdlib `testing` package has three outcome states: PASS, FAIL, SKIP. Once a subtest calls `t.Error`/`t.Fatal`, the failure propagates to every ancestor and cannot be cleared — `c.failed = true` is set on the parent chain in `Fail()` ([Go stdlib source](https://github.com/golang/go/blob/master/src/testing/testing.go), search for `func (c *common) Fail()`).

That leaves three options for "verification ran, found mismatches, results published, caller deferred to downstream gate":

- **PASS + `t.Logf`**: dishonest — the test report claims verification passed, but verification actually reported mismatches.
- **FAIL**: defeats the entire feature — the test fails, propagating to the parent.
- **SKIP** with the error in the message: the least-wrong stdlib state. JUnit XML serializes as `<skipped message="..."/>`, which test dashboards already recognize as "look here for context." Maps cleanly to pytest's `xfail` semantic.

## Backwards compatibility

Pure addition. Zero behavior change for any existing caller (`SoftFail` defaults to `false`, which is the existing branch).

## Test plan

- [x] `go build ./provider/...` clean
- [x] `go vet ./provider/...` clean (one pre-existing IPv6 warning unrelated to this PR)
- [x] `go test ./provider/ -short` clean
- [ ] CI green

## Downstream

Confluent's `service-runtime-go` library will adopt this immediately once the release ships, replacing its current shell-layer workaround with a single `SoftFail: true` setting on `VerifyRequest`. Tracking PR in [confluentinc/service-runtime-go#1099](https://github.com/confluentinc/service-runtime-go/pull/1099) (the strict-mode env var) — this pact-go change is what makes that work correctly under all conditions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
