### PR TITLE
fix: check, propagate, or deliberately discard error returns

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -3,11 +3,18 @@ run:
   build-tags:
     - consumer
     - provider
+issues:
+  max-issues-per-linter: 0
+  max-same-issues: 0
 linters:
   enable:
     - dupword
+    - errorlint
     - godot
     - misspell
+    - nilerr
+    - nilnesserr
+    - noinlineerr
     - whitespace
   settings:
     dupword:

--- a/command/check.go
+++ b/command/check.go
@@ -28,7 +28,8 @@ var checkCmd = &cobra.Command{
 			i.SetLibDir(libDir)
 		}
 
-		if err = i.CheckPackageInstall(); err != nil {
+		err = i.CheckPackageInstall()
+		if err != nil {
 			log.Println("[DEBUG] error from CheckPackageInstall:", err)
 			log.Println("[ERROR] Your Pact library installation is out of date. Run `pact-go install` to correct")
 			os.Exit(1)

--- a/command/install.go
+++ b/command/install.go
@@ -33,7 +33,8 @@ var (
 
 			i.Force(force)
 
-			if err = i.CheckInstallation(); err != nil {
+			err = i.CheckInstallation()
+			if err != nil {
 				log.Println("[ERROR] Your Pact library installation is out of date and we were unable to download a newer one for you:", err)
 				os.Exit(1)
 			}

--- a/command/root.go
+++ b/command/root.go
@@ -29,7 +29,8 @@ service provider project.`,
 // Execute adds all child commands to the root command sets flags appropriately.
 // This is called by main.main(). It only needs to happen once to the rootCmd.
 func Execute() {
-	if err := RootCmd.Execute(); err != nil {
+	err := RootCmd.Execute()
+	if err != nil {
 		fmt.Println(err)
 		os.Exit(-1)
 	}

--- a/consumer/http_v2.go
+++ b/consumer/http_v2.go
@@ -150,7 +150,8 @@ func (i *V2RequestBuilder) Headers(headers matchers.HeadersMatcher) *V2RequestBu
 // JSONBody adds a JSON body to the expected request.
 func (i *V2RequestBuilder) JSONBody(body interface{}) *V2RequestBuilder {
 	// TODO: Don't like panic, but not sure if there is a better builder experience?
-	if err := validateMatchers(i.interaction.specificationVersion, body); err != nil {
+	err := validateMatchers(i.interaction.specificationVersion, body)
+	if err != nil {
 		panic(err)
 	}
 
@@ -253,7 +254,8 @@ func (i *V2ResponseBuilder) Headers(headers matchers.HeadersMatcher) *V2Response
 // JSONBody adds a JSON body to the expected response.
 func (i *V2ResponseBuilder) JSONBody(body interface{}) *V2ResponseBuilder {
 	// TODO: Don't like panic, how to build a better builder here - nil return + log?
-	if err := validateMatchers(i.interaction.specificationVersion, body); err != nil {
+	err := validateMatchers(i.interaction.specificationVersion, body)
+	if err != nil {
 		panic(err)
 	}
 

--- a/consumer/http_v3.go
+++ b/consumer/http_v3.go
@@ -161,7 +161,8 @@ func (i *V3RequestBuilder) Headers(headers matchers.HeadersMatcher) *V3RequestBu
 // JSONBody adds a JSON body to the expected request.
 func (i *V3RequestBuilder) JSONBody(body interface{}) *V3RequestBuilder {
 	// TODO: Don't like panic, but not sure if there is a better builder experience?
-	if err := validateMatchers(i.interaction.specificationVersion, body); err != nil {
+	err := validateMatchers(i.interaction.specificationVersion, body)
+	if err != nil {
 		panic(err)
 	}
 
@@ -264,7 +265,8 @@ func (i *V3ResponseBuilder) Headers(headers matchers.HeadersMatcher) *V3Response
 // JSONBody adds a JSON body to the expected response.
 func (i *V3ResponseBuilder) JSONBody(body interface{}) *V3ResponseBuilder {
 	// TODO: Don't like panic, how to build a better builder here - nil return + log?
-	if err := validateMatchers(i.interaction.specificationVersion, body); err != nil {
+	err := validateMatchers(i.interaction.specificationVersion, body)
+	if err != nil {
 		panic(err)
 	}
 

--- a/consumer/http_v4.go
+++ b/consumer/http_v4.go
@@ -171,7 +171,8 @@ func (i *V4RequestBuilder) Headers(headers matchers.HeadersMatcher) *V4RequestBu
 // JSONBody adds a JSON body to the expected request.
 func (i *V4RequestBuilder) JSONBody(body interface{}) *V4RequestBuilder {
 	// TODO: Don't like panic, but not sure if there is a better builder experience?
-	if err := validateMatchers(i.interaction.specificationVersion, body); err != nil {
+	err := validateMatchers(i.interaction.specificationVersion, body)
+	if err != nil {
 		panic(err)
 	}
 
@@ -274,7 +275,8 @@ func (i *V4ResponseBuilder) Headers(headers matchers.HeadersMatcher) *V4Response
 // JSONBody adds a JSON body to the expected response.
 func (i *V4ResponseBuilder) JSONBody(body interface{}) *V4ResponseBuilder {
 	// TODO: Don't like panic, how to build a better builder here - nil return + log?
-	if err := validateMatchers(i.interaction.specificationVersion, body); err != nil {
+	err := validateMatchers(i.interaction.specificationVersion, body)
+	if err != nil {
 		panic(err)
 	}
 
@@ -477,7 +479,8 @@ func (i *V4InteractionWithPluginRequestBuilder) PluginContents(contentType strin
 // JSONBody adds a JSON body to the expected request.
 func (i *V4InteractionWithPluginRequestBuilder) JSONBody(body interface{}) *V4InteractionWithPluginRequestBuilder {
 	// TODO: Don't like panic, but not sure if there is a better builder experience?
-	if err := validateMatchers(i.interaction.specificationVersion, body); err != nil {
+	err := validateMatchers(i.interaction.specificationVersion, body)
+	if err != nil {
 		panic(err)
 	}
 
@@ -562,7 +565,8 @@ func (i *V4InteractionWithPluginResponseBuilder) PluginContents(contentType stri
 // JSONBody adds a JSON body to the expected response.
 func (i *V4InteractionWithPluginResponseBuilder) JSONBody(body interface{}) *V4InteractionWithPluginResponseBuilder {
 	// TODO: Don't like panic, how to build a better builder here - nil return + log?
-	if err := validateMatchers(i.interaction.specificationVersion, body); err != nil {
+	err := validateMatchers(i.interaction.specificationVersion, body)
+	if err != nil {
 		panic(err)
 	}
 

--- a/consumer/interaction.go
+++ b/consumer/interaction.go
@@ -63,10 +63,15 @@ func validateMatchers(version models.SpecificationVersion, obj interface{}) erro
 		return err
 	}
 
-	var maybeMatchers map[string]interface{}
-	err = json.Unmarshal(str, &maybeMatchers)
+	var raw interface{}
+	err = json.Unmarshal(str, &raw)
 	if err != nil {
-		// This means the object is not really an object, it's probably a primitive
+		return err
+	}
+
+	maybeMatchers, ok := raw.(map[string]interface{})
+	if !ok {
+		// Not a JSON object (e.g. a string, number, or array) - nothing to validate.
 		return nil
 	}
 

--- a/examples/avro/avro_provider_test.go
+++ b/examples/avro/avro_provider_test.go
@@ -58,8 +58,11 @@ func startHTTPProvider(port int) {
 			log.Println("ERROR: ", err)
 			w.WriteHeader(500)
 		} else {
-			w.Write(binary)
 			w.WriteHeader(200)
+			_, writeErr := w.Write(binary)
+			if writeErr != nil {
+				log.Println("ERROR writing response body: ", writeErr)
+			}
 		}
 	})
 

--- a/examples/consumer_v2_test.go
+++ b/examples/consumer_v2_test.go
@@ -37,7 +37,7 @@ var (
 type Map = matchers.MapMatcher
 
 func TestConsumerV2(t *testing.T) {
-	log.SetLogLevel("INFO")
+	assert.NoError(t, log.SetLogLevel("INFO"))
 
 	mockProvider, err := consumer.NewV2Pact(consumer.MockHTTPProviderConfig{
 		Consumer: "PactGoV2Consumer",
@@ -49,7 +49,7 @@ func TestConsumerV2(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Set up our expected interactions.
-	mockProvider.
+	err = mockProvider.
 		AddInteraction().
 		Given("User foo exists").
 		UponReceiving("A request to do a foo").
@@ -77,11 +77,12 @@ func TestConsumerV2(t *testing.T) {
 			})
 		}).
 		ExecuteTest(t, test)
+
 	assert.NoError(t, err)
 }
 
 func TestConsumerV2_Match(t *testing.T) {
-	log.SetLogLevel("INFO")
+	assert.NoError(t, log.SetLogLevel("INFO"))
 
 	mockProvider, err := consumer.NewV2Pact(consumer.MockHTTPProviderConfig{
 		Consumer: "PactGoV2ConsumerMatch",
@@ -93,7 +94,7 @@ func TestConsumerV2_Match(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Set up our expected interactions.
-	mockProvider.
+	err = mockProvider.
 		AddInteraction().
 		Given("User foo exists").
 		UponReceiving("A request to do a foo").
@@ -112,7 +113,7 @@ func TestConsumerV2_Match(t *testing.T) {
 }
 
 func TestConsumerV2AllInOne(t *testing.T) {
-	log.SetLogLevel("INFO")
+	assert.NoError(t, log.SetLogLevel("INFO"))
 
 	mockProvider, err := consumer.NewV2Pact(consumer.MockHTTPProviderConfig{
 		Consumer: "PactGoV2ConsumerAllInOne",

--- a/examples/consumer_v3_test.go
+++ b/examples/consumer_v3_test.go
@@ -32,7 +32,7 @@ var (
 )
 
 func TestConsumerV3(t *testing.T) {
-	log.SetLogLevel("INFO")
+	assert.NoError(t, log.SetLogLevel("INFO"))
 
 	mockProvider, err := consumer.NewV3Pact(consumer.MockHTTPProviderConfig{
 		Consumer: "PactGoV3Consumer",
@@ -92,7 +92,7 @@ func TestConsumerV3(t *testing.T) {
 }
 
 func TestMessagePact(t *testing.T) {
-	log.SetLogLevel("INFO")
+	assert.NoError(t, log.SetLogLevel("INFO"))
 
 	provider, err := message.NewMessagePact(message.Config{
 		Consumer: "PactGoV3MessageConsumer",

--- a/examples/consumer_v4_test.go
+++ b/examples/consumer_v4_test.go
@@ -14,7 +14,7 @@ import (
 )
 
 func TestConsumerV4(t *testing.T) {
-	log.SetLogLevel("INFO")
+	assert.NoError(t, log.SetLogLevel("INFO"))
 
 	mockProvider, err := consumer.NewV4Pact(consumer.MockHTTPProviderConfig{
 		Consumer: "PactGoV4Consumer",

--- a/examples/grpc/grpc_consumer_test.go
+++ b/examples/grpc/grpc_consumer_test.go
@@ -27,7 +27,7 @@ func TestGetFeatureSuccess(t *testing.T) {
 		Provider: "grpcprovider",
 		PactDir:  filepath.ToSlash(fmt.Sprintf("%s/../pacts", dir)),
 	})
-	log.SetLogLevel("DEBUG")
+	assert.NoError(t, log.SetLogLevel("DEBUG"))
 
 	dir, _ := os.Getwd()
 	path := fmt.Sprintf("%s/routeguide/route_guide.proto", strings.ReplaceAll(dir, "\\", "/"))
@@ -65,7 +65,7 @@ func TestGetFeatureSuccess(t *testing.T) {
 			if err != nil {
 				t.Fatal("unable to communicate to grpc server", err)
 			}
-			defer conn.Close()
+			defer func() { _ = conn.Close() }() // best-effort cleanup; error is not actionable in a test
 
 			// Create the gRPC client
 			c := routeguide.NewRouteGuideClient(conn)
@@ -94,7 +94,7 @@ func TestGetFeatureSuccess(t *testing.T) {
 }
 
 func TestGetFeatureError(t *testing.T) {
-	log.SetLogLevel("DEBUG")
+	assert.NoError(t, log.SetLogLevel("DEBUG"))
 	p, _ := message.NewSynchronousPact(message.Config{
 		Consumer: "grpcconsumer",
 		Provider: "grpcprovider",
@@ -132,7 +132,7 @@ func TestGetFeatureError(t *testing.T) {
 			// Establish the gRPC connection
 			conn, err := grpc.NewClient(fmt.Sprintf("127.0.0.1:%d", transport.Port), grpc.WithTransportCredentials(insecure.NewCredentials()))
 			require.NoError(t, err)
-			defer conn.Close()
+			defer func() { _ = conn.Close() }() // best-effort cleanup; error is not actionable in a test
 
 			// Create the gRPC client
 			c := routeguide.NewRouteGuideClient(conn)
@@ -164,7 +164,7 @@ func TestSaveFeature(t *testing.T) {
 		Provider: "grpcprovider",
 		PactDir:  filepath.ToSlash(fmt.Sprintf("%s/../pacts", dir)),
 	})
-	log.SetLogLevel("INFO")
+	assert.NoError(t, log.SetLogLevel("INFO"))
 
 	dir, _ := os.Getwd()
 	path := fmt.Sprintf("%s/routeguide/route_guide.proto", strings.ReplaceAll(dir, "\\", "/"))
@@ -205,7 +205,7 @@ func TestSaveFeature(t *testing.T) {
 			if err != nil {
 				t.Fatal("unable to communicate to grpc server", err)
 			}
-			defer conn.Close()
+			defer func() { _ = conn.Close() }() // best-effort cleanup; error is not actionable in a test
 
 			// Create the gRPC client
 			c := routeguide.NewRouteGuideClient(conn)

--- a/examples/grpc/grpc_provider_test.go
+++ b/examples/grpc/grpc_provider_test.go
@@ -20,7 +20,7 @@ import (
 
 func TestGrpcProvider(t *testing.T) {
 	go startProvider()
-	l.SetLogLevel("INFO")
+	assert.NoError(t, l.SetLogLevel("INFO"))
 
 	verifier := provider.NewVerifier()
 
@@ -49,5 +49,8 @@ func startProvider() {
 	var opts []grpc.ServerOption
 	grpcServer := grpc.NewServer(opts...)
 	pb.RegisterRouteGuideServer(grpcServer, server.NewServer())
-	grpcServer.Serve(lis)
+	err = grpcServer.Serve(lis)
+	if err != nil {
+		log.Printf("failed to serve: %v", err)
+	}
 }

--- a/examples/grpc/routeguide/server/server.go
+++ b/examples/grpc/routeguide/server/server.go
@@ -25,6 +25,7 @@ package server
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -92,7 +93,8 @@ func (s *routeGuideServer) SaveFeature(ctx context.Context, feature *pb.Feature)
 func (s *routeGuideServer) ListFeatures(rect *pb.Rectangle, stream pb.RouteGuide_ListFeaturesServer) error {
 	for _, feature := range s.savedFeatures {
 		if inRange(feature.Location, rect) {
-			if err := stream.Send(feature); err != nil {
+			err := stream.Send(feature)
+			if err != nil {
 				return err
 			}
 		}
@@ -111,7 +113,7 @@ func (s *routeGuideServer) RecordRoute(stream pb.RouteGuide_RecordRouteServer) e
 	startTime := time.Now()
 	for {
 		point, err := stream.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			endTime := time.Now()
 			return stream.SendAndClose(&pb.RouteSummary{
 				PointCount:   pointCount,
@@ -141,7 +143,7 @@ func (s *routeGuideServer) RecordRoute(stream pb.RouteGuide_RecordRouteServer) e
 func (s *routeGuideServer) RouteChat(stream pb.RouteGuide_RouteChatServer) error {
 	for {
 		in, err := stream.Recv()
-		if err == io.EOF {
+		if errors.Is(err, io.EOF) {
 			return nil
 		}
 		if err != nil {
@@ -159,7 +161,8 @@ func (s *routeGuideServer) RouteChat(stream pb.RouteGuide_RouteChatServer) error
 		s.mu.Unlock()
 
 		for _, note := range rn {
-			if err := stream.Send(note); err != nil {
+			err := stream.Send(note)
+			if err != nil {
 				return err
 			}
 		}
@@ -178,7 +181,8 @@ func (s *routeGuideServer) loadFeatures(filePath string) {
 	} else {
 		data = exampleData
 	}
-	if err := json.Unmarshal(data, &s.savedFeatures); err != nil {
+	err := json.Unmarshal(data, &s.savedFeatures)
+	if err != nil {
 		log.Fatalf("Failed to load default features: %v", err)
 	}
 }
@@ -255,7 +259,8 @@ func main() {
 	}
 	grpcServer := grpc.NewServer(opts...)
 	pb.RegisterRouteGuideServer(grpcServer, NewServer())
-	if err := grpcServer.Serve(lis); err != nil {
+	err = grpcServer.Serve(lis)
+	if err != nil {
 		log.Fatalf("failed to serve: %v", err)
 	}
 }

--- a/examples/plugin/consumer_plugin_test.go
+++ b/examples/plugin/consumer_plugin_test.go
@@ -119,7 +119,10 @@ func callMattServiceTCP(transport message.TransportConfig, message string) (stri
 		return "", err
 	}
 
-	conn.Write([]byte(generateMattMessage(message)))
+	_, err = conn.Write([]byte(generateMattMessage(message)))
+	if err != nil {
+		return "", err
+	}
 
 	str, err := bufio.NewReader(conn).ReadString('\n')
 	if err != nil {

--- a/examples/plugin/provider_plugin_test.go
+++ b/examples/plugin/provider_plugin_test.go
@@ -56,8 +56,11 @@ func startHTTPProvider(port int) {
 
 	mux.HandleFunc("/matt", func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Add("Content-Type", "application/matt")
-		fmt.Fprintf(w, `MATTworldMATT`)
 		w.WriteHeader(200)
+		_, err := fmt.Fprintf(w, `MATTworldMATT`)
+		if err != nil {
+			log.Println("ERROR writing response body:", err)
+		}
 	})
 
 	log.Printf("started HTTP server on port: %d\n", port)
@@ -88,7 +91,7 @@ func startTCPServer(port int) {
 
 func handleConnection(conn net.Conn) {
 	log.Println("Handling TCP connection")
-	defer conn.Close()
+	defer func() { _ = conn.Close() }() // best-effort cleanup; error is not actionable in a test server
 
 	s := bufio.NewScanner(conn)
 
@@ -109,13 +112,19 @@ func handleRequest(req string, conn net.Conn) {
 
 	if !isValidMessage(req) {
 		log.Println("TCP Server received invalid request, erroring")
-		conn.Write([]byte("ERROR\n"))
+		_, err := conn.Write([]byte("ERROR\n"))
+		if err != nil {
+			log.Println("ERROR writing to connection:", err)
+		}
 	}
 	log.Println("TCP Server received valid request, responding")
 
 	// var expectedResponse = "badworld"
 	expectedResponse := "tcpworld"
-	conn.Write([]byte(generateMattMessage(expectedResponse)))
+	_, err := conn.Write([]byte(generateMattMessage(expectedResponse)))
+	if err != nil {
+		log.Println("ERROR writing to connection:", err)
+	}
 }
 
 func isValidMessage(str string) bool {

--- a/examples/provider_test.go
+++ b/examples/provider_test.go
@@ -31,7 +31,7 @@ var (
 )
 
 func TestV3HTTPProvider(t *testing.T) {
-	log.SetLogLevel("DEBUG")
+	assert.NoError(t, log.SetLogLevel("DEBUG"))
 	version.CheckVersion()
 
 	// Start provider API in the background
@@ -145,7 +145,7 @@ func TestV3HTTPProvider(t *testing.T) {
 }
 
 func TestV3MessageProvider(t *testing.T) {
-	log.SetLogLevel("DEBUG")
+	assert.NoError(t, log.SetLogLevel("DEBUG"))
 	var user *User
 
 	verifier := provider.NewVerifier()
@@ -184,7 +184,7 @@ func TestV3MessageProvider(t *testing.T) {
 	// Verify the Provider with local Pact Files
 
 	if os.Getenv("SKIP_PUBLISH") != "true" {
-		verifier.VerifyProvider(t, provider.VerifyRequest{
+		err := verifier.VerifyProvider(t, provider.VerifyRequest{
 			StateHandlers:   stateMappings,
 			Provider:        "V3MessageProvider",
 			ProviderVersion: os.Getenv("APP_SHA"),
@@ -192,13 +192,15 @@ func TestV3MessageProvider(t *testing.T) {
 			BrokerURL:       os.Getenv("PACT_BROKER_BASE_URL"),
 			MessageHandlers: functionMappings,
 		})
+		assert.NoError(t, err)
 	} else {
-		verifier.VerifyProvider(t, provider.VerifyRequest{
+		err := verifier.VerifyProvider(t, provider.VerifyRequest{
 			PactFiles:       []string{filepath.ToSlash(fmt.Sprintf("%s/PactGoV3MessageConsumer-V3MessageProvider.json", pactDir))},
 			StateHandlers:   stateMappings,
 			Provider:        "V3MessageProvider",
 			MessageHandlers: functionMappings,
 		})
+		assert.NoError(t, err)
 	}
 }
 
@@ -207,7 +209,7 @@ func startServer() {
 
 	mux.HandleFunc("/foobar", func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Add("Content-Type", "application/json")
-		fmt.Fprintf(w, `
+		_, err := fmt.Fprintf(w, `
 			{
 				"accountBalance": 123.76,
 				"datetime": "2020-01-01",
@@ -237,6 +239,9 @@ func startServer() {
 				]
 			}`,
 		)
+		if err != nil {
+			l.Println("[ERROR] failed to write response body:", err)
+		}
 	})
 
 	l.Fatal(http.ListenAndServe("127.0.0.1:8111", mux))

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -98,25 +98,29 @@ func (i *Installer) CheckInstallation() error {
 	// Check if files exist
 	// --> Check if existing installed files
 	if !i.force {
-		if err := i.CheckPackageInstall(); err == nil {
+		err := i.CheckPackageInstall()
+		if err == nil {
 			return nil
 		}
 	}
 
 	// Download dependencies
-	if err := i.downloadDependencies(); err != nil {
+	err := i.downloadDependencies()
+	if err != nil {
 		return err
 	}
 
 	// Install dependencies
-	if err := i.installDependencies(); err != nil {
+	err = i.installDependencies()
+	if err != nil {
 		return err
 	}
 
 	// Double check files landed correctly (can't execute 'version' call here,
 	// because of dependency on the native libs we're trying to download!)
-	if err := i.CheckPackageInstall(); err != nil {
-		return fmt.Errorf("unable to verify downloaded/installed dependencies: %s", err)
+	err = i.CheckPackageInstall()
+	if err != nil {
+		return fmt.Errorf("unable to verify downloaded/installed dependencies: %w", err)
 	}
 
 	return nil
@@ -140,7 +144,8 @@ func (i *Installer) CheckPackageInstall() error {
 	for pkg, info := range packages {
 		dst, _ := i.getLibDstForPackage(pkg)
 
-		if _, err := i.fs.Stat(dst); err != nil {
+		_, err := i.fs.Stat(dst)
+		if err != nil {
 			log.Println("[INFO] package", info.libName, "not found")
 			return err
 		} else {
@@ -149,7 +154,8 @@ func (i *Installer) CheckPackageInstall() error {
 
 		lib, ok := i.config.readConfig().Libraries[pkg]
 		if ok {
-			if err := checkVersion(info.libName, lib.Version, info.semverRange); err != nil {
+			err := checkVersion(info.libName, lib.Version, info.semverRange)
+			if err != nil {
 				return err
 			}
 			log.Println("[INFO] package", info.libName, "is correctly installed")
@@ -166,7 +172,8 @@ func (i *Installer) CheckPackageInstall() error {
 
 			if ok {
 				log.Println("[INFO] checking version", lib.Version(), "for lib", info.libName, "within semver range", info.semverRange)
-				if err := checkVersion(info.libName, lib.Version(), info.semverRange); err != nil {
+				err := checkVersion(info.libName, lib.Version(), info.semverRange)
+				if err != nil {
 					return err
 				}
 			} else {
@@ -287,7 +294,7 @@ var setMacOSInstallName = func(file string) error {
 	log.Println("[DEBUG] running command:", cmd)
 	stdoutStderr, err := cmd.CombinedOutput()
 	if err != nil {
-		return fmt.Errorf("error setting install name on pact lib: %s", err)
+		return fmt.Errorf("error setting install name on pact lib: %w", err)
 	}
 
 	log.Println("[DEBUG] output from command", string(stdoutStderr))
@@ -402,7 +409,8 @@ func (d *defaultDownloader) download(src string, dst string) error {
 	log.Println("[INFO] downloading library from", src, "to", dst)
 
 	baseDir := path.Dir(dst)
-	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+	err := os.MkdirAll(baseDir, 0o755)
+	if err != nil {
 		return fmt.Errorf("failed to create %s; %w", baseDir, err)
 	}
 
@@ -525,7 +533,8 @@ func (d *defaultHasher) hash(src string) (string, error) {
 	}()
 
 	h := md5.New()
-	if _, err := io.Copy(h, f); err != nil {
+	_, err = io.Copy(h, f)
+	if err != nil {
 		return "", err
 	}
 

--- a/matchers/matcher.go
+++ b/matchers/matcher.go
@@ -394,21 +394,25 @@ func pluckParams(srcType reflect.Type, pactTag string) params {
 
 	switch kind := srcType.Kind(); kind {
 	case reflect.Bool:
-		if _, err := fmt.Sscanf(pactTag, "example=%t", &params.boolean.value); err != nil {
+		_, err := fmt.Sscanf(pactTag, "example=%t", &params.boolean.value)
+		if err != nil {
 			triggerInvalidPactTagPanic(pactTag, err)
 		}
 		params.boolean.defined = true
 	case reflect.Float32, reflect.Float64:
-		if _, err := fmt.Sscanf(pactTag, "example=%g", &params.number.float); err != nil {
+		_, err := fmt.Sscanf(pactTag, "example=%g", &params.number.float)
+		if err != nil {
 			triggerInvalidPactTagPanic(pactTag, err)
 		}
 	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
 		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
-		if _, err := fmt.Sscanf(pactTag, "example=%d", &params.number.integer); err != nil {
+		_, err := fmt.Sscanf(pactTag, "example=%d", &params.number.integer)
+		if err != nil {
 			triggerInvalidPactTagPanic(pactTag, err)
 		}
 	case reflect.Slice:
-		if _, err := fmt.Sscanf(pactTag, "min=%d", &params.slice.min); err != nil {
+		_, err := fmt.Sscanf(pactTag, "min=%d", &params.slice.min)
+		if err != nil {
 			triggerInvalidPactTagPanic(pactTag, err)
 		}
 	case reflect.String:
@@ -422,7 +426,8 @@ func pluckParams(srcType reflect.Type, pactTag string) params {
 				triggerInvalidPactTagPanic(pactTag, fmt.Errorf("invalid format: regex must not be empty"))
 			}
 
-			if _, err := fmt.Sscanf(components[0], "example=%s", &params.str.example); err != nil {
+			_, err := fmt.Sscanf(components[0], "example=%s", &params.str.example)
+			if err != nil {
 				triggerInvalidPactTagPanic(pactTag, err)
 			}
 			params.str.regEx = components[1]

--- a/matchers/matcher_test.go
+++ b/matchers/matcher_test.go
@@ -488,7 +488,7 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 				match, err := regexp.MatchString(uuid, v.(string))
 
 				if !match {
-					err = fmt.Errorf("want string, got '%v'. Err: %v", v, err)
+					err = fmt.Errorf("want string, got '%v'", v)
 				}
 				return
 			},
@@ -496,7 +496,8 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 	}
 	var err error
 	for k, v := range matchers {
-		if err = v.testCase(getMatcherValue(v.matcher)); err != nil {
+		err = v.testCase(getMatcherValue(v.matcher))
+		if err != nil {
 			t.Fatalf("error validating matcher '%s': %v", k, err)
 		}
 	}

--- a/message/v3/asynchronous_message.go
+++ b/message/v3/asynchronous_message.go
@@ -225,7 +225,7 @@ func (p *AsynchronousPact) verifyMessageConsumerRaw(messageToVerify *Asynchronou
 		// }
 		err = json.Unmarshal(body, &messageToVerify.Type)
 		if err != nil {
-			return fmt.Errorf("unable to narrow type to %v: %v", t.Name(), err)
+			return fmt.Errorf("unable to narrow type to %v: %w", t.Name(), err)
 		}
 
 		m.Content = messageToVerify.Type

--- a/message/v4/asynchronous_message.go
+++ b/message/v4/asynchronous_message.go
@@ -327,7 +327,7 @@ func getAsynchronousMessageWithReifiedContents(message *native.Message, reifiedT
 
 	m, err = getAsynchronousMessageWithContents(message)
 	if err != nil {
-		return m, fmt.Errorf("unexpected response from message server, this is a bug in the framework: %v", err)
+		return m, fmt.Errorf("unexpected response from message server, this is a bug in the framework: %w", err)
 	}
 	log.Println("[DEBUG] reified body raw", string(m.Contents))
 
@@ -345,7 +345,7 @@ func getAsynchronousMessageWithReifiedContents(message *native.Message, reifiedT
 	if t != nil && t.Name() != "interface" {
 		err = json.Unmarshal(m.Contents, &reifiedType)
 		if err != nil {
-			return m, fmt.Errorf("unable to narrow type to %v: %v", t.Name(), err)
+			return m, fmt.Errorf("unable to narrow type to %v: %w", t.Name(), err)
 		}
 
 		m.Body = reifiedType

--- a/message/verifier.go
+++ b/message/verifier.go
@@ -60,7 +60,8 @@ func CreateMessageHandler(messageHandlers Handlers) proxy.Middleware {
 				// Extract message
 				var message messageVerificationHandlerRequest
 				body, err := io.ReadAll(r.Body)
-				if closeErr := r.Body.Close(); closeErr != nil {
+				closeErr := r.Body.Close()
+				if closeErr != nil {
 					log.Println("[WARN] failed to close request body:", closeErr)
 				}
 				log.Printf("[TRACE] message verification handler received request: %+s, %s", body, r.URL.Path)
@@ -91,7 +92,7 @@ func CreateMessageHandler(messageHandlers Handlers) proxy.Middleware {
 				res, metadata, handlerErr := f(message.States)
 
 				if handlerErr != nil {
-					log.Printf("[ERROR] error executive message handler %s", err)
+					log.Printf("[ERROR] error executive message handler %s", handlerErr)
 					w.WriteHeader(http.StatusServiceUnavailable)
 					return
 				}

--- a/provider/verifier.go
+++ b/provider/verifier.go
@@ -159,7 +159,7 @@ func (v *Verifier) verifyProviderRaw(request VerifyRequest, writer outputWriter)
 		fmt.Sprintf(`Timed out waiting for http verification proxy on port %d - check for errors`, port))
 
 	if portErr != nil {
-		log.Fatal("Error:", err)
+		log.Println("[ERROR]", portErr)
 		return portErr
 	}
 

--- a/provider/verify_request.go
+++ b/provider/verify_request.go
@@ -258,7 +258,7 @@ func (v *VerifyRequest) validate(handle *native.Verifier) error {
 		for i, selector := range v.ConsumerVersionSelectors {
 			body, err := json.Marshal(selector)
 			if err != nil {
-				return fmt.Errorf("invalid consumer version selector specified: %v", err)
+				return fmt.Errorf("invalid consumer version selector specified: %w", err)
 			}
 
 			selectors[i] = string(body)

--- a/provider/verify_request_test.go
+++ b/provider/verify_request_test.go
@@ -114,11 +114,13 @@ func TestVerifyRequest(t *testing.T) {
 		const webhookURL, verificationUrl = "pact_changed_webhook_url", "http://localhost:1234/path/to/pact"
 		enablePactUrlFunc := func() func() {
 			const pactUrl = "PACT_URL"
-			if err := os.Setenv(pactUrl, webhookURL); err != nil {
+			err := os.Setenv(pactUrl, webhookURL)
+			if err != nil {
 				panic(err)
 			}
 			return func() {
-				if err := os.Unsetenv(pactUrl); err != nil {
+				err := os.Unsetenv(pactUrl)
+				if err != nil {
 					panic(err)
 				}
 			}

--- a/version/version.go
+++ b/version/version.go
@@ -10,7 +10,8 @@ import (
 // and will attempt to download the files to the default or configured directory if
 // incorrect.
 func CheckVersion() {
-	if err := checker.CheckInstall(); err != nil {
+	err := checker.CheckInstall()
+	if err != nil {
 		log.Fatal("check version failed:", err)
 	}
 


### PR DESCRIPTION
## Summary

Enables `errcheck` uncapped plus `errorlint`, `nilerr`, `nilnesserr` and `noinlineerr`, and fixes every finding. Four bugs fall out of it.

## Motivation

The default per-linter cap of 3 was hiding two thirds of errcheck's backlog — 27 findings, 9 visible. Raising it to 0 surfaced the rest, and triaging them individually turned up real defects rather than just noise.

## Notes for reviewers

This is the first PR in the stack that changes runtime behaviour, and it is small on purpose. The four bugs:

- `message/verifier.go` and `provider/verifier.go` each logged an earlier, already-nil `err` instead of the live one, so every message-handler failure logged `<nil>` and a verification-proxy timeout printed `Error: <nil>` before exiting.
- `provider/verifier.go` called `log.Fatal` on that timeout, killing the test binary and leaving `return portErr` dead. It now logs without exiting so `VerifyProvider` turns it into a `t.Error`/`t.Skipf` on the named subtest. **No existing test covers this path.**
- `examples/consumer_v2_test.go` discarded `ExecuteTest`'s return in two tests, so the trailing `assert.NoError` re-checked an always-nil setup error. Neither test could ever have failed.

Every `_ =` discard carries a one-line reason. CI lint is still red here on three findings (one `govet`, two `staticcheck` deprecations) that #613 fixes.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
