### PR TITLE
fix: enable resource, type safety and gosec linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,12 +8,16 @@ issues:
   max-same-issues: 0
 linters:
   enable:
+    - bodyclose
     - dupword
     - errorlint
+    - exhaustive
+    - forcetypeassert
     - godot
     - misspell
     - nilerr
     - nilnesserr
+    - noctx
     - noinlineerr
     - whitespace
   settings:
@@ -27,19 +31,14 @@ linters:
       # lib.go only contains cgo annotations
       - internal/native/lib.go
     rules:
-      # TEMPORARY. Adding consumer/provider to run.build-tags brings ~3,600
-      # previously uncompiled lines under examples/ into scope, and the linters
-      # already on by default immediately report 21 findings there: 18 errcheck,
-      # one govet hostport and two staticcheck SA1019 deprecations. Fixing them
-      # here would pull the error-handling and safety work forward out of the
-      # commits that own it, so the examples are excused from those three
-      # linters until it lands. Remove this rule once the safety pass fixes the
-      # last of them.
-      - path: ^examples/
+      # matchers/matcher.go switches over reflect.Kind to build Pact matchers.
+      # Kinds with no JSON representation (Chan, Func, Complex*, ...) have no
+      # meaningful matcher and are handled by an explicit default case; scoped
+      # to this file only so exhaustive still catches a missing case in a real
+      # enum switch (e.g. models.SpecificationVersion) elsewhere in the repo.
+      - path: matchers/matcher\.go
         linters:
-          - errcheck
-          - govet
-          - staticcheck
+          - exhaustive
 formatters:
   enable:
     - gofumpt

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -14,6 +14,7 @@ linters:
     - exhaustive
     - forcetypeassert
     - godot
+    - gosec
     - misspell
     - nilerr
     - nilnesserr

--- a/consumer/http_v4_test.go
+++ b/consumer/http_v4_test.go
@@ -1,6 +1,7 @@
 package consumer
 
 import (
+	"context"
 	"fmt"
 	"net/http"
 	"os"
@@ -96,8 +97,16 @@ func TestV4HTTPAddExternalReference(t *testing.T) {
 		WithRequest("GET", "/", func(b *V4RequestBuilder) {}).
 		WillRespondWith(200, func(b *V4ResponseBuilder) {}).
 		ExecuteTest(t, func(msc MockServerConfig) error {
-			_, err := http.Get(fmt.Sprintf("http://%s:%d/", msc.Host, msc.Port))
-			return err
+			req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, fmt.Sprintf("http://%s:%d/", msc.Host, msc.Port), nil)
+			if err != nil {
+				return err
+			}
+			res, err := http.DefaultClient.Do(req)
+			if err != nil {
+				return err
+			}
+			defer func() { _ = res.Body.Close() }()
+			return nil
 		})
 	assert.NoError(t, err)
 }

--- a/consumer/interaction.go
+++ b/consumer/interaction.go
@@ -88,8 +88,15 @@ func hasMatcherGreaterThanSpec(version models.SpecificationVersion, obj map[stri
 	results := make([]string, 0)
 
 	for k, v := range obj {
-		if k == "pact:specification" && v.(string) > string(version) {
-			results = append(results, obj["pact:matcher:type"].(string))
+		specVersion, ok := v.(string)
+		if k == "pact:specification" && ok && specVersion > string(version) {
+			matcherType, ok := obj["pact:matcher:type"].(string)
+			if !ok {
+				// Still surface the finding even if the matcher type is
+				// missing or malformed, so it isn't silently dropped.
+				matcherType = "<unknown matcher type>"
+			}
+			results = append(results, matcherType)
 		}
 
 		m, ok := v.(map[string]interface{})

--- a/consumer/interaction_test.go
+++ b/consumer/interaction_test.go
@@ -65,3 +65,57 @@ func TestInteraction(t *testing.T) {
 		}
 	})
 }
+
+func TestHasMatcherGreaterThanSpec(t *testing.T) {
+	testCases := []struct {
+		description string
+		obj         map[string]interface{}
+		want        []string
+	}{
+		{
+			description: "matcher within the spec version is not reported",
+			obj: map[string]interface{}{
+				"pact:specification": "2.0.0",
+				"pact:matcher:type":  "regex",
+			},
+			want: []string{},
+		},
+		{
+			description: "matcher beyond the spec version is reported by type",
+			obj: map[string]interface{}{
+				"pact:specification": "3.0.0",
+				"pact:matcher:type":  "include",
+			},
+			want: []string{"include"},
+		},
+		{
+			description: "matcher beyond the spec version with no type is still reported",
+			obj: map[string]interface{}{
+				"pact:specification": "3.0.0",
+			},
+			want: []string{"<unknown matcher type>"},
+		},
+		{
+			description: "matcher beyond the spec version with a non-string type is still reported",
+			obj: map[string]interface{}{
+				"pact:specification": "3.0.0",
+				"pact:matcher:type":  27,
+			},
+			want: []string{"<unknown matcher type>"},
+		},
+		{
+			description: "a non-string specification version is ignored",
+			obj: map[string]interface{}{
+				"pact:specification": 3,
+				"pact:matcher:type":  "include",
+			},
+			want: []string{},
+		},
+	}
+
+	for _, test := range testCases {
+		t.Run(test.description, func(t *testing.T) {
+			assert.Equal(t, test.want, hasMatcherGreaterThanSpec(models.V2, test.obj))
+		})
+	}
+}

--- a/examples/avro/avro_consumer_test.go
+++ b/examples/avro/avro_consumer_test.go
@@ -78,6 +78,7 @@ func callServiceHTTP(msc consumer.MockServerConfig) (*User, error) {
 	if err != nil {
 		return nil, err
 	}
+	defer func() { _ = res.Body.Close() }()
 
 	bytes, err := io.ReadAll(res.Body)
 	if err != nil {
@@ -90,9 +91,24 @@ func callServiceHTTP(msc consumer.MockServerConfig) (*User, error) {
 		return nil, err
 	}
 
+	fields, ok := native.(map[string]interface{})
+	if !ok {
+		return nil, fmt.Errorf("expected avro record to decode to map[string]interface{}, got %T", native)
+	}
+
+	id, ok := fields["id"].(int64)
+	if !ok {
+		return nil, fmt.Errorf("expected field \"id\" to be int64, got %T", fields["id"])
+	}
+
+	username, ok := fields["username"].(string)
+	if !ok {
+		return nil, fmt.Errorf("expected field \"username\" to be string, got %T", fields["username"])
+	}
+
 	user := &User{
-		ID:       native.(map[string]interface{})["id"].(int64),
-		Username: native.(map[string]interface{})["username"].(string),
+		ID:       id,
+		Username: username,
 	}
 
 	return user, err

--- a/examples/avro/avro_provider_test.go
+++ b/examples/avro/avro_provider_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/pact-foundation/pact-go/v2/provider"
 	"github.com/pact-foundation/pact-go/v2/utils"
@@ -67,5 +68,10 @@ func startHTTPProvider(port int) {
 	})
 
 	log.Printf("started HTTP server on port: %d\n", port)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), mux))
+	server := &http.Server{
+		Addr:              fmt.Sprintf("127.0.0.1:%d", port),
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	log.Fatal(server.ListenAndServe())
 }

--- a/examples/basic_test.go
+++ b/examples/basic_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"net/http"
@@ -70,10 +71,16 @@ func newClient(host string, port int) *productAPIClient {
 }
 
 func (u *productAPIClient) GetProduct(id string) (*Product, error) {
-	resp, err := http.Get(fmt.Sprintf("http://%s:%d:%s%s", u.host, u.port, "/products/", id))
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, fmt.Sprintf("http://%s:%d/products/%s", u.host, u.port, id), nil)
 	if err != nil {
 		return nil, err
 	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer func() { _ = resp.Body.Close() }()
 
 	product := new(Product)
 	err = json.NewDecoder(resp.Body).Decode(product)

--- a/examples/consumer_v3_test.go
+++ b/examples/consumer_v3_test.go
@@ -6,6 +6,7 @@ package main
 
 import (
 	"errors"
+	"fmt"
 	"testing"
 
 	"github.com/pact-foundation/pact-go/v2/consumer"
@@ -94,7 +95,7 @@ func TestConsumerV3(t *testing.T) {
 func TestMessagePact(t *testing.T) {
 	assert.NoError(t, log.SetLogLevel("INFO"))
 
-	provider, err := message.NewMessagePact(message.Config{
+	provider, err := message.NewAsynchronousPact(message.Config{
 		Consumer: "PactGoV3MessageConsumer",
 		Provider: "V3MessageProvider", // must be different to the HTTP one, can't mix both interaction styles
 	})
@@ -126,7 +127,11 @@ func TestMessagePact(t *testing.T) {
 
 // Message Pact - wrapped handler extracts the message.
 var userHandlerWrapper = func(m message.MessageContents) error {
-	return userHandler(*m.Content.(*User))
+	user, ok := m.Content.(*User)
+	if !ok {
+		return fmt.Errorf("expected message content to be *User, got %T", m.Content)
+	}
+	return userHandler(*user)
 }
 
 // Message Pact - actual handler.

--- a/examples/grpc/grpc_provider_test.go
+++ b/examples/grpc/grpc_provider_test.go
@@ -4,6 +4,7 @@
 package grpc
 
 import (
+	"context"
 	"fmt"
 	"log"
 	"net"
@@ -42,7 +43,7 @@ func TestGrpcProvider(t *testing.T) {
 }
 
 func startProvider() {
-	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", 8222))
+	lis, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", fmt.Sprintf("localhost:%d", 8222))
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}

--- a/examples/grpc/routeguide/server/server.go
+++ b/examples/grpc/routeguide/server/server.go
@@ -239,7 +239,7 @@ func NewServer() *routeGuideServer {
 
 func main() {
 	flag.Parse()
-	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", *port))
+	lis, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", fmt.Sprintf("localhost:%d", *port))
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}

--- a/examples/grpc/routeguide/server/server.go
+++ b/examples/grpc/routeguide/server/server.go
@@ -174,6 +174,8 @@ func (s *routeGuideServer) loadFeatures(filePath string) {
 	var data []byte
 	if filePath != "" {
 		var err error
+		//nolint:gosec // G304: filePath is an operator-supplied CLI flag (-json_db_file), not
+		// remote or otherwise untrusted input.
 		data, err = os.ReadFile(filePath)
 		if err != nil {
 			log.Fatalf("Failed to load default features: %v", err)

--- a/examples/plugin/consumer_plugin_test.go
+++ b/examples/plugin/consumer_plugin_test.go
@@ -5,12 +5,14 @@ package plugin
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
 	"net"
 	"net/http"
 	"net/url"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -104,6 +106,7 @@ func callMattServiceHTTP(msc consumer.MockServerConfig, message string) (string,
 	if err != nil {
 		return "", err
 	}
+	defer func() { _ = res.Body.Close() }()
 
 	bytes, err := io.ReadAll(res.Body)
 	if err != nil {
@@ -114,10 +117,11 @@ func callMattServiceHTTP(msc consumer.MockServerConfig, message string) (string,
 }
 
 func callMattServiceTCP(transport message.TransportConfig, message string) (string, error) {
-	conn, err := net.Dial("tcp", fmt.Sprintf("%s:%d", transport.Address, transport.Port))
+	conn, err := (&net.Dialer{}).DialContext(context.Background(), "tcp", net.JoinHostPort(transport.Address, strconv.Itoa(transport.Port)))
 	if err != nil {
 		return "", err
 	}
+	defer func() { _ = conn.Close() }()
 
 	_, err = conn.Write([]byte(generateMattMessage(message)))
 	if err != nil {

--- a/examples/plugin/provider_plugin_test.go
+++ b/examples/plugin/provider_plugin_test.go
@@ -5,6 +5,7 @@ package plugin
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"log"
 	"net"
@@ -69,7 +70,7 @@ func startHTTPProvider(port int) {
 
 func startTCPServer(port int) {
 	log.Println("Starting TCP server on port", port)
-	listener, err := net.Listen("tcp", fmt.Sprintf(":%d", port))
+	listener, err := (&net.ListenConfig{}).Listen(context.Background(), "tcp", fmt.Sprintf(":%d", port))
 	if err != nil {
 		log.Println("ERROR:", err)
 	}

--- a/examples/plugin/provider_plugin_test.go
+++ b/examples/plugin/provider_plugin_test.go
@@ -13,6 +13,7 @@ import (
 	"path/filepath"
 	"regexp"
 	"testing"
+	"time"
 
 	"github.com/pact-foundation/pact-go/v2/provider"
 	"github.com/pact-foundation/pact-go/v2/utils"
@@ -43,8 +44,10 @@ func TestPluginProvider(t *testing.T) {
 		Transports: []provider.Transport{
 			{
 				Protocol: "matt",
-				Port:     uint16(tcpPort),
-				Scheme:   "tcp",
+				//nolint:gosec // G115: tcpPort comes from utils.GetFreePort(), which returns
+				// net.TCPAddr.Port, a value the kernel always assigns in the 0-65535 range.
+				Port:   uint16(tcpPort),
+				Scheme: "tcp",
 			},
 		},
 	})
@@ -65,7 +68,12 @@ func startHTTPProvider(port int) {
 	})
 
 	log.Printf("started HTTP server on port: %d\n", port)
-	log.Fatal(http.ListenAndServe(fmt.Sprintf("127.0.0.1:%d", port), mux))
+	server := &http.Server{
+		Addr:              fmt.Sprintf("127.0.0.1:%d", port),
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	log.Fatal(server.ListenAndServe())
 }
 
 func startTCPServer(port int) {

--- a/examples/protobuf-message/protobuf_provider_test.go
+++ b/examples/protobuf-message/protobuf_provider_test.go
@@ -9,7 +9,6 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/pact-foundation/pact-go/v2/examples/grpc/routeguide"
 	pactlog "github.com/pact-foundation/pact-go/v2/log"
 	"github.com/pact-foundation/pact-go/v2/message"
@@ -17,6 +16,7 @@ import (
 	"github.com/pact-foundation/pact-go/v2/provider"
 	pactversion "github.com/pact-foundation/pact-go/v2/version"
 	"github.com/stretchr/testify/assert"
+	"google.golang.org/protobuf/proto"
 )
 
 func TestPluginMessageProvider(t *testing.T) {

--- a/examples/provider_test.go
+++ b/examples/provider_test.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/pact-foundation/pact-go/v2/log"
 	"github.com/pact-foundation/pact-go/v2/message"
@@ -244,5 +245,10 @@ func startServer() {
 		}
 	})
 
-	l.Fatal(http.ListenAndServe("127.0.0.1:8111", mux))
+	server := &http.Server{
+		Addr:              "127.0.0.1:8111",
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	l.Fatal(server.ListenAndServe())
 }

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/pact-foundation/pact-go/v2
 go 1.25.0
 
 require (
-	github.com/golang/protobuf v1.5.4
 	github.com/hashicorp/go-version v1.9.0
 	github.com/hashicorp/logutils v1.0.0
 	github.com/linkedin/goavro/v2 v2.15.0

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -4,6 +4,7 @@ package installer
 
 import (
 	"compress/gzip"
+	"context"
 	"crypto/md5"
 	"fmt"
 	"io"
@@ -16,6 +17,7 @@ import (
 	"path/filepath"
 	"runtime"
 	"strings"
+	"time"
 
 	goversion "github.com/hashicorp/go-version"
 	"gopkg.in/yaml.v3"
@@ -330,7 +332,7 @@ func checkMusl() bool {
 		return false
 	}
 
-	cmd := exec.Command(lddPath, "/bin/echo")
+	cmd := exec.CommandContext(context.Background(), lddPath, "/bin/echo")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
 		return false
@@ -422,7 +424,15 @@ func (d *defaultDownloader) download(src string, dst string) error {
 		_ = f.Close()
 	}()
 
-	resp, err := http.Get(src)
+	ctx, cancel := context.WithTimeout(context.Background(), downloadTimeout)
+	defer cancel()
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, src, nil)
+	if err != nil {
+		return fmt.Errorf("failed to create request for %s; %w", src, err)
+	}
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return fmt.Errorf("failed http call to %s; %w", src, err)
 	}
@@ -442,6 +452,12 @@ func (d *defaultDownloader) download(src string, dst string) error {
 
 	return nil
 }
+
+// downloadTimeout bounds a single library download end to end, so a stalled
+// connection fails the install instead of hanging it. The largest FFI asset is
+// ~6.6MB compressed, so this leaves room for a slow link without leaving
+// `pact-go install` waiting forever.
+const downloadTimeout = 5 * time.Minute
 
 type packageMetadata struct {
 	LibName string

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -5,7 +5,7 @@ package installer
 import (
 	"compress/gzip"
 	"context"
-	"crypto/md5"
+	"crypto/sha256"
 	"fmt"
 	"io"
 	"log"
@@ -211,6 +211,11 @@ func (i *Installer) downloadDependencies() error {
 			return err
 		}
 
+		//nolint:gosec // G302: the documented default install path is the system-wide
+		// /usr/local/lib, installed via `sudo pact-go install` (README.md); the library must
+		// stay world-readable so the non-root process that later dlopen's it (go test, the
+		// compiled binary) can load it. A 0600 mode here would leave the file readable only
+		// by the root user that ran the installer.
 		err = os.Chmod(dst, 0o755)
 		if err != nil {
 			log.Println("[WARN] unable to set permissions on file", dst, "due to error:", err)
@@ -292,6 +297,11 @@ func (i *Installer) updateConfiguration(dst string, pkg string, info packageInfo
 }
 
 var setMacOSInstallName = func(file string) error {
+	//nolint:gosec // G204: file is the local install destination built from getLibDstForPackage
+	// (getLibDir + internal osToLibName/osToExtension maps). getLibDir can be overridden via
+	// SetLibDir or PACT_GO_LIB_DOWNLOAD_PATH, so file is not purely internal, but exec.Command
+	// here takes a fixed binary name with a fixed argv (no shell), so there is no injection
+	// vector regardless of what file's value is.
 	cmd := exec.Command("install_name_tool", "-id", file, file)
 	log.Println("[DEBUG] running command:", cmd)
 	stdoutStderr, err := cmd.CombinedOutput()
@@ -332,6 +342,8 @@ func checkMusl() bool {
 		return false
 	}
 
+	//nolint:gosec // G204: lddPath is resolved via exec.LookPath("ldd"), a fixed binary name;
+	// the second argument is a hardcoded literal. Neither is user- or network-supplied input.
 	cmd := exec.CommandContext(context.Background(), lddPath, "/bin/echo")
 	out, err := cmd.CombinedOutput()
 	if err != nil {
@@ -411,16 +423,29 @@ func (d *defaultDownloader) download(src string, dst string) error {
 	log.Println("[INFO] downloading library from", src, "to", dst)
 
 	baseDir := path.Dir(dst)
+	//nolint:gosec // G301: the documented default install path is the system-wide
+	// /usr/local/lib, installed via `sudo pact-go install` (README.md); this directory
+	// (already present by default, only actually created here for a custom --libDir) must
+	// stay world-readable/-executable so a non-root process can stat and dlopen the library
+	// inside it. A 0750 mode here would leave a freshly created directory inaccessible to
+	// anyone but the root user that ran the installer.
 	err := os.MkdirAll(baseDir, 0o755)
 	if err != nil {
 		return fmt.Errorf("failed to create %s; %w", baseDir, err)
 	}
 
+	//nolint:gosec // G304: dst is the local install destination built from getLibDstForPackage
+	// (getLibDir + internal osToLibName/osToExtension maps). getLibDir can be overridden via
+	// SetLibDir or PACT_GO_LIB_DOWNLOAD_PATH, so dst is not purely internal, but this is the
+	// installer choosing where to write the file it is downloading, not an attacker directing
+	// a read of an arbitrary existing file — the caller who sets libDir already controls the
+	// filesystem the installer runs against.
 	f, err := os.Create(dst)
 	if err != nil {
 		return fmt.Errorf("failed to create output file; %w", err)
 	}
 	defer func() {
+		// No-op when the oversize path below has already closed it.
 		_ = f.Close()
 	}()
 
@@ -445,9 +470,25 @@ func (d *defaultDownloader) download(src string, dst string) error {
 		return fmt.Errorf("failed to create new gzip reader; %w", err)
 	}
 
-	_, err = io.Copy(f, archive)
+	written, err := io.Copy(f, io.LimitReader(archive, maxDecompressedLibSize+1))
 	if err != nil {
 		return fmt.Errorf("failed to copy archive to file; %w", err)
+	}
+	if written > maxDecompressedLibSize {
+		// Close before removing: Windows refuses to unlink an open file, which
+		// would otherwise leave the oversized partial library on disk for
+		// CheckPackageInstall to find.
+		closeErr := f.Close()
+		if closeErr != nil {
+			return fmt.Errorf("decompressed library exceeds the %d byte safety limit, and closing the partial file at %s failed; %w", maxDecompressedLibSize, dst, closeErr)
+		}
+
+		removeErr := os.Remove(dst)
+		if removeErr != nil {
+			return fmt.Errorf("decompressed library exceeds the %d byte safety limit, and removing the partial file at %s failed; %w", maxDecompressedLibSize, dst, removeErr)
+		}
+
+		return fmt.Errorf("decompressed library exceeds the %d byte safety limit; aborting", maxDecompressedLibSize)
 	}
 
 	return nil
@@ -458,6 +499,13 @@ func (d *defaultDownloader) download(src string, dst string) error {
 // ~6.6MB compressed, so this leaves room for a slow link without leaving
 // `pact-go install` waiting forever.
 const downloadTimeout = 5 * time.Minute
+
+// maxDecompressedLibSize bounds decompression of the downloaded FFI archive.
+// The largest FFI asset pact-reference currently publishes (libpact_ffi-linux-aarch64-musl.so.gz)
+// compresses to ~6.6MB; genuine machine code rarely compresses beyond ~5x, so 150MB gives roughly
+// 20x headroom for the library to grow while still bounding a pathological decompression bomb.
+// A var so tests can lower it rather than materialising 150MB.
+var maxDecompressedLibSize int64 = 150 * 1024 * 1024
 
 type packageMetadata struct {
 	LibName string
@@ -498,6 +546,8 @@ func (configuration) readConfig() pactConfig {
 		Libraries: map[string]packageMetadata{},
 	}
 
+	//nolint:gosec // G304: pactConfigPath is derived from the current OS user's home directory
+	// (getConfigPath), not user- or network-supplied input.
 	bytes, err := os.ReadFile(pactConfigPath)
 	if err != nil {
 		log.Println("[DEBUG] error reading file", pactConfigPath, "error: ", err)
@@ -515,7 +565,7 @@ func (configuration) writeConfig(c pactConfig) error {
 	log.Println("[DEBUG] writing config", c)
 	pactConfigPath := getConfigPath()
 
-	err := os.MkdirAll(filepath.Dir(pactConfigPath), 0o755)
+	err := os.MkdirAll(filepath.Dir(pactConfigPath), 0o750)
 	if err != nil {
 		log.Println("[DEBUG] error creating pact config directory")
 		return err
@@ -528,7 +578,7 @@ func (configuration) writeConfig(c pactConfig) error {
 	}
 	log.Println("[DEBUG] writing yaml config to file", string(bytes))
 
-	return os.WriteFile(pactConfigPath, bytes, 0o644)
+	return os.WriteFile(pactConfigPath, bytes, 0o600)
 }
 
 type hasher interface {
@@ -540,6 +590,11 @@ type defaultHasher struct{}
 func (d *defaultHasher) hash(src string) (string, error) {
 	log.Println("[DEBUG] obtaining hash for file", src)
 
+	//nolint:gosec // G304: src is the local install destination built from getLibDstForPackage
+	// (getLibDir + internal osToLibName/osToExtension maps). getLibDir can be overridden via
+	// SetLibDir or PACT_GO_LIB_DOWNLOAD_PATH, so src is not purely internal, but this reads
+	// back the exact file the installer itself just downloaded to that same path — the caller
+	// who sets libDir already controls the filesystem the installer runs against.
 	f, err := os.Open(src)
 	if err != nil {
 		return "", err
@@ -548,7 +603,7 @@ func (d *defaultHasher) hash(src string) (string, error) {
 		_ = f.Close()
 	}()
 
-	h := md5.New()
+	h := sha256.New()
 	_, err = io.Copy(h, f)
 	if err != nil {
 		return "", err

--- a/installer/installer_test.go
+++ b/installer/installer_test.go
@@ -3,7 +3,11 @@
 package installer
 
 import (
+	"bytes"
+	"compress/gzip"
 	"fmt"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
@@ -16,6 +20,8 @@ func TestNativeLibPath(t *testing.T) {
 	lib := NativeLibPath()
 
 	libFilePath := filepath.Join(lib, "lib.go")
+	//nolint:gosec // G304: libFilePath is derived from NativeLibPath(), a fixed repo-relative
+	// path, not user- or network-supplied input.
 	file, err := os.ReadFile(libFilePath)
 	assert.NoError(t, err)
 	assert.Contains(t, string(file), "-lpact_ffi")
@@ -259,4 +265,56 @@ func TestPackagesVersionSatisfiesOwnSemverRange(t *testing.T) {
 		err := checkVersion(info.libName, info.version, info.semverRange)
 		assert.NoErrorf(t, err, "package %q: compiled-in version %q must satisfy its own semverRange %q", pkg, info.version, info.semverRange)
 	}
+}
+
+// gzipped returns n bytes of zeroes, gzip compressed.
+func gzipped(t *testing.T, n int) []byte {
+	t.Helper()
+
+	var buf bytes.Buffer
+	w := gzip.NewWriter(&buf)
+	_, err := w.Write(make([]byte, n))
+	assert.NoError(t, err)
+	assert.NoError(t, w.Close())
+
+	return buf.Bytes()
+}
+
+func TestDefaultDownloader_Download(t *testing.T) {
+	original := maxDecompressedLibSize
+	defer func() { maxDecompressedLibSize = original }()
+	maxDecompressedLibSize = 1024
+
+	t.Run("within the size limit", func(t *testing.T) {
+		body := gzipped(t, int(maxDecompressedLibSize))
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		dst := filepath.Join(t.TempDir(), "libpact_ffi.so")
+		assert.NoError(t, (&defaultDownloader{}).download(server.URL, dst))
+
+		info, err := os.Stat(dst)
+		assert.NoError(t, err)
+		assert.Equal(t, maxDecompressedLibSize, info.Size())
+	})
+
+	t.Run("beyond the size limit", func(t *testing.T) {
+		body := gzipped(t, int(maxDecompressedLibSize)+1)
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+			_, _ = w.Write(body)
+		}))
+		defer server.Close()
+
+		dst := filepath.Join(t.TempDir(), "libpact_ffi.so")
+		err := (&defaultDownloader{}).download(server.URL, dst)
+
+		assert.ErrorContains(t, err, "exceeds the 1024 byte safety limit")
+
+		// The oversized partial download must not be left behind for
+		// CheckPackageInstall to mistake for a good library.
+		_, statErr := os.Stat(dst)
+		assert.True(t, os.IsNotExist(statErr), "expected %s to be removed, got %v", dst, statErr)
+	})
 }

--- a/internal/native/mock_server_test.go
+++ b/internal/native/mock_server_test.go
@@ -1,6 +1,7 @@
 package native
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"net/http"
@@ -10,8 +11,19 @@ import (
 
 	"github.com/pact-foundation/pact-go/v2/log"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
+
+// httpGet is a context-aware GET helper for the tests below, which only
+// ever hit a mock server started in the same test.
+func httpGet(url string) (*http.Response, error) {
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, url, nil)
+	if err != nil {
+		return nil, err
+	}
+	return http.DefaultClient.Do(req)
+}
 
 func init() {
 	Init("")
@@ -56,10 +68,11 @@ func TestMockServer_MismatchesSuccess(t *testing.T) {
 	m, port := newSimpleMockServer(t)
 	defer m.CleanupMockServer(port)
 
-	res, err := http.Get(fmt.Sprintf("http://localhost:%d/foobar", port))
+	res, err := httpGet(fmt.Sprintf("http://localhost:%d/foobar", port))
 	if err != nil {
 		t.Fatalf("Error sending request: %v", err)
 	}
+	defer func() { _ = res.Body.Close() }()
 
 	if res.StatusCode != 200 {
 		t.Fatalf("want '200', got '%d'", res.StatusCode)
@@ -88,10 +101,11 @@ func TestMockServer_VerifySuccess(t *testing.T) {
 	m, port := newSimpleMockServer(t)
 	defer m.CleanupMockServer(port)
 
-	_, err = http.Get(fmt.Sprintf("http://localhost:%d/foobar", port))
+	res, err := httpGet(fmt.Sprintf("http://localhost:%d/foobar", port))
 	if err != nil {
 		t.Fatalf("Error sending request: %v", err)
 	}
+	defer func() { _ = res.Body.Close() }()
 
 	success, mismatches := m.Verify(port, tmpPactFolder)
 	if !success {
@@ -125,10 +139,11 @@ func TestMockServer_WritePactfile(t *testing.T) {
 	m, port := newSimpleMockServer(t)
 	defer m.CleanupMockServer(port)
 
-	_, err = http.Get(fmt.Sprintf("http://localhost:%d/foobar", port))
+	res, err := httpGet(fmt.Sprintf("http://localhost:%d/foobar", port))
 	if err != nil {
 		t.Fatalf("Error sending request: %v", err)
 	}
+	defer func() { _ = res.Body.Close() }()
 	err = m.WritePactFile(port, tmpPactFolder)
 	if err != nil {
 		t.Fatal("error: ", err)
@@ -172,8 +187,9 @@ func TestHandleBasedHTTPTests(t *testing.T) {
 	assert.NoError(t, err)
 	defer m.CleanupMockServer(port)
 
-	_, err = http.Get(fmt.Sprintf("http://0.0.0.0:%d/products", port))
-	assert.NoError(t, err)
+	res, err := httpGet(fmt.Sprintf("http://0.0.0.0:%d/products", port))
+	require.NoError(t, err)
+	defer func() { _ = res.Body.Close() }()
 	mismatches := m.MockServerMismatchedRequests(port)
 	if len(mismatches) != 0 {
 		t.Fatalf("want 0 mismatches, got '%d'", len(mismatches))
@@ -219,8 +235,9 @@ func TestPluginInteraction(t *testing.T) {
 	assert.NoError(t, err)
 	defer m.CleanupMockServer(port)
 
-	res, err := http.Get(fmt.Sprintf("http://0.0.0.0:%d/protobuf", port))
-	assert.NoError(t, err)
+	res, err := httpGet(fmt.Sprintf("http://0.0.0.0:%d/protobuf", port))
+	require.NoError(t, err)
+	defer func() { _ = res.Body.Close() }()
 
 	bytes, err := io.ReadAll(res.Body)
 	assert.NoError(t, err)

--- a/internal/native/transport_wait.go
+++ b/internal/native/transport_wait.go
@@ -1,15 +1,20 @@
 package native
 
 import (
+	"context"
 	"log"
 	"net"
 	"strconv"
 	"time"
 )
 
-// transportAcceptTimeout bounds how long waitForTransport waits for a mock
-// server to accept connections.
-const transportAcceptTimeout = 10 * time.Second
+const (
+	// transportAcceptTimeout bounds how long waitForTransport waits for a mock
+	// server to accept connections.
+	transportAcceptTimeout = 10 * time.Second
+	// transportPollInterval is how long waitForTransport waits between attempts.
+	transportPollInterval = 10 * time.Millisecond
+)
 
 // waitForTransport blocks until the mock server on port accepts a connection,
 // or transportAcceptTimeout elapses.
@@ -25,24 +30,29 @@ const transportAcceptTimeout = 10 * time.Second
 // would turn a slow start into a hard failure.
 func waitForTransport(address string, port int) {
 	target := net.JoinHostPort(address, strconv.Itoa(port))
-	deadline := time.Now().Add(transportAcceptTimeout)
+
+	ctx, cancel := context.WithTimeout(context.Background(), transportAcceptTimeout)
+	defer cancel()
+
+	dialer := &net.Dialer{}
 
 	for attempt := 0; ; attempt++ {
-		remaining := time.Until(deadline)
-		if remaining <= 0 {
-			log.Println("[WARN] mock server on", target, "did not accept a connection within", transportAcceptTimeout)
-			return
-		}
-
-		conn, err := net.DialTimeout("tcp", target, remaining)
+		conn, err := dialer.DialContext(ctx, "tcp", target)
 		if err == nil {
 			_ = conn.Close()
 			if attempt > 0 {
 				log.Println("[DEBUG] mock server on", target, "accepted a connection after", attempt, "retries")
 			}
+
 			return
 		}
 
-		time.Sleep(10 * time.Millisecond)
+		if ctx.Err() != nil {
+			log.Println("[WARN] mock server on", target, "did not accept a connection within", transportAcceptTimeout)
+
+			return
+		}
+
+		time.Sleep(transportPollInterval)
 	}
 }

--- a/matchers/matcher.go
+++ b/matchers/matcher.go
@@ -440,6 +440,9 @@ func pluckParams(srcType reflect.Type, pactTag string) params {
 
 			params.str.example = components[1]
 		}
+	default:
+		// Other kinds (e.g. Struct, Pointer, Map) have no `pact:"..."` tag
+		// support; the tag is silently ignored and the defaults are used.
 	}
 
 	return params

--- a/matchers/matcher_test.go
+++ b/matchers/matcher_test.go
@@ -389,7 +389,8 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 		"HexValue": {
 			matcher: HexValue(),
 			testCase: func(v interface{}) (err error) {
-				if v.(string) != "3F" {
+				s, valid := v.(string)
+				if !valid || s != "3F" {
 					err = fmt.Errorf("want '3F', got '%v'", reflect.TypeOf(v))
 				}
 				return
@@ -418,7 +419,8 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 		"IPAddress": {
 			matcher: IPAddress(),
 			testCase: func(v interface{}) (err error) {
-				if v.(string) != "127.0.0.1" {
+				s, valid := v.(string)
+				if !valid || s != "127.0.0.1" {
 					err = fmt.Errorf("want '127.0.0.1', got '%v'", reflect.TypeOf(v))
 				}
 				return
@@ -427,7 +429,8 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 		"IPv4Address": {
 			matcher: IPv4Address(),
 			testCase: func(v interface{}) (err error) {
-				if v.(string) != "127.0.0.1" {
+				s, valid := v.(string)
+				if !valid || s != "127.0.0.1" {
 					err = fmt.Errorf("want '127.0.0.1', got '%v'", reflect.TypeOf(v))
 				}
 				return
@@ -436,7 +439,8 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 		"IPv6Address": {
 			matcher: IPv6Address(),
 			testCase: func(v interface{}) (err error) {
-				if v.(string) != "::ffff:192.0.2.128" {
+				s, valid := v.(string)
+				if !valid || s != "::ffff:192.0.2.128" {
 					err = fmt.Errorf("want '::ffff:192.0.2.128', got '%v'", reflect.TypeOf(v))
 				}
 				return
@@ -485,8 +489,12 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 		"UUID": {
 			matcher: UUID(),
 			testCase: func(v interface{}) (err error) {
-				match, err := regexp.MatchString(uuid, v.(string))
+				s, valid := v.(string)
+				if !valid {
+					return fmt.Errorf("want string, got '%v'", reflect.TypeOf(v))
+				}
 
+				match, err := regexp.MatchString(uuid, s)
 				if !match {
 					err = fmt.Errorf("want string, got '%v'", v)
 				}

--- a/message/v4/asynchronous_message_test.go
+++ b/message/v4/asynchronous_message_test.go
@@ -30,7 +30,10 @@ func TestAsyncTypeSystem(t *testing.T) {
 		}).
 		AsType(&foo{}).
 		ConsumedBy(func(mc AsynchronousMessage) error {
-			fooMessage := mc.Body.(*foo)
+			fooMessage, ok := mc.Body.(*foo)
+			if !ok {
+				t.Fatalf("expected message body to be *foo, got %T", mc.Body)
+			}
 			assert.Equal(t, "bar", fooMessage.Foo)
 			return nil
 		}).

--- a/message/verifier.go
+++ b/message/verifier.go
@@ -37,18 +37,32 @@ func appendMetadataToResponseHeaders(metadata Metadata, w http.ResponseWriter) {
 		w.Header().Add(PACT_MESSAGE_METADATA_HEADER2, encoded)
 
 		// Content-Type must match the body content type in the pact.
-		if metadata["contentType"] != nil {
-			w.Header().Set("Content-Type", metadata["contentType"].(string))
-		} else if metadata["content-type"] != nil {
-			w.Header().Set("Content-Type", metadata["content-type"].(string))
-		} else if metadata["Content-Type"] != nil {
-			w.Header().Set("Content-Type", metadata["Content-Type"].(string))
-		} else {
-			defaultContentType := "application/json; charset=utf-8"
-			log.Println("[WARN] no content type (key 'contentType') found in message metadata. Defaulting to", defaultContentType)
-			w.Header().Set("Content-Type", defaultContentType)
+		contentType, ok := stringMetadataValue(metadata, "contentType", "content-type", "Content-Type")
+		if !ok {
+			contentType = "application/json; charset=utf-8"
+			log.Println("[WARN] no content type (key 'contentType') found in message metadata. Defaulting to", contentType)
 		}
+		w.Header().Set("Content-Type", contentType)
 	}
+}
+
+// stringMetadataValue returns the first string value found in metadata for
+// the given keys, in order. The second return value is false if none of the
+// keys are present or the value found is not a string.
+func stringMetadataValue(metadata Metadata, keys ...string) (string, bool) {
+	for _, key := range keys {
+		v, present := metadata[key]
+		if !present || v == nil {
+			continue
+		}
+		s, ok := v.(string)
+		if !ok {
+			log.Printf("[WARN] message metadata key %q is not a string (got %T), ignoring", key, v)
+			continue
+		}
+		return s, true
+	}
+	return "", false
 }
 
 func CreateMessageHandler(messageHandlers Handlers) proxy.Middleware {

--- a/message/verifier.go
+++ b/message/verifier.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"log"
 	"net/http"
+	"strconv"
 
 	"github.com/pact-foundation/pact-go/v2/models"
 	"github.com/pact-foundation/pact-go/v2/proxy"
@@ -78,7 +79,7 @@ func CreateMessageHandler(messageHandlers Handlers) proxy.Middleware {
 				if closeErr != nil {
 					log.Println("[WARN] failed to close request body:", closeErr)
 				}
-				log.Printf("[TRACE] message verification handler received request: %+s, %s", body, r.URL.Path)
+				log.Printf("[TRACE] message verification handler received request: %s, %s", strconv.Quote(string(body)), strconv.Quote(r.URL.Path))
 
 				if err != nil {
 					log.Printf("[ERROR] unable to parse message verification request: %s", err)
@@ -135,7 +136,7 @@ func CreateMessageHandler(messageHandlers Handlers) proxy.Middleware {
 
 				return
 			}
-			log.Println("[TRACE] skipping message handler for request", r.RequestURI)
+			log.Println("[TRACE] skipping message handler for request", strconv.Quote(r.RequestURI))
 
 			// Pass through to application
 			next.ServeHTTP(w, r)

--- a/provider/verifier.go
+++ b/provider/verifier.go
@@ -1,6 +1,7 @@
 package provider
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -369,16 +370,21 @@ func stateHandlerMiddleware(stateHandlers models.StateHandlers, afterEach Hook) 
 // to running tests.
 func WaitForPort(port int, network string, address string, timeoutDuration time.Duration, message string) error {
 	log.Println("[DEBUG] waiting for port", port, "to become available")
-	timeout := time.After(timeoutDuration)
+
+	ctx, cancel := context.WithTimeout(context.Background(), timeoutDuration)
+	defer cancel()
 
 	for {
 		select {
-		case <-timeout:
+		case <-ctx.Done():
 			log.Printf("[ERROR] expected server to start < %s. %s", timeoutDuration, message)
 			return fmt.Errorf("expected server to start < %s. %s", timeoutDuration, message)
 		case <-time.After(50 * time.Millisecond):
-			_, err := net.Dial(network, net.JoinHostPort(address, strconv.Itoa(port)))
+			// The dial shares the overall deadline, so a connection that hangs
+			// rather than refusing cannot hold the loop past timeoutDuration.
+			conn, err := (&net.Dialer{}).DialContext(ctx, network, net.JoinHostPort(address, strconv.Itoa(port)))
 			if err == nil {
+				_ = conn.Close()
 				return nil
 			}
 		}

--- a/provider/verifier.go
+++ b/provider/verifier.go
@@ -63,7 +63,12 @@ func (v *Verifier) validateConfig() error {
 func (v *Verifier) startDefaultHTTPServer(port int) {
 	mux := http.NewServeMux()
 
-	_ = http.ListenAndServe(fmt.Sprintf("%s:%d", v.Hostname, port), mux)
+	server := &http.Server{
+		Addr:              fmt.Sprintf("%s:%d", v.Hostname, port),
+		Handler:           mux,
+		ReadHeaderTimeout: 10 * time.Second,
+	}
+	_ = server.ListenAndServe()
 }
 
 // VerifyProviderRaw reads the provided pact files and runs verification against
@@ -138,7 +143,10 @@ func (v *Verifier) verifyProviderRaw(request VerifyRequest, writer outputWriter)
 		request.Transports = append(request.Transports, Transport{
 			Path:     MESSAGE_PATH,
 			Protocol: "message",
-			Port:     uint16(port),
+			//nolint:gosec // G115: port is returned by proxy.HTTPReverseProxy. The Options
+			// passed to it here never set ProxyPort, so port is always utils.GetFreePort(),
+			// an OS-assigned net.TCPAddr.Port, always 0-65535.
+			Port: uint16(port),
 		})
 	}
 
@@ -358,7 +366,7 @@ func stateHandlerMiddleware(stateHandlers models.StateHandlers, afterEach Hook) 
 				return
 			}
 
-			log.Println("[TRACE] skipping state handler for request", r.RequestURI)
+			log.Println("[TRACE] skipping state handler for request", strconv.Quote(r.RequestURI))
 
 			// Pass through to application
 			next.ServeHTTP(w, r)

--- a/provider/verify_request.go
+++ b/provider/verify_request.go
@@ -9,7 +9,6 @@ import (
 	"net/url"
 	"os"
 	"strconv"
-	"strings"
 	"time"
 
 	"github.com/pact-foundation/pact-go/v2/internal/native"
@@ -200,10 +199,16 @@ func (v *VerifyRequest) validate(handle *native.Verifier) error {
 		}
 
 		port := getPort(v.ProviderBaseURL)
-		if port == -1 {
+		switch port {
+		case portOutOfRange:
+			return fmt.Errorf("port in 'ProviderBaseURL' %q is out of range, must be between 0 and 65535", v.ProviderBaseURL)
+		case portUnknownScheme:
 			return fmt.Errorf("unknown scheme '%s' given to 'ProviderBaseURL', unable to determine default port. Use 'Transports' for non-HTTP providers instead", url.Scheme)
 		}
 
+		//nolint:gosec // G115: getPort returns either portOutOfRange or portUnknownScheme
+		// (both handled above) or a value already checked to be within 0-65535, so this
+		// conversion cannot overflow uint16.
 		handle.SetProviderInfo(v.Provider, url.Scheme, url.Hostname(), uint16(port), url.Path)
 
 		log.Println("[DEBUG] v.Transports", v.Transports)
@@ -325,22 +330,40 @@ func (v *VerifyRequest) Verify(handle *native.Verifier, writer outputWriter) err
 	return res
 }
 
-// Get a port given a URL.
+// Sentinel returns from getPort, distinct from any valid port (0-65535).
+const (
+	// portUnknownScheme means the URL did not parse, or its scheme has no
+	// default port. A caller that has already parsed the URL itself only ever
+	// sees the latter.
+	portUnknownScheme = -1
+	// portOutOfRange means the URL carried an explicit port outside 0-65535.
+	portOutOfRange = -2
+)
+
+// getPort returns the port of a URL, falling back to the default port for the
+// scheme when the URL carries none. Only http and https have a default port.
 func getPort(rawURL string) int {
 	parsedURL, err := url.Parse(rawURL)
-	if err == nil {
-		splitHost := strings.Split(parsedURL.Host, ":")
-		if len(splitHost) == 2 {
-			port, err := strconv.Atoi(splitHost[1])
-			if err == nil {
-				return port
-			}
-		}
-		if parsedURL.Scheme == "https" {
-			return 443
-		}
-		return 80
+	if err != nil {
+		return portUnknownScheme
 	}
 
-	return -1
+	// Port is empty unless the URL carries an explicit port, and strips the
+	// brackets from an IPv6 host.
+	if rawPort := parsedURL.Port(); rawPort != "" {
+		port, err := strconv.Atoi(rawPort)
+		if err != nil || port < 0 || port > 65535 {
+			return portOutOfRange
+		}
+		return port
+	}
+
+	switch parsedURL.Scheme {
+	case "https":
+		return 443
+	case "http":
+		return 80
+	default:
+		return portUnknownScheme
+	}
 }

--- a/provider/verify_request_test.go
+++ b/provider/verify_request_test.go
@@ -161,3 +161,55 @@ func TestVerifyRequest(t *testing.T) {
 		}
 	})
 }
+
+func TestGetPort(t *testing.T) {
+	tests := []struct {
+		name     string
+		rawURL   string
+		expected int
+	}{
+		{name: "explicit port", rawURL: "http://localhost:8080", expected: 8080},
+		{name: "explicit port on a non-http scheme", rawURL: "grpc://localhost:1234", expected: 1234},
+		{name: "explicit port on an IPv6 host", rawURL: "http://[::1]:8080", expected: 8080},
+		{name: "lowest valid port", rawURL: "http://localhost:0", expected: 0},
+		{name: "highest valid port", rawURL: "http://localhost:65535", expected: 65535},
+		{name: "http default", rawURL: "http://localhost", expected: 80},
+		{name: "https default", rawURL: "https://localhost", expected: 443},
+		{name: "port above the uint16 range", rawURL: "http://localhost:65536", expected: portOutOfRange},
+		{name: "port far above the uint16 range", rawURL: "http://localhost:99999", expected: portOutOfRange},
+		{name: "port beyond the int range", rawURL: "http://localhost:99999999999999999999", expected: portOutOfRange},
+		{name: "scheme with no default port", rawURL: "tcp://localhost", expected: portUnknownScheme},
+		{name: "host and port with no scheme", rawURL: "localhost:8080", expected: portUnknownScheme},
+		{name: "unparseable URL", rawURL: "http://localhost:not-a-port", expected: portUnknownScheme},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, getPort(tt.rawURL))
+		})
+	}
+}
+
+func TestVerifyRequestValidatePort(t *testing.T) {
+	handle := native.NewVerifier("pact-go", command.Version)
+
+	t.Run("port out of range", func(t *testing.T) {
+		err := (&VerifyRequest{
+			Provider:        "provider",
+			ProviderBaseURL: "http://localhost:99999",
+			PactFiles:       []string{"/tmp/doesnotexist.json"},
+		}).validate(handle)
+
+		assert.ErrorContains(t, err, "out of range")
+	})
+
+	t.Run("scheme with no default port", func(t *testing.T) {
+		err := (&VerifyRequest{
+			Provider:        "provider",
+			ProviderBaseURL: "tcp://localhost",
+			PactFiles:       []string{"/tmp/doesnotexist.json"},
+		}).validate(handle)
+
+		assert.ErrorContains(t, err, "unknown scheme")
+	})
+}

--- a/proxy/http.go
+++ b/proxy/http.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -49,7 +50,7 @@ type Options struct {
 // loggingMiddleware logs requests to the proxy.
 func loggingMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		log.Printf("[DEBUG] http reverse proxy received connection from %s on path %s\n", r.RemoteAddr, r.RequestURI)
+		log.Printf("[DEBUG] http reverse proxy received connection from %s on path %s\n", strconv.Quote(r.RemoteAddr), strconv.Quote(r.RequestURI))
 		next.ServeHTTP(w, r)
 	})
 }
@@ -97,7 +98,12 @@ func HTTPReverseProxy(options Options) (int, error) {
 
 	log.Println("[DEBUG] starting reverse proxy on port", port)
 	go func() {
-		err := http.ListenAndServe(fmt.Sprintf(":%d", port), wrapper(proxy))
+		server := &http.Server{
+			Addr:              fmt.Sprintf(":%d", port),
+			Handler:           wrapper(proxy),
+			ReadHeaderTimeout: 10 * time.Second,
+		}
+		err := server.ListenAndServe()
 		if err != nil {
 			log.Println("[ERROR] error when starting reverse proxy server:", err)
 			panic(err)
@@ -156,13 +162,13 @@ func createProxy(target *url.URL, ignorePrefix string) *httputil.ReverseProxy {
 	director := func(req *http.Request) {
 		if !strings.HasPrefix(req.URL.Path, ignorePrefix) {
 			log.Println("[DEBUG] setting proxy to target")
-			log.Println("[DEBUG] incoming request", req.URL)
+			log.Println("[DEBUG] incoming request", strconv.Quote(req.URL.String()))
 			req.URL.Scheme = target.Scheme
 			req.URL.Host = target.Host
 			req.Host = target.Host
 
 			req.URL.Path = singleJoiningSlash(target.Path, req.URL.Path)
-			log.Println("[DEBUG] outgoing request to target", req.URL)
+			log.Println("[DEBUG] outgoing request to target", strconv.Quote(req.URL.String()))
 			if targetQuery == "" || req.URL.RawQuery == "" {
 				req.URL.RawQuery = targetQuery + req.URL.RawQuery
 			} else {

--- a/proxy/http_test.go
+++ b/proxy/http_test.go
@@ -1,6 +1,7 @@
 package proxy
 
 import (
+	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -22,7 +23,7 @@ func DummyMiddleware(header string) Middleware {
 }
 
 func TestLoggingMiddleware(t *testing.T) {
-	req, err := http.NewRequest("GET", "/x", nil)
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/x", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -38,7 +39,7 @@ func TestLoggingMiddleware(t *testing.T) {
 }
 
 func TestChainHandlers(t *testing.T) {
-	req, err := http.NewRequest("GET", "/health-check", nil)
+	req, err := http.NewRequestWithContext(context.Background(), "GET", "/health-check", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/utils/port.go
+++ b/utils/port.go
@@ -24,7 +24,12 @@ func GetFreePort() (int, error) {
 	defer func() {
 		_ = l.Close()
 	}()
-	return l.Addr().(*net.TCPAddr).Port, nil
+
+	tcpAddr, ok := l.Addr().(*net.TCPAddr)
+	if !ok {
+		return 0, fmt.Errorf("expected a *net.TCPAddr from net.ListenTCP, got %T", l.Addr())
+	}
+	return tcpAddr.Port, nil
 }
 
 // FindPortInRange Iterate through CSV or Range of ports to find open port


### PR DESCRIPTION
## Summary

Enables `bodyclose`, `forcetypeassert`, `noctx`, `exhaustive` and `gosec`, closing 10 leaked connections and bounding the FFI download path. It also drops the temporary `^examples/` exclusion the previous PR left behind, bringing `examples/` under `errcheck`, `govet` and `staticcheck` for the first time.

## Motivation

The second and last behaviour-changing PR in the stack. gosec surfaced 28 findings beyond the expected `installer/` ones, including log-injection (G706) and missing server timeouts (G114) in `provider/`, `proxy/` and `message/`.

Retiring the `^examples/` exclusion is what accounts for the otherwise unrelated-looking churn under `examples/`: the `NewMessagePact` → `NewAsynchronousPact` and `golang/protobuf` → `google.golang.org/protobuf` swaps (staticcheck SA1019, which also lets `go.mod` drop a dependency), the `net.JoinHostPort` fix (govet hostport), and the `assert.NoError(t, log.SetLogLevel(...))` wrapping (errcheck).

## Notes for reviewers

- **File permissions.** The installed library and its directory stay at 0755. gosec wants 0600/0750, but the README documents the default install path as `/usr/local/lib` via `sudo pact-go install`; narrowing them leaves the library root-owned and unreadable to the non-root process that later `dlopen`s it. Same-user `/tmp` installs were verified directly; the root-owned case was reasoned through from mode and ownership, since sudo is unavailable in the dev sandbox. The config file under the user's home has no such constraint and *does* narrow, from 0644/0755 to 0600/0750 — only pact-go reads it.
- MD5 → SHA-256 in the installer is safe because the computed hash is only ever written to local config and never read back or compared.
- Decompression is bounded by `io.LimitReader` at 150MB — roughly 20x headroom over the largest FFI asset pact-reference currently publishes.
- **Contexts carry deadlines where they guard a real wait.** A context added only to satisfy `noctx` buys nothing. The FFI download had no timeout of any kind (`http.DefaultClient` sets none), so a stalled connection hung `pact-go install` with no output; it now gets 5 minutes end to end. `WaitForPort`'s dial was likewise unbounded and could hold its loop past `timeoutDuration`; it now shares a context built from that duration.
- **`getPort` got more than a bounds check.** Bounding the `int` → `uint16` cast meant reading the function closely, and three defects fell out. Every unrecognised scheme fell through to port 80, so the "unknown scheme … use `Transports` for non-HTTP providers instead" arm in `validate` was unreachable and a provider given as `tcp://host` was silently verified against port 80 — only `http` and `https` carry a default port now. Splitting `Host` on `":"` put an IPv6 URL into three fields and discarded the explicit port, so the lookup moves to `url.URL.Port()`. And `url.Parse` already rejects a negative port, so that arm only ever catches `Atoi` overflow.
- **The two new guards have tests.** `getPort` across both boundaries, both sentinels, IPv6 and overflow; `defaultDownloader.download` at the decompression limit and one byte past it, asserting the oversized partial file is removed rather than left for `CheckPackageInstall` to mistake for a good library. The limit is a `var` so the test can lower it instead of materialising 150MB.
- **That test immediately earned its keep.** It failed on all three Windows runners: `os.Remove` was called while the output file was still open, which Windows refuses, and the error was discarded — so on Windows the cleanup had never worked and the oversized partial library was left exactly where `CheckPackageInstall` would later find it. The file is now closed before the remove, and both errors are reported rather than dropped.
- Remaining G115 findings are annotated, not restructured: the ports all come from `utils.GetFreePort()`, which gosec's range analysis cannot see across the call boundary.
- **Lint is green from this PR onward**, and from each commit in it independently.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>

