### PR TITLE
test: enable test-quality linters and characterise two untested handlers

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -16,10 +16,14 @@ linters:
     - godot
     - gosec
     - misspell
+    - musttag
     - nilerr
     - nilnesserr
     - noctx
     - noinlineerr
+    - testifylint
+    - thelper
+    - usetesting
     - whitespace
   settings:
     dupword:

--- a/consumer/http.go
+++ b/consumer/http.go
@@ -131,6 +131,7 @@ func (p *httpMockProvider) configure() error {
 // Will cleanup interactions between tests within a suite
 // and write the pact file if successful.
 func (p *httpMockProvider) ExecuteTest(t *testing.T, integrationTest func(MockServerConfig) error) error {
+	t.Helper()
 	log.Println("[DEBUG] pact verify")
 
 	var err error
@@ -191,6 +192,7 @@ func (p *httpMockProvider) reset() {
 // TODO: improve / pretty print this to make it really easy to understand the problems
 // See existing Pact/Ruby code examples.
 func (p *httpMockProvider) displayMismatches(t *testing.T, mismatches []native.MismatchedRequest) {
+	t.Helper()
 	if len(mismatches) > 0 {
 		if len(callerInfo()) > 0 {
 			fmt.Printf("\n\n%s:\n", callerInfo()[len(callerInfo())-1])

--- a/consumer/http_v2.go
+++ b/consumer/http_v2.go
@@ -304,5 +304,6 @@ func (i *V2ResponseBuilder) BodyMatch(body interface{}) *V2ResponseBuilder {
 
 // ExecuteTest runs the current test case against a Mock Service.
 func (m *V2InteractionWithResponse) ExecuteTest(t *testing.T, integrationTest func(MockServerConfig) error) error {
+	t.Helper()
 	return m.provider.ExecuteTest(t, integrationTest)
 }

--- a/consumer/http_v3.go
+++ b/consumer/http_v3.go
@@ -315,5 +315,6 @@ func (i *V3ResponseBuilder) BodyMatch(body interface{}) *V3ResponseBuilder {
 
 // ExecuteTest runs the current test case against a Mock Service.
 func (m *V3InteractionWithResponse) ExecuteTest(t *testing.T, integrationTest func(MockServerConfig) error) error {
+	t.Helper()
 	return m.provider.ExecuteTest(t, integrationTest)
 }

--- a/consumer/http_v4.go
+++ b/consumer/http_v4.go
@@ -325,6 +325,7 @@ func (i *V4ResponseBuilder) BodyMatch(body interface{}) *V4ResponseBuilder {
 
 // ExecuteTest runs the current test case against a Mock Service.
 func (m *V4InteractionWithResponse) ExecuteTest(t *testing.T, integrationTest func(MockServerConfig) error) error {
+	t.Helper()
 	return m.provider.ExecuteTest(t, integrationTest)
 }
 
@@ -441,6 +442,7 @@ type V4InteractionWithPluginResponse struct {
 
 // ExecuteTest runs the current test case against a Mock Service.
 func (m *V4InteractionWithPluginResponse) ExecuteTest(t *testing.T, integrationTest func(MockServerConfig) error) error {
+	t.Helper()
 	return m.provider.ExecuteTest(t, integrationTest)
 }
 

--- a/consumer/http_v4_test.go
+++ b/consumer/http_v4_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/pact-foundation/pact-go/v2/matchers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHttpV4TypeSystem(t *testing.T) {
@@ -17,7 +18,7 @@ func TestHttpV4TypeSystem(t *testing.T) {
 		Consumer: "consumer",
 		Provider: "provider",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = p.AddInteraction().
 		Given("some state").
@@ -49,7 +50,7 @@ func TestHttpV4TypeSystem(t *testing.T) {
 
 			return nil
 		})
-	assert.Error(t, err)
+	require.Error(t, err)
 
 	dir, _ := os.Getwd()
 	path := fmt.Sprintf("%s/pact_plugin.proto", strings.ReplaceAll(dir, "\\", "/"))
@@ -89,7 +90,7 @@ func TestV4HTTPAddExternalReference(t *testing.T) {
 		Consumer: "consumer",
 		Provider: "provider",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = p.AddInteraction().
 		UponReceiving("a request with an external reference").

--- a/examples/avro/avro_consumer_test.go
+++ b/examples/avro/avro_consumer_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pact-foundation/pact-go/v2/consumer"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestAvroHTTP(t *testing.T) {
@@ -24,7 +25,7 @@ func TestAvroHTTP(t *testing.T) {
 		Provider: "AvroProvider",
 		PactDir:  filepath.ToSlash(fmt.Sprintf("%s/../pacts", dir)),
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	dir, _ := os.Getwd()
 	path := fmt.Sprintf("%s/user.avsc", strings.ReplaceAll(dir, "\\", "/"))

--- a/examples/basic_test.go
+++ b/examples/basic_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/pact-foundation/pact-go/v2/consumer"
 	"github.com/pact-foundation/pact-go/v2/matchers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 type S = matchers.S
@@ -21,7 +22,7 @@ func TestProductAPIClient(t *testing.T) {
 		Consumer: "PactGoProductAPIConsumer",
 		Provider: "PactGoProductAPI",
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Arrange: Setup our expected interactions
 	err = mockProvider.
@@ -41,7 +42,7 @@ func TestProductAPIClient(t *testing.T) {
 			product, err := client.GetProduct("10")
 
 			// Assert: check the result
-			assert.NoError(t, err)
+			require.NoError(t, err)
 			assert.Equal(t, 10, product.ID)
 
 			return err

--- a/examples/consumer_v2_test.go
+++ b/examples/consumer_v2_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pact-foundation/pact-go/v2/log"
 	"github.com/pact-foundation/pact-go/v2/matchers"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -37,7 +38,7 @@ var (
 type Map = matchers.MapMatcher
 
 func TestConsumerV2(t *testing.T) {
-	assert.NoError(t, log.SetLogLevel("INFO"))
+	require.NoError(t, log.SetLogLevel("INFO"))
 
 	mockProvider, err := consumer.NewV2Pact(consumer.MockHTTPProviderConfig{
 		Consumer: "PactGoV2Consumer",
@@ -46,7 +47,7 @@ func TestConsumerV2(t *testing.T) {
 		TLS:      true,
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Set up our expected interactions.
 	err = mockProvider.
@@ -82,7 +83,7 @@ func TestConsumerV2(t *testing.T) {
 }
 
 func TestConsumerV2_Match(t *testing.T) {
-	assert.NoError(t, log.SetLogLevel("INFO"))
+	require.NoError(t, log.SetLogLevel("INFO"))
 
 	mockProvider, err := consumer.NewV2Pact(consumer.MockHTTPProviderConfig{
 		Consumer: "PactGoV2ConsumerMatch",
@@ -91,7 +92,7 @@ func TestConsumerV2_Match(t *testing.T) {
 		TLS:      true,
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Set up our expected interactions.
 	err = mockProvider.
@@ -113,7 +114,7 @@ func TestConsumerV2_Match(t *testing.T) {
 }
 
 func TestConsumerV2AllInOne(t *testing.T) {
-	assert.NoError(t, log.SetLogLevel("INFO"))
+	require.NoError(t, log.SetLogLevel("INFO"))
 
 	mockProvider, err := consumer.NewV2Pact(consumer.MockHTTPProviderConfig{
 		Consumer: "PactGoV2ConsumerAllInOne",
@@ -122,7 +123,7 @@ func TestConsumerV2AllInOne(t *testing.T) {
 		TLS:      true,
 	})
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Set up our expected interactions.
 	err = mockProvider.

--- a/examples/consumer_v3_test.go
+++ b/examples/consumer_v3_test.go
@@ -15,6 +15,7 @@ import (
 	message "github.com/pact-foundation/pact-go/v2/message/v3"
 	"github.com/pact-foundation/pact-go/v2/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -33,7 +34,7 @@ var (
 )
 
 func TestConsumerV3(t *testing.T) {
-	assert.NoError(t, log.SetLogLevel("INFO"))
+	require.NoError(t, log.SetLogLevel("INFO"))
 
 	mockProvider, err := consumer.NewV3Pact(consumer.MockHTTPProviderConfig{
 		Consumer: "PactGoV3Consumer",
@@ -41,7 +42,7 @@ func TestConsumerV3(t *testing.T) {
 		Host:     "127.0.0.1",
 		TLS:      true,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Set up our expected interactions.
 	err = mockProvider.
@@ -93,13 +94,13 @@ func TestConsumerV3(t *testing.T) {
 }
 
 func TestMessagePact(t *testing.T) {
-	assert.NoError(t, log.SetLogLevel("INFO"))
+	require.NoError(t, log.SetLogLevel("INFO"))
 
 	provider, err := message.NewAsynchronousPact(message.Config{
 		Consumer: "PactGoV3MessageConsumer",
 		Provider: "V3MessageProvider", // must be different to the HTTP one, can't mix both interaction styles
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	err = provider.AddMessage().
 		GivenWithParameter(models.ProviderState{

--- a/examples/consumer_v4_test.go
+++ b/examples/consumer_v4_test.go
@@ -11,10 +11,11 @@ import (
 	"github.com/pact-foundation/pact-go/v2/log"
 	"github.com/pact-foundation/pact-go/v2/models"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestConsumerV4(t *testing.T) {
-	assert.NoError(t, log.SetLogLevel("INFO"))
+	require.NoError(t, log.SetLogLevel("INFO"))
 
 	mockProvider, err := consumer.NewV4Pact(consumer.MockHTTPProviderConfig{
 		Consumer: "PactGoV4Consumer",
@@ -22,7 +23,7 @@ func TestConsumerV4(t *testing.T) {
 		Host:     "127.0.0.1",
 		TLS:      true,
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Set up our expected interactions.
 	err = mockProvider.

--- a/examples/grpc/grpc_consumer_test.go
+++ b/examples/grpc/grpc_consumer_test.go
@@ -27,7 +27,7 @@ func TestGetFeatureSuccess(t *testing.T) {
 		Provider: "grpcprovider",
 		PactDir:  filepath.ToSlash(fmt.Sprintf("%s/../pacts", dir)),
 	})
-	assert.NoError(t, log.SetLogLevel("DEBUG"))
+	require.NoError(t, log.SetLogLevel("DEBUG"))
 
 	dir, _ := os.Getwd()
 	path := fmt.Sprintf("%s/routeguide/route_guide.proto", strings.ReplaceAll(dir, "\\", "/"))
@@ -94,7 +94,7 @@ func TestGetFeatureSuccess(t *testing.T) {
 }
 
 func TestGetFeatureError(t *testing.T) {
-	assert.NoError(t, log.SetLogLevel("DEBUG"))
+	require.NoError(t, log.SetLogLevel("DEBUG"))
 	p, _ := message.NewSynchronousPact(message.Config{
 		Consumer: "grpcconsumer",
 		Provider: "grpcprovider",
@@ -164,7 +164,7 @@ func TestSaveFeature(t *testing.T) {
 		Provider: "grpcprovider",
 		PactDir:  filepath.ToSlash(fmt.Sprintf("%s/../pacts", dir)),
 	})
-	assert.NoError(t, log.SetLogLevel("INFO"))
+	require.NoError(t, log.SetLogLevel("INFO"))
 
 	dir, _ := os.Getwd()
 	path := fmt.Sprintf("%s/routeguide/route_guide.proto", strings.ReplaceAll(dir, "\\", "/"))
@@ -226,7 +226,7 @@ func TestSaveFeature(t *testing.T) {
 			}
 
 			assert.Equal(t, feature.GetName(), response.GetName())
-			assert.Equal(t, feature.GetLocation().GetLatitude(), feature.GetLocation().GetLatitude())
+			assert.Equal(t, feature.GetLocation().GetLatitude(), response.GetLocation().GetLatitude())
 
 			return nil
 		})

--- a/examples/grpc/grpc_provider_test.go
+++ b/examples/grpc/grpc_provider_test.go
@@ -16,12 +16,13 @@ import (
 	l "github.com/pact-foundation/pact-go/v2/log"
 	"github.com/pact-foundation/pact-go/v2/provider"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
 )
 
 func TestGrpcProvider(t *testing.T) {
 	go startProvider()
-	assert.NoError(t, l.SetLogLevel("INFO"))
+	require.NoError(t, l.SetLogLevel("INFO"))
 
 	verifier := provider.NewVerifier()
 

--- a/examples/plugin/consumer_plugin_test.go
+++ b/examples/plugin/consumer_plugin_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pact-foundation/pact-go/v2/consumer"
 	message "github.com/pact-foundation/pact-go/v2/message/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHTTPPlugin(t *testing.T) {
@@ -27,7 +28,7 @@ func TestHTTPPlugin(t *testing.T) {
 		Provider: "MattProvider",
 		PactDir:  filepath.ToSlash(fmt.Sprintf("%s/../pacts", dir)),
 	})
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// MATT is a protocol, where all message start and end with a MATT
 	mattRequest := `{"request": {"body": "hello"}}`

--- a/examples/protobuf-message/protobuf_provider_test.go
+++ b/examples/protobuf-message/protobuf_provider_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/pact-foundation/pact-go/v2/provider"
 	pactversion "github.com/pact-foundation/pact-go/v2/version"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -24,7 +25,7 @@ func TestPluginMessageProvider(t *testing.T) {
 	pactDir := fmt.Sprintf("%s/../pacts", dir)
 
 	err := pactlog.SetLogLevel("INFO")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	pactversion.CheckVersion()
 

--- a/examples/provider_test.go
+++ b/examples/provider_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/pact-foundation/pact-go/v2/provider"
 	"github.com/pact-foundation/pact-go/v2/version"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 var (
@@ -32,7 +33,7 @@ var (
 )
 
 func TestV3HTTPProvider(t *testing.T) {
-	assert.NoError(t, log.SetLogLevel("DEBUG"))
+	require.NoError(t, log.SetLogLevel("DEBUG"))
 	version.CheckVersion()
 
 	// Start provider API in the background
@@ -101,7 +102,7 @@ func TestV3HTTPProvider(t *testing.T) {
 			},
 			DisableColoredOutput: true,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, requestFilterCalled)
 		assert.True(t, stateHandlerCalled)
 	} else {
@@ -139,14 +140,14 @@ func TestV3HTTPProvider(t *testing.T) {
 			},
 			DisableColoredOutput: true,
 		})
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.True(t, requestFilterCalled)
 		assert.True(t, stateHandlerCalled)
 	}
 }
 
 func TestV3MessageProvider(t *testing.T) {
-	assert.NoError(t, log.SetLogLevel("DEBUG"))
+	require.NoError(t, log.SetLogLevel("DEBUG"))
 	var user *User
 
 	verifier := provider.NewVerifier()

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -508,13 +508,13 @@ const downloadTimeout = 5 * time.Minute
 var maxDecompressedLibSize int64 = 150 * 1024 * 1024
 
 type packageMetadata struct {
-	LibName string
-	Version string
-	Hash    string
+	LibName string `yaml:"libname"`
+	Version string `yaml:"version"`
+	Hash    string `yaml:"hash"`
 }
 
 type pactConfig struct {
-	Libraries map[string]packageMetadata
+	Libraries map[string]packageMetadata `yaml:"libraries"`
 }
 
 type configReader interface {

--- a/installer/installer_test.go
+++ b/installer/installer_test.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/spf13/afero"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestNativeLibPath(t *testing.T) {
@@ -23,7 +24,7 @@ func TestNativeLibPath(t *testing.T) {
 	//nolint:gosec // G304: libFilePath is derived from NativeLibPath(), a fixed repo-relative
 	// path, not user- or network-supplied input.
 	file, err := os.ReadFile(libFilePath)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Contains(t, string(file), "-lpact_ffi")
 }
 
@@ -102,7 +103,7 @@ func TestInstallerDownloader(t *testing.T) {
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
 				src, err := tt.test.getDownloadURLForPackage(tt.pkg)
-				assert.NoError(t, err)
+				require.NoError(t, err)
 				assert.Equal(t, tt.want, src)
 			})
 		}
@@ -293,10 +294,10 @@ func TestDefaultDownloader_Download(t *testing.T) {
 		defer server.Close()
 
 		dst := filepath.Join(t.TempDir(), "libpact_ffi.so")
-		assert.NoError(t, (&defaultDownloader{}).download(server.URL, dst))
+		require.NoError(t, (&defaultDownloader{}).download(server.URL, dst))
 
 		info, err := os.Stat(dst)
-		assert.NoError(t, err)
+		require.NoError(t, err)
 		assert.Equal(t, maxDecompressedLibSize, info.Size())
 	})
 
@@ -310,7 +311,7 @@ func TestDefaultDownloader_Download(t *testing.T) {
 		dst := filepath.Join(t.TempDir(), "libpact_ffi.so")
 		err := (&defaultDownloader{}).download(server.URL, dst)
 
-		assert.ErrorContains(t, err, "exceeds the 1024 byte safety limit")
+		require.ErrorContains(t, err, "exceeds the 1024 byte safety limit")
 
 		// The oversized partial download must not be left behind for
 		// CheckPackageInstall to mistake for a good library.

--- a/internal/native/message_server_test.go
+++ b/internal/native/message_server_test.go
@@ -17,13 +17,13 @@ import (
 	"google.golang.org/protobuf/proto"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 	grpc "google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 )
 
 func TestHandleBasedMessageTestsWithString(t *testing.T) {
-	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
-	assert.NoError(t, err)
+	tmpPactFolder := t.TempDir()
 	s := NewMessageServer("test-message-consumer", "test-message-provider")
 
 	m := s.NewMessage().
@@ -39,7 +39,7 @@ func TestHandleBasedMessageTestsWithString(t *testing.T) {
 
 	body, err := m.GetMessageRequestContents()
 
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "some string", string(body))
 
 	// This is where you would invoke the real function with the message
@@ -49,8 +49,7 @@ func TestHandleBasedMessageTestsWithString(t *testing.T) {
 }
 
 func TestHandleBasedMessageTestsWithJSON(t *testing.T) {
-	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
-	assert.NoError(t, err)
+	tmpPactFolder := t.TempDir()
 	s := NewMessageServer("test-message-consumer", "test-message-provider")
 
 	m := s.NewMessage().
@@ -67,13 +66,13 @@ func TestHandleBasedMessageTestsWithJSON(t *testing.T) {
 		})
 
 	body, err := m.GetMessageRequestContents()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	var res struct {
 		Some string `json:"some"`
 	}
 	err = json.Unmarshal(body, &res)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "json", res.Some)
 
 	// This is where you would invoke the real function with the message
@@ -83,8 +82,7 @@ func TestHandleBasedMessageTestsWithJSON(t *testing.T) {
 }
 
 func TestHandleBasedMessageTestsWithBinary(t *testing.T) {
-	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
-	assert.NoError(t, err)
+	tmpPactFolder := t.TempDir()
 
 	s := NewMessageServer("test-binarymessage-consumer", "test-binarymessage-provider").
 		WithMetadata("some-namespace", "the-key", "the-value")
@@ -94,11 +92,11 @@ func TestHandleBasedMessageTestsWithBinary(t *testing.T) {
 	zw := gzip.NewWriter(&buf)
 
 	encodedMessage := "A long time ago in a galaxy far, far away..."
-	_, err = zw.Write([]byte(encodedMessage))
-	assert.NoError(t, err)
+	_, err := zw.Write([]byte(encodedMessage))
+	require.NoError(t, err)
 
 	err = zw.Close()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	m := s.NewMessage().
 		Given("some binary state").
@@ -112,11 +110,11 @@ func TestHandleBasedMessageTestsWithBinary(t *testing.T) {
 		WithRequestBinaryContentType("application/gzip", buf.Bytes())
 
 	body, err := m.GetMessageRequestContents()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Extract binary payload, base 64 decode it, unzip it
 	r, err := gzip.NewReader(bytes.NewReader(body))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	result, _ := io.ReadAll(r)
 
 	assert.Equal(t, encodedMessage, string(result))
@@ -144,7 +142,7 @@ func TestGetAsyncMessageContentsAsBytes(t *testing.T) {
 		})
 
 	bytes, err := m.GetMessageRequestContents()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, bytes)
 
 	// Should be able to convert back into the JSON structure
@@ -152,7 +150,7 @@ func TestGetAsyncMessageContentsAsBytes(t *testing.T) {
 		Some string `json:"some"`
 	}
 	err = json.Unmarshal(bytes, &v)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "json", v.Some)
 }
 
@@ -176,7 +174,7 @@ func TestGetSyncMessageContentsAsBytes(t *testing.T) {
 		})
 
 	bytes, err := m.GetMessageResponseContents()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, bytes)
 
 	// Should be able to convert back into the JSON structure
@@ -184,7 +182,7 @@ func TestGetSyncMessageContentsAsBytes(t *testing.T) {
 		Some string `json:"some"`
 	}
 	err = json.Unmarshal(bytes[0], &v)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "response", v.Some)
 }
 
@@ -202,9 +200,9 @@ func TestGetSyncMessageContentsAsBytes_EmptyResponse(t *testing.T) {
 		})
 
 	bytes, err := m.GetMessageResponseContents()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, bytes)
-	assert.Equal(t, 1, len(bytes))
+	assert.Len(t, bytes, 1)
 	assert.Empty(t, bytes[0])
 }
 
@@ -214,7 +212,7 @@ func TestGetPluginSyncMessageContentsAsBytes(t *testing.T) {
 	// Protobuf plugin test
 	defer m.CleanupPlugins()
 	err := m.UsingPlugin("protobuf", "0.5.4")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	i := m.NewSyncMessageInteraction("grpc interaction")
 
@@ -243,25 +241,25 @@ func TestGetPluginSyncMessageContentsAsBytes(t *testing.T) {
 		Given("plugin state").
 		// For gRPC interactions we prpvide the config once for both the request and response parts
 		WithPluginInteractionContents(INTERACTION_PART_REQUEST, "application/protobuf", grpcInteraction)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	bytes, err := i.GetMessageRequestContents()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, bytes)
 
 	// Should be able to convert request body back into a protobuf
 	p := &InitPluginRequest{}
 	err = proto.Unmarshal(bytes, p)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "0.0.0", p.Version)
 
 	// Should be able to convert response into a protobuf
 	response, err := i.GetMessageResponseContents()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, bytes)
 	r := &InitPluginResponse{}
 	err = proto.Unmarshal(response[0], r)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "test", r.Catalogue[0].Key)
 }
 
@@ -271,7 +269,7 @@ func TestGetPluginSyncMessageContentsAsBytes_EmptyResponse(t *testing.T) {
 	// Protobuf plugin test
 	defer m.CleanupPlugins()
 	err := m.UsingPlugin("protobuf", "0.5.4")
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	i := m.NewSyncMessageInteraction("grpc interaction")
 
@@ -292,23 +290,23 @@ func TestGetPluginSyncMessageContentsAsBytes_EmptyResponse(t *testing.T) {
 		Given("plugin state").
 		// For gRPC interactions we prpvide the config once for both the request and response parts
 		WithPluginInteractionContents(INTERACTION_PART_REQUEST, "application/protobuf", grpcInteraction)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	bytes, err := i.GetMessageRequestContents()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, bytes)
 
 	// Should be able to convert request body back into a protobuf
 	p := &InitPluginRequest{}
 	err = proto.Unmarshal(bytes, p)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "0.0.0", p.Version)
 
 	// Should be able to convert response into a protobuf
 	response_bytes, err := i.GetMessageResponseContents()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, response_bytes)
-	assert.Equal(t, 1, len(response_bytes))
+	assert.Len(t, response_bytes, 1)
 	assert.Empty(t, response_bytes[0])
 }
 
@@ -336,22 +334,21 @@ func TestGetPluginAsyncMessageContentsAsBytes(t *testing.T) {
 		Given("plugin state").
 		// For gRPC interactions we prpvide the config once for both the request and response parts
 		WithPluginInteractionContents(INTERACTION_PART_REQUEST, "application/protobuf", protobufInteraction)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	bytes, err := i.GetMessageRequestContents()
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.NotNil(t, bytes)
 
 	// Should be able to convert body back into a protobuf
 	p := &InitPluginRequest{}
 	err = proto.Unmarshal(bytes, p)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	assert.Equal(t, "0.0.0", p.Version)
 }
 
 func TestGrpcPluginInteraction(t *testing.T) {
-	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
-	assert.NoError(t, err)
+	tmpPactFolder := t.TempDir()
 	_ = log.SetLogLevel("INFO")
 
 	m := NewMessageServer("test-message-consumer", "test-message-provider")
@@ -383,15 +380,15 @@ func TestGrpcPluginInteraction(t *testing.T) {
 			}
 		}`
 
-	err = i.
+	err := i.
 		Given("plugin state").
 		// For gRPC interactions we prpvide the config once for both the request and response parts
 		WithPluginInteractionContents(INTERACTION_PART_REQUEST, "application/protobuf", grpcInteraction)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Start the gRPC mock server
 	port, err := m.StartTransport("grpc", "127.0.0.1", 0, make(map[string][]interface{}))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer m.CleanupMockServer(port)
 
 	// Now we can make a normal gRPC request
@@ -421,7 +418,7 @@ func TestGrpcPluginInteraction(t *testing.T) {
 
 	mismatches := m.MockServerMismatchedRequests(port)
 	if len(mismatches) != 0 {
-		assert.Len(t, mismatches, 0)
+		assert.Empty(t, mismatches)
 		t.Log(mismatches)
 	}
 
@@ -430,8 +427,7 @@ func TestGrpcPluginInteraction(t *testing.T) {
 }
 
 func TestGrpcPluginInteraction_ErrorResponse(t *testing.T) {
-	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
-	assert.NoError(t, err)
+	tmpPactFolder := t.TempDir()
 	_ = log.SetLogLevel("INFO")
 
 	m := NewMessageServer("test-message-consumer", "test-message-provider")
@@ -459,15 +455,15 @@ func TestGrpcPluginInteraction_ErrorResponse(t *testing.T) {
 			}
 		}`
 
-	err = i.
+	err := i.
 		Given("plugin state").
 		// For gRPC interactions we prpvide the config once for both the request and response parts
 		WithPluginInteractionContents(INTERACTION_PART_REQUEST, "application/protobuf", grpcInteraction)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	// Start the gRPC mock server
 	port, err := m.StartTransport("grpc", "127.0.0.1", 0, make(map[string][]interface{}))
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer m.CleanupMockServer(port)
 
 	// Now we can make a normal gRPC request
@@ -491,11 +487,11 @@ func TestGrpcPluginInteraction_ErrorResponse(t *testing.T) {
 	defer cancel()
 	r, err := c.InitPlugin(ctx, initPluginRequest)
 	assert.Nil(t, r)
-	assert.ErrorContains(t, err, "not found")
+	require.ErrorContains(t, err, "not found")
 
 	mismatches := m.MockServerMismatchedRequests(port)
 	if len(mismatches) != 0 {
-		assert.Len(t, mismatches, 0)
+		assert.Empty(t, mismatches)
 		t.Log(mismatches)
 	}
 

--- a/internal/native/mismatch.go
+++ b/internal/native/mismatch.go
@@ -28,16 +28,16 @@ type Request struct {
 
 // MismatchDetail contains the specific assertions that failed during the verification.
 type MismatchDetail struct {
-	Actual   string
-	Expected string
-	Key      string
-	Mismatch string
-	Type     string
+	Actual   string `json:"actual"`
+	Expected string `json:"expected"`
+	Key      string `json:"key"`
+	Mismatch string `json:"mismatch"`
+	Type     string `json:"type"`
 }
 
 // MismatchedRequest contains details of any request mismatches during pact verification.
 type MismatchedRequest struct {
 	Request
-	Mismatches []MismatchDetail
-	Type       string
+	Mismatches []MismatchDetail `json:"mismatches"`
+	Type       string           `json:"type"`
 }

--- a/internal/native/mock_server_test.go
+++ b/internal/native/mock_server_test.go
@@ -95,8 +95,7 @@ func TestMockServer_MismatchesFail(t *testing.T) {
 }
 
 func TestMockServer_VerifySuccess(t *testing.T) {
-	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
-	assert.NoError(t, err)
+	tmpPactFolder := t.TempDir()
 
 	m, port := newSimpleMockServer(t)
 	defer m.CleanupMockServer(port)
@@ -118,8 +117,7 @@ func TestMockServer_VerifySuccess(t *testing.T) {
 }
 
 func TestMockServer_VerifyFail(t *testing.T) {
-	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
-	assert.NoError(t, err)
+	tmpPactFolder := t.TempDir()
 	m, port := newSimpleMockServer(t)
 
 	success, mismatches := m.Verify(port, tmpPactFolder)
@@ -133,8 +131,7 @@ func TestMockServer_VerifyFail(t *testing.T) {
 }
 
 func TestMockServer_WritePactfile(t *testing.T) {
-	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
-	assert.NoError(t, err)
+	tmpPactFolder := t.TempDir()
 
 	m, port := newSimpleMockServer(t)
 	defer m.CleanupMockServer(port)
@@ -161,8 +158,7 @@ func TestVersion(t *testing.T) {
 }
 
 func TestHandleBasedHTTPTests(t *testing.T) {
-	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
-	assert.NoError(t, err)
+	tmpPactFolder := t.TempDir()
 
 	m := NewHTTPPact("test-http-consumer", "test-http-provider")
 
@@ -184,7 +180,7 @@ func TestHandleBasedHTTPTests(t *testing.T) {
 	// // Start the mock service
 	// const host = "127.0.0.1"
 	port, err := m.Start("0.0.0.0:0", false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer m.CleanupMockServer(port)
 
 	res, err := httpGet(fmt.Sprintf("http://0.0.0.0:%d/products", port))
@@ -200,8 +196,7 @@ func TestHandleBasedHTTPTests(t *testing.T) {
 }
 
 func TestPluginInteraction(t *testing.T) {
-	tmpPactFolder, err := os.MkdirTemp("", "pact-go")
-	assert.NoError(t, err)
+	tmpPactFolder := t.TempDir()
 	_ = log.SetLogLevel("info")
 
 	m := NewHTTPPact("test-plugin-consumer", "test-plugin-provider")
@@ -224,15 +219,15 @@ func TestPluginInteraction(t *testing.T) {
 			"version": "matching(semver, '0.0.0')"
 		}`
 
-	err = i.UponReceiving("some interaction").
+	err := i.UponReceiving("some interaction").
 		Given("plugin state").
 		WithRequest("GET", "/protobuf").
 		WithStatus(200).
 		WithPluginInteractionContents(INTERACTION_PART_RESPONSE, "application/protobuf", protobufInteraction)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	port, err := m.Start("0.0.0.0:0", false)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 	defer m.CleanupMockServer(port)
 
 	res, err := httpGet(fmt.Sprintf("http://0.0.0.0:%d/protobuf", port))
@@ -240,18 +235,18 @@ func TestPluginInteraction(t *testing.T) {
 	defer func() { _ = res.Body.Close() }()
 
 	bytes, err := io.ReadAll(res.Body)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	initPluginRequest := &InitPluginRequest{}
 	err = proto.Unmarshal(bytes, initPluginRequest)
-	assert.NoError(t, err)
+	require.NoError(t, err)
 
 	assert.Equal(t, "pact-go-driver", initPluginRequest.Implementation)
 	assert.Equal(t, "0.0.0", initPluginRequest.Version)
 
 	mismatches := m.MockServerMismatchedRequests(port)
 	if len(mismatches) != 0 {
-		assert.Len(t, mismatches, 0)
+		assert.Empty(t, mismatches)
 		t.Log(mismatches)
 	}
 

--- a/message/v3/asynchronous_message.go
+++ b/message/v3/asynchronous_message.go
@@ -126,6 +126,7 @@ func (m *AsynchronousMessageBuilderWithContents) ConsumedBy(handler Asynchronous
 
 // The function that will consume the message.
 func (m *AsynchronousMessageBuilderWithConsumer) Verify(t *testing.T) error {
+	t.Helper()
 	return m.rootBuilder.messagePactV3.Verify(t, m.rootBuilder, m.rootBuilder.handler)
 }
 
@@ -246,6 +247,7 @@ func (p *AsynchronousPact) verifyMessageConsumerRaw(messageToVerify *Asynchronou
 // VerifyMessageConsumer is a test convience function for VerifyMessageConsumerRaw,
 // accepting an instance of `*testing.T`.
 func (p *AsynchronousPact) Verify(t *testing.T, message *AsynchronousMessageBuilder, handler AsynchronousConsumer) error {
+	t.Helper()
 	err := p.verifyMessageConsumerRaw(message, handler)
 	if err != nil {
 		t.Errorf("VerifyMessageConsumer failed: %v", err)

--- a/message/v4/asynchronous_message.go
+++ b/message/v4/asynchronous_message.go
@@ -104,6 +104,7 @@ type AsynchronousMessageWithPluginContents struct {
 }
 
 func (s *AsynchronousMessageWithPluginContents) ExecuteTest(t *testing.T, integrationTest func(m AsynchronousMessage) error) error {
+	t.Helper()
 	defer s.rootBuilder.pact.messageserver.CleanupPlugins()
 	message, err := getAsynchronousMessageWithReifiedContents(s.rootBuilder.messageHandle, s.rootBuilder.Type)
 	if err != nil {
@@ -140,6 +141,7 @@ type AsynchronousMessageWithTransport struct {
 }
 
 func (s *AsynchronousMessageWithTransport) ExecuteTest(t *testing.T, integrationTest func(tc TransportConfig, m AsynchronousMessage) error) error {
+	t.Helper()
 	defer s.rootBuilder.pact.messageserver.CleanupMockServer(s.transport.Port)
 	defer s.rootBuilder.pact.messageserver.CleanupPlugins()
 	message, err := getAsynchronousMessageWithReifiedContents(s.rootBuilder.messageHandle, s.rootBuilder.Type)
@@ -216,6 +218,7 @@ type AsynchronousMessageWithConsumer struct {
 
 // The function that will consume the message.
 func (m *AsynchronousMessageWithConsumer) Verify(t *testing.T) error {
+	t.Helper()
 	return m.rootBuilder.pact.Verify(t, m.rootBuilder, m.rootBuilder.handler)
 }
 
@@ -300,6 +303,7 @@ func (p *AsynchronousPact) verifyMessageConsumerRaw(messageToVerify *Asynchronou
 // VerifyMessageConsumer is a test convience function for VerifyMessageConsumerRaw,
 // accepting an instance of `*testing.T`.
 func (p *AsynchronousPact) Verify(t *testing.T, message *AsynchronousMessageBuilder, handler AsynchronousConsumer) error {
+	t.Helper()
 	err := p.verifyMessageConsumerRaw(message, handler)
 	if err != nil {
 		t.Errorf("VerifyMessageConsumer failed: %v", err)

--- a/message/v4/synchronous_message.go
+++ b/message/v4/synchronous_message.go
@@ -215,6 +215,7 @@ type SynchronousMessageWithPluginContents struct {
 // Will cleanup interactions between tests within a suite
 // and write the pact file if successful.
 func (m *SynchronousMessageWithPluginContents) ExecuteTest(t *testing.T, integrationTest func(m SynchronousMessage) error) error {
+	t.Helper()
 	defer m.pact.mockserver.CleanupPlugins()
 	message, err := getSynchronousMessageWithContents(m.messageHandle)
 	if err != nil {
@@ -252,6 +253,7 @@ type SynchronousMessageWithTransport struct {
 }
 
 func (s *SynchronousMessageWithTransport) ExecuteTest(t *testing.T, integrationTest func(tc TransportConfig, m SynchronousMessage) error) error {
+	t.Helper()
 	defer s.pact.mockserver.CleanupMockServer(s.transport.Port)
 	defer s.pact.mockserver.CleanupPlugins()
 	message, err := getSynchronousMessageWithContents(s.messageHandle)
@@ -326,6 +328,7 @@ func (m *SynchronousPact) AddSynchronousMessage(description string) *Unconfigure
 // Will cleanup interactions between tests within a suite
 // and write the pact file if successful.
 func (m *SynchronousMessageWithResponse) ExecuteTest(t *testing.T, integrationTest func(md SynchronousMessage) error) error {
+	t.Helper()
 	message, err := getSynchronousMessageWithContents(m.messageHandle)
 	if err != nil {
 		return err

--- a/message/verifier_test.go
+++ b/message/verifier_test.go
@@ -1,0 +1,171 @@
+package message
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/pact-foundation/pact-go/v2/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// erroringBody is an io.ReadCloser that fails on Read, used to
+// characterise CreateMessageHandler's handling of a body it cannot read.
+type erroringBody struct{}
+
+func (erroringBody) Read(p []byte) (int, error) { return 0, errors.New("read boom") }
+func (erroringBody) Close() error               { return nil }
+
+// TestCreateMessageHandler_PassThrough characterises the case where the
+// request does not target the message-verification path: the middleware
+// must not touch the response and must delegate straight to next.
+func TestCreateMessageHandler_PassThrough(t *testing.T) {
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	mw := CreateMessageHandler(Handlers{})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/not-the-messages-path", strings.NewReader(""))
+	rr := httptest.NewRecorder()
+
+	mw(next).ServeHTTP(rr, req)
+
+	assert.True(t, nextCalled)
+	assert.Equal(t, http.StatusTeapot, rr.Code)
+}
+
+// TestCreateMessageHandler_UnreadableBody characterises the response when
+// the request body cannot be read at all.
+func TestCreateMessageHandler_UnreadableBody(t *testing.T) {
+	mw := CreateMessageHandler(Handlers{})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/__messages", erroringBody{})
+	rr := httptest.NewRecorder()
+
+	mw(nil).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+// TestCreateMessageHandler_InvalidJSON characterises the response to a body
+// that is readable but not valid JSON.
+func TestCreateMessageHandler_InvalidJSON(t *testing.T) {
+	mw := CreateMessageHandler(Handlers{})
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/__messages", strings.NewReader("not-json"))
+	rr := httptest.NewRecorder()
+
+	mw(nil).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusBadRequest, rr.Code)
+}
+
+// TestCreateMessageHandler_MessageNotFound characterises the response when
+// no handler is registered for the requested description.
+func TestCreateMessageHandler_MessageNotFound(t *testing.T) {
+	mw := CreateMessageHandler(Handlers{})
+	body := `{"description":"an unregistered message"}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/__messages", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	mw(nil).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusNotFound, rr.Code)
+}
+
+// TestCreateMessageHandler_HandlerErrors characterises the response when
+// the registered handler returns an error.
+func TestCreateMessageHandler_HandlerErrors(t *testing.T) {
+	handlers := Handlers{
+		"a user event": func(states []models.ProviderState) (Body, Metadata, error) {
+			return nil, nil, errors.New("handler boom")
+		},
+	}
+	mw := CreateMessageHandler(handlers)
+	body := `{"description":"a user event"}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/__messages", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	mw(nil).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusServiceUnavailable, rr.Code)
+}
+
+// TestCreateMessageHandler_ByteBody characterises the success path where
+// the handler returns a []byte body: it is written through unmodified,
+// without being re-encoded as JSON.
+func TestCreateMessageHandler_ByteBody(t *testing.T) {
+	var gotStates []models.ProviderState
+	handlers := Handlers{
+		"a user event": func(states []models.ProviderState) (Body, Metadata, error) {
+			gotStates = states
+			// Deliberately not valid JSON: proves the handler writes these
+			// bytes through unmodified rather than re-encoding them.
+			return []byte("raw-bytes-payload"), nil, nil
+		},
+	}
+	mw := CreateMessageHandler(handlers)
+	body := `{"description":"a user event","providerStates":[{"name":"User with id 127 exists"}]}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/__messages", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	mw(nil).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "raw-bytes-payload", rr.Body.String())
+	require.Len(t, gotStates, 1)
+	assert.Equal(t, "User with id 127 exists", gotStates[0].Name)
+}
+
+// TestCreateMessageHandler_NonByteBody characterises the success path where
+// the handler returns a non-[]byte body: it is marshalled as JSON before
+// being written.
+func TestCreateMessageHandler_NonByteBody(t *testing.T) {
+	handlers := Handlers{
+		"a user event": func(states []models.ProviderState) (Body, Metadata, error) {
+			return map[string]any{"id": float64(127)}, nil, nil
+		},
+	}
+	mw := CreateMessageHandler(handlers)
+	body := `{"description":"a user event"}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/__messages", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	mw(nil).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+
+	var got map[string]any
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+	assert.InDelta(t, 127, got["id"], 0)
+}
+
+// TestCreateMessageHandler_MetadataHeaders characterises the metadata
+// propagation: non-empty metadata is base64-encoded onto both metadata
+// headers, and a "contentType" entry overrides the response Content-Type.
+func TestCreateMessageHandler_MetadataHeaders(t *testing.T) {
+	handlers := Handlers{
+		"a user event": func(states []models.ProviderState) (Body, Metadata, error) {
+			return []byte("payload"), Metadata{"contentType": "text/plain"}, nil
+		},
+	}
+	mw := CreateMessageHandler(handlers)
+	body := `{"description":"a user event"}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/__messages", strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	mw(nil).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "text/plain", rr.Header().Get("Content-Type"))
+	assert.NotEmpty(t, rr.Header().Get(PACT_MESSAGE_METADATA_HEADER))
+	assert.NotEmpty(t, rr.Header().Get(PACT_MESSAGE_METADATA_HEADER2))
+}
+
+var _ io.ReadCloser = erroringBody{}

--- a/provider/verifier.go
+++ b/provider/verifier.go
@@ -191,6 +191,7 @@ func (v *Verifier) verifyProviderRaw(request VerifyRequest, writer outputWriter)
 //     the verifier itself could not produce a result (infrastructure
 //     error, panic, etc.).
 func (v *Verifier) VerifyProvider(t *testing.T, request VerifyRequest) error {
+	t.Helper()
 	err := v.verifyProviderRaw(request, t)
 
 	// TODO: granular test reporting
@@ -241,9 +242,9 @@ func beforeEachMiddleware(BeforeEach Hook) proxy.Middleware {
 
 // {"action":"teardown","id":"foo","state":"User foo exists"}.
 type stateHandlerAction struct {
-	Action string `json:"action"`
-	State  string `json:"state"`
-	Params map[string]interface{}
+	Action string                 `json:"action"`
+	State  string                 `json:"state"`
+	Params map[string]interface{} `json:"params"`
 }
 
 func getStateFromRequest(r *http.Request) (stateHandlerAction, error) {

--- a/provider/verifier_test.go
+++ b/provider/verifier_test.go
@@ -1,0 +1,243 @@
+package provider
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/pact-foundation/pact-go/v2/models"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestStateHandlerMiddleware_PassThrough characterises the case where the
+// request does not target the state-setup path: the middleware must not
+// touch the response and must delegate straight to next.
+func TestStateHandlerMiddleware_PassThrough(t *testing.T) {
+	nextCalled := false
+	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		nextCalled = true
+		w.WriteHeader(http.StatusTeapot)
+	})
+
+	mw := stateHandlerMiddleware(models.StateHandlers{}, nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, "/not-the-setup-path", strings.NewReader(""))
+	rr := httptest.NewRecorder()
+
+	mw(next).ServeHTTP(rr, req)
+
+	assert.True(t, nextCalled)
+	assert.Equal(t, http.StatusTeapot, rr.Code)
+}
+
+// TestStateHandlerMiddleware_InvalidPayload characterises the response to a
+// request body that cannot be decoded as a stateHandlerAction.
+func TestStateHandlerMiddleware_InvalidPayload(t *testing.T) {
+	mw := stateHandlerMiddleware(models.StateHandlers{}, nil)
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, providerStatesSetupPath, strings.NewReader("not-json"))
+	rr := httptest.NewRecorder()
+
+	mw(nil).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+// TestStateHandlerMiddleware_StateNotFound characterises the "no handler
+// registered for this state" path: it returns 200 without invoking any
+// handler, sharing the trailing w.WriteHeader(http.StatusOK) with the
+// success path inside the "found" branch.
+func TestStateHandlerMiddleware_StateNotFound(t *testing.T) {
+	handlerCalled := false
+	handlers := models.StateHandlers{
+		"a different state": func(setup bool, s models.ProviderState) (models.ProviderStateResponse, error) {
+			handlerCalled = true
+			return nil, nil
+		},
+	}
+
+	mw := stateHandlerMiddleware(handlers, nil)
+	body := `{"action":"setup","state":"unregistered state"}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, providerStatesSetupPath, strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	mw(nil).ServeHTTP(rr, req)
+
+	assert.False(t, handlerCalled)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, rr.Body.String())
+}
+
+// TestStateHandlerMiddleware_SetupNoResponse characterises the setup path
+// for a found state handler that returns no provider state values: it
+// falls through to the same trailing 200 as the "not found" case.
+func TestStateHandlerMiddleware_SetupNoResponse(t *testing.T) {
+	var gotSetup bool
+	var gotState models.ProviderState
+	handlers := models.StateHandlers{
+		"User foo exists": func(setup bool, s models.ProviderState) (models.ProviderStateResponse, error) {
+			gotSetup = setup
+			gotState = s
+			return nil, nil
+		},
+	}
+
+	mw := stateHandlerMiddleware(handlers, nil)
+	body := `{"action":"setup","state":"User foo exists","id":"foo"}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, providerStatesSetupPath, strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	mw(nil).ServeHTTP(rr, req)
+
+	assert.True(t, gotSetup)
+	assert.Equal(t, "User foo exists", gotState.Name)
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Empty(t, rr.Body.String())
+}
+
+// TestStateHandlerMiddleware_TeardownNoAfterEach characterises the teardown
+// path when no AfterEach hook is configured: the handler runs with
+// setup=false and afterEach is simply skipped.
+func TestStateHandlerMiddleware_TeardownNoAfterEach(t *testing.T) {
+	var gotSetup bool
+	handlerCalled := false
+	handlers := models.StateHandlers{
+		"User foo exists": func(setup bool, s models.ProviderState) (models.ProviderStateResponse, error) {
+			handlerCalled = true
+			gotSetup = setup
+			return nil, nil
+		},
+	}
+
+	mw := stateHandlerMiddleware(handlers, nil)
+	body := `{"action":"teardown","state":"User foo exists"}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, providerStatesSetupPath, strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	mw(nil).ServeHTTP(rr, req)
+
+	assert.True(t, handlerCalled)
+	assert.False(t, gotSetup)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+// TestStateHandlerMiddleware_TeardownAfterEachSucceeds characterises the
+// teardown path when an AfterEach hook is configured and succeeds.
+func TestStateHandlerMiddleware_TeardownAfterEachSucceeds(t *testing.T) {
+	afterEachCalled := false
+	handlers := models.StateHandlers{
+		"User foo exists": func(setup bool, s models.ProviderState) (models.ProviderStateResponse, error) {
+			return nil, nil
+		},
+	}
+
+	mw := stateHandlerMiddleware(handlers, func() error {
+		afterEachCalled = true
+		return nil
+	})
+	body := `{"action":"teardown","state":"User foo exists"}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, providerStatesSetupPath, strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	mw(nil).ServeHTTP(rr, req)
+
+	assert.True(t, afterEachCalled)
+	assert.Equal(t, http.StatusOK, rr.Code)
+}
+
+// TestStateHandlerMiddleware_TeardownAfterEachErrors characterises the
+// teardown path when the AfterEach hook itself fails: the middleware must
+// respond 500 and must not fall through to the trailing 200.
+func TestStateHandlerMiddleware_TeardownAfterEachErrors(t *testing.T) {
+	handlers := models.StateHandlers{
+		"User foo exists": func(setup bool, s models.ProviderState) (models.ProviderStateResponse, error) {
+			return nil, nil
+		},
+	}
+
+	mw := stateHandlerMiddleware(handlers, func() error {
+		return errors.New("after each boom")
+	})
+	body := `{"action":"teardown","state":"User foo exists"}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, providerStatesSetupPath, strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	mw(nil).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+// TestStateHandlerMiddleware_HandlerErrors characterises the case where the
+// state handler itself returns an error: the middleware must respond 500.
+func TestStateHandlerMiddleware_HandlerErrors(t *testing.T) {
+	handlers := models.StateHandlers{
+		"User foo exists": func(setup bool, s models.ProviderState) (models.ProviderStateResponse, error) {
+			return nil, errors.New("state handler boom")
+		},
+	}
+
+	mw := stateHandlerMiddleware(handlers, nil)
+	body := `{"action":"setup","state":"User foo exists"}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, providerStatesSetupPath, strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	mw(nil).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusInternalServerError, rr.Code)
+}
+
+// TestStateHandlerMiddleware_ReturnsProviderStateValues characterises the
+// success path where the handler returns provider state values: the
+// middleware must marshal them as JSON, set the content-type header, and
+// respond 200 with the body — a distinct exit from the shared trailing
+// w.WriteHeader(http.StatusOK) used by the other success paths.
+func TestStateHandlerMiddleware_ReturnsProviderStateValues(t *testing.T) {
+	handlers := models.StateHandlers{
+		"User foo exists": func(setup bool, s models.ProviderState) (models.ProviderStateResponse, error) {
+			return models.ProviderStateResponse{"uuid": "1234"}, nil
+		},
+	}
+
+	mw := stateHandlerMiddleware(handlers, nil)
+	body := `{"action":"setup","state":"User foo exists"}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, providerStatesSetupPath, strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	mw(nil).ServeHTTP(rr, req)
+
+	assert.Equal(t, http.StatusOK, rr.Code)
+	assert.Equal(t, "application/json", rr.Header().Get("content-type"))
+
+	var got models.ProviderStateResponse
+	require.NoError(t, json.Unmarshal(rr.Body.Bytes(), &got))
+	assert.Equal(t, "1234", got["uuid"])
+}
+
+// TestStateHandlerMiddleware_ParamsExtracted characterises the extraction
+// of extra top-level payload fields into ProviderState.Parameters, with
+// "action" and "state" excluded.
+func TestStateHandlerMiddleware_ParamsExtracted(t *testing.T) {
+	var gotState models.ProviderState
+	handlers := models.StateHandlers{
+		"User foo exists": func(setup bool, s models.ProviderState) (models.ProviderStateResponse, error) {
+			gotState = s
+			return nil, nil
+		},
+	}
+
+	mw := stateHandlerMiddleware(handlers, nil)
+	body := `{"action":"setup","state":"User foo exists","id":"foo"}`
+	req := httptest.NewRequestWithContext(context.Background(), http.MethodPost, providerStatesSetupPath, strings.NewReader(body))
+	rr := httptest.NewRecorder()
+
+	mw(nil).ServeHTTP(rr, req)
+
+	assert.Equal(t, "foo", gotState.Parameters["id"])
+	_, hasAction := gotState.Parameters["action"]
+	_, hasState := gotState.Parameters["state"]
+	assert.False(t, hasAction)
+	assert.False(t, hasState)
+}

--- a/provider/verify_request_test.go
+++ b/provider/verify_request_test.go
@@ -1,7 +1,6 @@
 package provider
 
 import (
-	"os"
 	"testing"
 
 	"github.com/pact-foundation/pact-go/v2/command"
@@ -112,22 +111,13 @@ func TestVerifyRequestValidate(t *testing.T) {
 func TestVerifyRequest(t *testing.T) {
 	t.Run("#addPactUrlsFromEnvironment", func(t *testing.T) {
 		const webhookURL, verificationUrl = "pact_changed_webhook_url", "http://localhost:1234/path/to/pact"
-		enablePactUrlFunc := func() func() {
-			const pactUrl = "PACT_URL"
-			err := os.Setenv(pactUrl, webhookURL)
-			if err != nil {
-				panic(err)
-			}
-			return func() {
-				err := os.Unsetenv(pactUrl)
-				if err != nil {
-					panic(err)
-				}
-			}
+		enablePactUrlFunc := func(t *testing.T) {
+			t.Helper()
+			t.Setenv("PACT_URL", webhookURL)
 		}
 		tests := []struct {
 			name         string
-			setup        func() (teardown func())
+			setup        func(t *testing.T)
 			request      *VerifyRequest
 			expectedSize int
 			expectedUrls []string
@@ -146,15 +136,15 @@ func TestVerifyRequest(t *testing.T) {
 			},
 			{
 				name:         "without env var and configured PactURLS",
-				setup:        func() func() { return func() {} },
 				request:      &VerifyRequest{PactURLs: []string{verificationUrl}},
 				expectedUrls: []string{verificationUrl},
 			},
 		}
 		for _, tt := range tests {
 			t.Run(tt.name, func(t *testing.T) {
-				teardown := tt.setup()
-				defer teardown()
+				if tt.setup != nil {
+					tt.setup(t)
+				}
 				addPactUrlsFromEnvironment(tt.request)
 				assert.ElementsMatch(t, tt.request.PactURLs, tt.expectedUrls)
 			})


### PR DESCRIPTION
## Summary

Enables `testifylint`, `usetesting`, `thelper` and `musttag`, then adds characterisation tests for `stateHandlerMiddleware` and `CreateMessageHandler`.

## Motivation

Both handlers get restructured by `nestif` in #615, and neither had any coverage — `message` had no test file at all and `stateHandlerMiddleware` reported 0.0%. Restructuring an HTTP handler blind risks the classic missed-return or duplicated-`WriteHeader` bug, particularly around `stateHandlerMiddleware`'s trailing `w.WriteHeader(http.StatusOK)` reached from two different branches.

## Notes for reviewers

The tests pin *today's* behaviour — status codes, bodies, header propagation — across every branch, so the restructure in #615 has something to prove itself against instead of asserting its own output. They are deliberately written against the unrestructured code and should not be adjusted to match a later refactor.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
