### PR TITLE
fix(installer): pin libpact_ffi semver range to the shipped minor

### DIFF
--- a/installer/installer.go
+++ b/installer/installer.go
@@ -387,9 +387,15 @@ const (
 
 var packages = map[string]packageInfo{
 	FFIPackage: {
-		libName:     "libpact_ffi",
-		version:     "0.5.6",
-		semverRange: ">= 0.4.0, < 1.0.0",
+		libName: "libpact_ffi",
+		version: "0.5.6",
+		// Pin to the shipped FFI minor. The bindings in this release reference
+		// symbols specific to this libpact_ffi minor, and past minors have both
+		// added and removed symbols, so a wider range lets a mismatched-but-in-range
+		// library already on disk pass CheckPackageInstall and skip reinstalling,
+		// which then fails at link/load time with undefined FFI symbols. Bump this
+		// in lockstep with version above.
+		semverRange: ">= 0.5.6, < 0.6.0",
 	},
 }
 

--- a/installer/installer_test.go
+++ b/installer/installer_test.go
@@ -255,3 +255,15 @@ func restoreMacOSInstallName() func() {
 func TestUpdateConfiguration(t *testing.T) {
 
 }
+
+// TestPackagesVersionSatisfiesOwnSemverRange guards against version/semverRange
+// drift: the FFI version compiled into each release must fall inside the semver
+// range used to accept an already-installed library. If they drift apart, a
+// fresh install of the shipped version can fail its own post-install check, or a
+// stale, mismatched library can pass the check and then break at link/load time.
+func TestPackagesVersionSatisfiesOwnSemverRange(t *testing.T) {
+	for pkg, info := range packages {
+		err := checkVersion(info.libName, info.version, info.semverRange)
+		assert.NoErrorf(t, err, "package %q: compiled-in version %q must satisfy its own semverRange %q", pkg, info.version, info.semverRange)
+	}
+}


### PR DESCRIPTION
Fixes #604.

The FFI semver range `>= 0.4.0, < 1.0.0` is far wider than any single release actually supports. A release's bindings reference symbols specific to the `libpact_ffi` minor it ships, and past minors have both added and removed symbols. So a stale, mismatched FFI already on disk passes `CheckPackageInstall`, `pact-go install` skips re-downloading it, and the build then fails at link/load time with an undefined FFI symbol (e.g. `undefined reference to 'pactffi_add_interaction_reference'`). `-f` papers over it, but the version check is exactly the guard that's meant to make `-f` unnecessary.

This pins the range to the shipped minor (`>= 0.5.6, < 0.6.0`) so an incompatible library is rejected and reinstalled, plus a test asserting the compiled-in `version` satisfies its own `semverRange` - a drift guard so this can't silently come back on the next FFI bump (move the range in lockstep with `version`).

Full repro and reasoning in #604.

🤖 **Generated by Claude** on behalf of @stan-is-hate. Code, tests and this description are all AI-authored - review accordingly.
