### PR TITLE
refactor: enable modernisation, gocritic and protogetter linters

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -13,6 +13,7 @@ linters:
     - errorlint
     - exhaustive
     - forcetypeassert
+    - gocritic
     - godot
     - gosec
     - intrange
@@ -20,6 +21,7 @@ linters:
     - misspell
     - modernize
     - musttag
+    - nestif
     - nilerr
     - nilnesserr
     - noctx

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,6 +27,7 @@ linters:
     - noctx
     - noinlineerr
     - perfsprint
+    - protogetter
     - testifylint
     - thelper
     - unconvert

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -15,14 +15,20 @@ linters:
     - forcetypeassert
     - godot
     - gosec
+    - intrange
+    - mirror
     - misspell
+    - modernize
     - musttag
     - nilerr
     - nilnesserr
     - noctx
     - noinlineerr
+    - perfsprint
     - testifylint
     - thelper
+    - unconvert
+    - usestdlibvars
     - usetesting
     - whitespace
   settings:

--- a/consumer/http.go
+++ b/consumer/http.go
@@ -142,7 +142,7 @@ func (p *httpMockProvider) ExecuteTest(t *testing.T, integrationTest func(MockSe
 	}
 
 	if err != nil {
-		return fmt.Errorf("error: unable to find free port, mock server will fail to start")
+		return errors.New("error: unable to find free port, mock server will fail to start")
 	}
 
 	p.config.Port, err = p.mockserver.Start(fmt.Sprintf("%s:%d", p.config.Host, p.config.Port), p.config.TLS)

--- a/consumer/http_v2.go
+++ b/consumer/http_v2.go
@@ -148,7 +148,7 @@ func (i *V2RequestBuilder) Headers(headers matchers.HeadersMatcher) *V2RequestBu
 }
 
 // JSONBody adds a JSON body to the expected request.
-func (i *V2RequestBuilder) JSONBody(body interface{}) *V2RequestBuilder {
+func (i *V2RequestBuilder) JSONBody(body any) *V2RequestBuilder {
 	// TODO: Don't like panic, but not sure if there is a better builder experience?
 	err := validateMatchers(i.interaction.specificationVersion, body)
 	if err != nil {
@@ -159,7 +159,7 @@ func (i *V2RequestBuilder) JSONBody(body interface{}) *V2RequestBuilder {
 		// Check if someone tried to add an object as a string representation
 		// as per original allowed implementation, e.g.
 		// { "foo": "bar", "baz": like("bat") }
-		if utils.IsJSONFormattedObject(string(s)) {
+		if utils.IsJSONFormattedObject(s) {
 			log.Println("[WARN] request body appears to be a JSON formatted object, " +
 				"no matching will occur. Support for structured strings has been" +
 				"deprecated as of 0.13.0. Please use the JSON() method instead")
@@ -202,7 +202,7 @@ func (i *V2RequestBuilder) Body(contentType string, body []byte) *V2RequestBuild
 }
 
 // BodyMatch uses struct tags to automatically determine matchers from the given struct.
-func (i *V2RequestBuilder) BodyMatch(body interface{}) *V2RequestBuilder {
+func (i *V2RequestBuilder) BodyMatch(body any) *V2RequestBuilder {
 	i.interaction.interaction.WithJSONRequestBody(matchers.MatchV2(body))
 
 	return i
@@ -252,7 +252,7 @@ func (i *V2ResponseBuilder) Headers(headers matchers.HeadersMatcher) *V2Response
 }
 
 // JSONBody adds a JSON body to the expected response.
-func (i *V2ResponseBuilder) JSONBody(body interface{}) *V2ResponseBuilder {
+func (i *V2ResponseBuilder) JSONBody(body any) *V2ResponseBuilder {
 	// TODO: Don't like panic, how to build a better builder here - nil return + log?
 	err := validateMatchers(i.interaction.specificationVersion, body)
 	if err != nil {
@@ -263,7 +263,7 @@ func (i *V2ResponseBuilder) JSONBody(body interface{}) *V2ResponseBuilder {
 		// Check if someone tried to add an object as a string representation
 		// as per original allowed implementation, e.g.
 		// { "foo": "bar", "baz": like("bat") }
-		if utils.IsJSONFormattedObject(string(s)) {
+		if utils.IsJSONFormattedObject(s) {
 			log.Println("[WARN] response body appears to be a JSON formatted object, " +
 				"no matching will occur. Support for structured strings has been" +
 				"deprecated as of 0.13.0. Please use the JSON() method instead")
@@ -296,7 +296,7 @@ func (i *V2ResponseBuilder) Body(contentType string, body []byte) *V2ResponseBui
 }
 
 // BodyMatch uses struct tags to automatically determine matchers from the given struct.
-func (i *V2ResponseBuilder) BodyMatch(body interface{}) *V2ResponseBuilder {
+func (i *V2ResponseBuilder) BodyMatch(body any) *V2ResponseBuilder {
 	i.interaction.interaction.WithJSONResponseBody(matchers.MatchV2(body))
 
 	return i

--- a/consumer/http_v3.go
+++ b/consumer/http_v3.go
@@ -159,7 +159,7 @@ func (i *V3RequestBuilder) Headers(headers matchers.HeadersMatcher) *V3RequestBu
 }
 
 // JSONBody adds a JSON body to the expected request.
-func (i *V3RequestBuilder) JSONBody(body interface{}) *V3RequestBuilder {
+func (i *V3RequestBuilder) JSONBody(body any) *V3RequestBuilder {
 	// TODO: Don't like panic, but not sure if there is a better builder experience?
 	err := validateMatchers(i.interaction.specificationVersion, body)
 	if err != nil {
@@ -170,7 +170,7 @@ func (i *V3RequestBuilder) JSONBody(body interface{}) *V3RequestBuilder {
 		// Check if someone tried to add an object as a string representation
 		// as per original allowed implementation, e.g.
 		// { "foo": "bar", "baz": like("bat") }
-		if utils.IsJSONFormattedObject(string(s)) {
+		if utils.IsJSONFormattedObject(s) {
 			log.Println("[WARN] request body appears to be a JSON formatted object, " +
 				"no matching will occur. Support for structured strings has been" +
 				"deprecated as of 0.13.0. Please use the JSON() method instead")
@@ -213,7 +213,7 @@ func (i *V3RequestBuilder) Body(contentType string, body []byte) *V3RequestBuild
 }
 
 // BodyMatch uses struct tags to automatically determine matchers from the given struct.
-func (i *V3RequestBuilder) BodyMatch(body interface{}) *V3RequestBuilder {
+func (i *V3RequestBuilder) BodyMatch(body any) *V3RequestBuilder {
 	i.interaction.interaction.WithJSONRequestBody(matchers.MatchV2(body))
 
 	return i
@@ -263,7 +263,7 @@ func (i *V3ResponseBuilder) Headers(headers matchers.HeadersMatcher) *V3Response
 }
 
 // JSONBody adds a JSON body to the expected response.
-func (i *V3ResponseBuilder) JSONBody(body interface{}) *V3ResponseBuilder {
+func (i *V3ResponseBuilder) JSONBody(body any) *V3ResponseBuilder {
 	// TODO: Don't like panic, how to build a better builder here - nil return + log?
 	err := validateMatchers(i.interaction.specificationVersion, body)
 	if err != nil {
@@ -274,7 +274,7 @@ func (i *V3ResponseBuilder) JSONBody(body interface{}) *V3ResponseBuilder {
 		// Check if someone tried to add an object as a string representation
 		// as per original allowed implementation, e.g.
 		// { "foo": "bar", "baz": like("bat") }
-		if utils.IsJSONFormattedObject(string(s)) {
+		if utils.IsJSONFormattedObject(s) {
 			log.Println("[WARN] response body appears to be a JSON formatted object, " +
 				"no matching will occur. Support for structured strings has been" +
 				"deprecated as of 0.13.0. Please use the JSON() method instead")
@@ -307,7 +307,7 @@ func (i *V3ResponseBuilder) Body(contentType string, body []byte) *V3ResponseBui
 }
 
 // BodyMatch uses struct tags to automatically determine matchers from the given struct.
-func (i *V3ResponseBuilder) BodyMatch(body interface{}) *V3ResponseBuilder {
+func (i *V3ResponseBuilder) BodyMatch(body any) *V3ResponseBuilder {
 	i.interaction.interaction.WithJSONResponseBody(matchers.MatchV2(body))
 
 	return i

--- a/consumer/http_v4.go
+++ b/consumer/http_v4.go
@@ -169,7 +169,7 @@ func (i *V4RequestBuilder) Headers(headers matchers.HeadersMatcher) *V4RequestBu
 }
 
 // JSONBody adds a JSON body to the expected request.
-func (i *V4RequestBuilder) JSONBody(body interface{}) *V4RequestBuilder {
+func (i *V4RequestBuilder) JSONBody(body any) *V4RequestBuilder {
 	// TODO: Don't like panic, but not sure if there is a better builder experience?
 	err := validateMatchers(i.interaction.specificationVersion, body)
 	if err != nil {
@@ -180,7 +180,7 @@ func (i *V4RequestBuilder) JSONBody(body interface{}) *V4RequestBuilder {
 		// Check if someone tried to add an object as a string representation
 		// as per original allowed implementation, e.g.
 		// { "foo": "bar", "baz": like("bat") }
-		if utils.IsJSONFormattedObject(string(s)) {
+		if utils.IsJSONFormattedObject(s) {
 			log.Println("[WARN] request body appears to be a JSON formatted object, " +
 				"no matching will occur. Support for structured strings has been" +
 				"deprecated as of 0.13.0. Please use the JSON() method instead")
@@ -223,7 +223,7 @@ func (i *V4RequestBuilder) Body(contentType string, body []byte) *V4RequestBuild
 }
 
 // BodyMatch uses struct tags to automatically determine matchers from the given struct.
-func (i *V4RequestBuilder) BodyMatch(body interface{}) *V4RequestBuilder {
+func (i *V4RequestBuilder) BodyMatch(body any) *V4RequestBuilder {
 	i.interaction.interaction.WithJSONRequestBody(matchers.MatchV2(body))
 
 	return i
@@ -273,7 +273,7 @@ func (i *V4ResponseBuilder) Headers(headers matchers.HeadersMatcher) *V4Response
 }
 
 // JSONBody adds a JSON body to the expected response.
-func (i *V4ResponseBuilder) JSONBody(body interface{}) *V4ResponseBuilder {
+func (i *V4ResponseBuilder) JSONBody(body any) *V4ResponseBuilder {
 	// TODO: Don't like panic, how to build a better builder here - nil return + log?
 	err := validateMatchers(i.interaction.specificationVersion, body)
 	if err != nil {
@@ -284,7 +284,7 @@ func (i *V4ResponseBuilder) JSONBody(body interface{}) *V4ResponseBuilder {
 		// Check if someone tried to add an object as a string representation
 		// as per original allowed implementation, e.g.
 		// { "foo": "bar", "baz": like("bat") }
-		if utils.IsJSONFormattedObject(string(s)) {
+		if utils.IsJSONFormattedObject(s) {
 			log.Println("[WARN] response body appears to be a JSON formatted object, " +
 				"no matching will occur. Support for structured strings has been" +
 				"deprecated as of 0.13.0. Please use the JSON() method instead")
@@ -317,7 +317,7 @@ func (i *V4ResponseBuilder) Body(contentType string, body []byte) *V4ResponseBui
 }
 
 // BodyMatch uses struct tags to automatically determine matchers from the given struct.
-func (i *V4ResponseBuilder) BodyMatch(body interface{}) *V4ResponseBuilder {
+func (i *V4ResponseBuilder) BodyMatch(body any) *V4ResponseBuilder {
 	i.interaction.interaction.WithJSONResponseBody(matchers.MatchV2(body))
 
 	return i
@@ -479,7 +479,7 @@ func (i *V4InteractionWithPluginRequestBuilder) PluginContents(contentType strin
 }
 
 // JSONBody adds a JSON body to the expected request.
-func (i *V4InteractionWithPluginRequestBuilder) JSONBody(body interface{}) *V4InteractionWithPluginRequestBuilder {
+func (i *V4InteractionWithPluginRequestBuilder) JSONBody(body any) *V4InteractionWithPluginRequestBuilder {
 	// TODO: Don't like panic, but not sure if there is a better builder experience?
 	err := validateMatchers(i.interaction.specificationVersion, body)
 	if err != nil {
@@ -490,7 +490,7 @@ func (i *V4InteractionWithPluginRequestBuilder) JSONBody(body interface{}) *V4In
 		// Check if someone tried to add an object as a string representation
 		// as per original allowed implementation, e.g.
 		// { "foo": "bar", "baz": like("bat") }
-		if utils.IsJSONFormattedObject(string(s)) {
+		if utils.IsJSONFormattedObject(s) {
 			log.Println("[WARN] request body appears to be a JSON formatted object, " +
 				"no matching will occur. Support for structured strings has been" +
 				"deprecated as of 0.13.0. Please use the JSON() method instead")
@@ -533,7 +533,7 @@ func (i *V4InteractionWithPluginRequestBuilder) Body(contentType string, body []
 }
 
 // BodyMatch uses struct tags to automatically determine matchers from the given struct.
-func (i *V4InteractionWithPluginRequestBuilder) BodyMatch(body interface{}) *V4InteractionWithPluginRequestBuilder {
+func (i *V4InteractionWithPluginRequestBuilder) BodyMatch(body any) *V4InteractionWithPluginRequestBuilder {
 	i.interaction.interaction.WithJSONRequestBody(matchers.MatchV2(body))
 
 	return i
@@ -565,7 +565,7 @@ func (i *V4InteractionWithPluginResponseBuilder) PluginContents(contentType stri
 }
 
 // JSONBody adds a JSON body to the expected response.
-func (i *V4InteractionWithPluginResponseBuilder) JSONBody(body interface{}) *V4InteractionWithPluginResponseBuilder {
+func (i *V4InteractionWithPluginResponseBuilder) JSONBody(body any) *V4InteractionWithPluginResponseBuilder {
 	// TODO: Don't like panic, how to build a better builder here - nil return + log?
 	err := validateMatchers(i.interaction.specificationVersion, body)
 	if err != nil {
@@ -576,7 +576,7 @@ func (i *V4InteractionWithPluginResponseBuilder) JSONBody(body interface{}) *V4I
 		// Check if someone tried to add an object as a string representation
 		// as per original allowed implementation, e.g.
 		// { "foo": "bar", "baz": like("bat") }
-		if utils.IsJSONFormattedObject(string(s)) {
+		if utils.IsJSONFormattedObject(s) {
 			log.Println("[WARN] response body appears to be a JSON formatted object, " +
 				"no matching will occur. Support for structured strings has been" +
 				"deprecated as of 0.13.0. Please use the JSON() method instead")
@@ -609,7 +609,7 @@ func (i *V4InteractionWithPluginResponseBuilder) Body(contentType string, body [
 }
 
 // BodyMatch uses struct tags to automatically determine matchers from the given struct.
-func (i *V4InteractionWithPluginResponseBuilder) BodyMatch(body interface{}) *V4InteractionWithPluginResponseBuilder {
+func (i *V4InteractionWithPluginResponseBuilder) BodyMatch(body any) *V4InteractionWithPluginResponseBuilder {
 	i.interaction.interaction.WithJSONResponseBody(matchers.MatchV2(body))
 
 	return i

--- a/consumer/http_v4_test.go
+++ b/consumer/http_v4_test.go
@@ -53,7 +53,7 @@ func TestHttpV4TypeSystem(t *testing.T) {
 	require.Error(t, err)
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/pact_plugin.proto", strings.ReplaceAll(dir, "\\", "/"))
+	path := strings.ReplaceAll(dir, "\\", "/") + "/pact_plugin.proto"
 
 	err = p.AddInteraction().
 		Given("some state").

--- a/consumer/interaction.go
+++ b/consumer/interaction.go
@@ -21,7 +21,7 @@ type Interaction struct {
 // confirm that the Provider provides an API listening on the given interface.
 // Mandatory.
 func (i *Interaction) WithCompleteRequest(request Request) *Interaction {
-	i.interaction.WithRequest(string(request.Method), request.Path)
+	i.interaction.WithRequest(request.Method, request.Path)
 
 	if request.Body != nil {
 		i.interaction.WithJSONRequestBody(request.Body)
@@ -53,7 +53,7 @@ func (i *Interaction) WithCompleteResponse(response Response) *Interaction {
 	return i
 }
 
-func validateMatchers(version models.SpecificationVersion, obj interface{}) error {
+func validateMatchers(version models.SpecificationVersion, obj any) error {
 	if obj == nil {
 		return nil
 	}
@@ -63,13 +63,13 @@ func validateMatchers(version models.SpecificationVersion, obj interface{}) erro
 		return err
 	}
 
-	var raw interface{}
+	var raw any
 	err = json.Unmarshal(str, &raw)
 	if err != nil {
 		return err
 	}
 
-	maybeMatchers, ok := raw.(map[string]interface{})
+	maybeMatchers, ok := raw.(map[string]any)
 	if !ok {
 		// Not a JSON object (e.g. a string, number, or array) - nothing to validate.
 		return nil
@@ -84,7 +84,7 @@ func validateMatchers(version models.SpecificationVersion, obj interface{}) erro
 	return nil
 }
 
-func hasMatcherGreaterThanSpec(version models.SpecificationVersion, obj map[string]interface{}) []string {
+func hasMatcherGreaterThanSpec(version models.SpecificationVersion, obj map[string]any) []string {
 	results := make([]string, 0)
 
 	for k, v := range obj {
@@ -99,7 +99,7 @@ func hasMatcherGreaterThanSpec(version models.SpecificationVersion, obj map[stri
 			results = append(results, matcherType)
 		}
 
-		m, ok := v.(map[string]interface{})
+		m, ok := v.(map[string]any)
 		if ok {
 			results = append(results, hasMatcherGreaterThanSpec(version, m)...)
 		}
@@ -108,8 +108,8 @@ func hasMatcherGreaterThanSpec(version models.SpecificationVersion, obj map[stri
 	return results
 }
 
-func keyValuesToMapStringArrayInterface(key string, values ...matchers.Matcher) map[string][]interface{} {
-	q := make(map[string][]interface{})
+func keyValuesToMapStringArrayInterface(key string, values ...matchers.Matcher) map[string][]any {
+	q := make(map[string][]any)
 	for _, v := range values {
 		q[key] = append(q[key], v)
 	}
@@ -117,11 +117,11 @@ func keyValuesToMapStringArrayInterface(key string, values ...matchers.Matcher) 
 	return q
 }
 
-func headersMatcherToNativeHeaders(headers matchers.HeadersMatcher) map[string][]interface{} {
-	h := make(map[string][]interface{})
+func headersMatcherToNativeHeaders(headers matchers.HeadersMatcher) map[string][]any {
+	h := make(map[string][]any)
 
 	for k, v := range headers {
-		h[k] = make([]interface{}, len(v))
+		h[k] = make([]any, len(v))
 		for i, vv := range v {
 			h[k][i] = vv
 		}
@@ -130,11 +130,11 @@ func headersMatcherToNativeHeaders(headers matchers.HeadersMatcher) map[string][
 	return h
 }
 
-func headersMapMatcherToNativeHeaders(headers matchers.MapMatcher) map[string][]interface{} {
-	h := make(map[string][]interface{})
+func headersMapMatcherToNativeHeaders(headers matchers.MapMatcher) map[string][]any {
+	h := make(map[string][]any)
 
 	for k, v := range headers {
-		h[k] = []interface{}{
+		h[k] = []any{
 			v,
 		}
 	}

--- a/consumer/interaction_test.go
+++ b/consumer/interaction_test.go
@@ -13,7 +13,7 @@ func TestInteraction(t *testing.T) {
 	t.Run("validateMatchers for V2 Specification", func(t *testing.T) {
 		testCases := []struct {
 			description string
-			test        interface{}
+			test        any
 			want        error
 		}{
 			{
@@ -33,7 +33,7 @@ func TestInteraction(t *testing.T) {
 			},
 			{
 				description: "v3 matches should error",
-				test: map[string]interface{}{
+				test: map[string]any{
 					"dateTime":    matchers.Regex("2020-01-01", "[0-9\\-]+"),
 					"name":        matchers.S("Billy"),
 					"superstring": matchers.Includes("foo"),
@@ -45,7 +45,7 @@ func TestInteraction(t *testing.T) {
 			},
 			{
 				description: "v2 matches should no terror",
-				test: map[string]interface{}{
+				test: map[string]any{
 					"dateTime": matchers.Regex("2020-01-01", "[0-9\\-]+"),
 					"name":     matchers.S("Billy"),
 					"nested": map[string]matchers.Matcher{
@@ -69,12 +69,12 @@ func TestInteraction(t *testing.T) {
 func TestHasMatcherGreaterThanSpec(t *testing.T) {
 	testCases := []struct {
 		description string
-		obj         map[string]interface{}
+		obj         map[string]any
 		want        []string
 	}{
 		{
 			description: "matcher within the spec version is not reported",
-			obj: map[string]interface{}{
+			obj: map[string]any{
 				"pact:specification": "2.0.0",
 				"pact:matcher:type":  "regex",
 			},
@@ -82,7 +82,7 @@ func TestHasMatcherGreaterThanSpec(t *testing.T) {
 		},
 		{
 			description: "matcher beyond the spec version is reported by type",
-			obj: map[string]interface{}{
+			obj: map[string]any{
 				"pact:specification": "3.0.0",
 				"pact:matcher:type":  "include",
 			},
@@ -90,14 +90,14 @@ func TestHasMatcherGreaterThanSpec(t *testing.T) {
 		},
 		{
 			description: "matcher beyond the spec version with no type is still reported",
-			obj: map[string]interface{}{
+			obj: map[string]any{
 				"pact:specification": "3.0.0",
 			},
 			want: []string{"<unknown matcher type>"},
 		},
 		{
 			description: "matcher beyond the spec version with a non-string type is still reported",
-			obj: map[string]interface{}{
+			obj: map[string]any{
 				"pact:specification": "3.0.0",
 				"pact:matcher:type":  27,
 			},
@@ -105,7 +105,7 @@ func TestHasMatcherGreaterThanSpec(t *testing.T) {
 		},
 		{
 			description: "a non-string specification version is ignored",
-			obj: map[string]interface{}{
+			obj: map[string]any{
 				"pact:specification": 3,
 				"pact:matcher:type":  "include",
 			},

--- a/consumer/request.go
+++ b/consumer/request.go
@@ -8,6 +8,6 @@ type Request struct {
 	Path    matchers.Matcher    `json:"path"`
 	Query   matchers.MapMatcher `json:"query,omitempty"`
 	Headers matchers.MapMatcher `json:"headers,omitempty"`
-	Body    interface{}         `json:"body,omitempty"`
+	Body    any                 `json:"body,omitempty"`
 }
 type Method string

--- a/consumer/response.go
+++ b/consumer/response.go
@@ -6,5 +6,5 @@ import "github.com/pact-foundation/pact-go/v2/matchers"
 type Response struct {
 	Status  int                 `json:"status"`
 	Headers matchers.MapMatcher `json:"headers,omitempty"`
-	Body    interface{}         `json:"body,omitempty"`
+	Body    any                 `json:"body,omitempty"`
 }

--- a/examples/avro/avro_consumer_test.go
+++ b/examples/avro/avro_consumer_test.go
@@ -1,5 +1,4 @@
 //go:build consumer
-// +build consumer
 
 package avro
 
@@ -23,12 +22,12 @@ func TestAvroHTTP(t *testing.T) {
 	mockProvider, err := consumer.NewV4Pact(consumer.MockHTTPProviderConfig{
 		Consumer: "AvroConsumer",
 		Provider: "AvroProvider",
-		PactDir:  filepath.ToSlash(fmt.Sprintf("%s/../pacts", dir)),
+		PactDir:  filepath.ToSlash(dir + "/../pacts"),
 	})
 	require.NoError(t, err)
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/user.avsc", strings.ReplaceAll(dir, "\\", "/"))
+	path := strings.ReplaceAll(dir, "\\", "/") + "/user.avsc"
 
 	avroResponse := `{
 		"pact:avro": "` + path + `",
@@ -64,7 +63,7 @@ func TestAvroHTTP(t *testing.T) {
 func callServiceHTTP(msc consumer.MockServerConfig) (*User, error) {
 	client := &http.Client{}
 	req := &http.Request{
-		Method: "GET",
+		Method: http.MethodGet,
 		URL: &url.URL{
 			Host:   fmt.Sprintf("%s:%d", msc.Host, msc.Port),
 			Scheme: "http",
@@ -92,7 +91,7 @@ func callServiceHTTP(msc consumer.MockServerConfig) (*User, error) {
 		return nil, err
 	}
 
-	fields, ok := native.(map[string]interface{})
+	fields, ok := native.(map[string]any)
 	if !ok {
 		return nil, fmt.Errorf("expected avro record to decode to map[string]interface{}, got %T", native)
 	}

--- a/examples/avro/avro_provider_test.go
+++ b/examples/avro/avro_provider_test.go
@@ -1,5 +1,4 @@
 //go:build provider
-// +build provider
 
 package avro
 
@@ -16,7 +15,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var pactDir = fmt.Sprintf("%s/../pacts", dir)
+var pactDir = dir + "/../pacts"
 
 func TestAvroHTTPProvider(t *testing.T) {
 	httpPort, _ := utils.GetFreePort()
@@ -31,7 +30,7 @@ func TestAvroHTTPProvider(t *testing.T) {
 		ProviderBaseURL: fmt.Sprintf("http://127.0.0.1:%d", httpPort),
 		Provider:        "AvroProvider",
 		PactFiles: []string{
-			filepath.ToSlash(fmt.Sprintf("%s/AvroConsumer-AvroProvider.json", pactDir)),
+			filepath.ToSlash(pactDir + "/AvroConsumer-AvroProvider.json"),
 		},
 	})
 
@@ -51,15 +50,15 @@ func startHTTPProvider(port int) {
 		}
 
 		codec := getCodec()
-		binary, err := codec.BinaryFromNative(nil, map[string]interface{}{
+		binary, err := codec.BinaryFromNative(nil, map[string]any{
 			"id":       user.ID,
 			"username": user.Username,
 		})
 		if err != nil {
 			log.Println("ERROR: ", err)
-			w.WriteHeader(500)
+			w.WriteHeader(http.StatusInternalServerError)
 		} else {
-			w.WriteHeader(200)
+			w.WriteHeader(http.StatusOK)
 			_, writeErr := w.Write(binary)
 			if writeErr != nil {
 				log.Println("ERROR writing response body: ", writeErr)

--- a/examples/consumer_v2_test.go
+++ b/examples/consumer_v2_test.go
@@ -1,5 +1,4 @@
 //go:build consumer
-// +build consumer
 
 // Package main contains a runnable Consumer Pact test example.
 package main
@@ -175,7 +174,7 @@ var rawTest = func(query string) func(config consumer.MockServerConfig) error {
 			},
 		}
 		req := &http.Request{
-			Method: "POST",
+			Method: http.MethodPost,
 			URL: &url.URL{
 				Host:     fmt.Sprintf("%s:%d", "localhost", config.Port),
 				Scheme:   "https",

--- a/examples/consumer_v3_test.go
+++ b/examples/consumer_v3_test.go
@@ -101,7 +101,7 @@ func TestMessagePact(t *testing.T) {
 	})
 	require.NoError(t, err)
 
-	err = provider.AddMessage().
+	err = provider.AddAsynchronousMessage().
 		GivenWithParameter(models.ProviderState{
 			Name: "User with id 127 exists",
 			Parameters: map[string]any{

--- a/examples/consumer_v3_test.go
+++ b/examples/consumer_v3_test.go
@@ -1,5 +1,4 @@
 //go:build consumer
-// +build consumer
 
 // Package main contains a runnable Consumer Pact test example.
 package main
@@ -50,7 +49,7 @@ func TestConsumerV3(t *testing.T) {
 		Given("state 1").
 		GivenWithParameter(models.ProviderState{
 			Name: "User foo exists",
-			Parameters: map[string]interface{}{
+			Parameters: map[string]any{
 				"id": "foo",
 			},
 		}).
@@ -80,7 +79,7 @@ func TestConsumerV3(t *testing.T) {
 					"itemsMinMax":    ArrayMinMaxLike(27, 3, 5),
 					"itemsMin":       ArrayMinLike("thereshouldbe3ofthese", 3),
 					"equality":       Equality("a thing"),
-					"arrayContaining": ArrayContaining([]interface{}{
+					"arrayContaining": ArrayContaining([]any{
 						Like("string"),
 						Integer(1),
 						Map{
@@ -105,7 +104,7 @@ func TestMessagePact(t *testing.T) {
 	err = provider.AddMessage().
 		GivenWithParameter(models.ProviderState{
 			Name: "User with id 127 exists",
-			Parameters: map[string]interface{}{
+			Parameters: map[string]any{
 				"id": 127,
 			},
 		}).

--- a/examples/consumer_v4_test.go
+++ b/examples/consumer_v4_test.go
@@ -1,5 +1,4 @@
 //go:build consumer
-// +build consumer
 
 // Package main contains a runnable Consumer Pact test example.
 package main
@@ -31,7 +30,7 @@ func TestConsumerV4(t *testing.T) {
 		Given("state 1").
 		GivenWithParameter(models.ProviderState{
 			Name: "User foo exists",
-			Parameters: map[string]interface{}{
+			Parameters: map[string]any{
 				"id": "foo",
 			},
 		}).
@@ -61,7 +60,7 @@ func TestConsumerV4(t *testing.T) {
 					"itemsMinMax":    ArrayMinMaxLike(27, 3, 5),
 					"itemsMin":       ArrayMinLike("thereshouldbe3ofthese", 3),
 					"equality":       Equality("a thing"),
-					"arrayContaining": ArrayContaining([]interface{}{
+					"arrayContaining": ArrayContaining([]any{
 						Like("string"),
 						Integer(1),
 						Map{

--- a/examples/grpc/grpc_consumer_test.go
+++ b/examples/grpc/grpc_consumer_test.go
@@ -1,5 +1,4 @@
 //go:build consumer
-// +build consumer
 
 package grpc
 
@@ -25,12 +24,12 @@ func TestGetFeatureSuccess(t *testing.T) {
 	p, _ := message.NewSynchronousPact(message.Config{
 		Consumer: "grpcconsumer",
 		Provider: "grpcprovider",
-		PactDir:  filepath.ToSlash(fmt.Sprintf("%s/../pacts", dir)),
+		PactDir:  filepath.ToSlash(dir + "/../pacts"),
 	})
 	require.NoError(t, log.SetLogLevel("DEBUG"))
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/routeguide/route_guide.proto", strings.ReplaceAll(dir, "\\", "/"))
+	path := strings.ReplaceAll(dir, "\\", "/") + "/routeguide/route_guide.proto"
 
 	grpcInteraction := `{
 		"pact:proto": "` + path + `",
@@ -98,11 +97,11 @@ func TestGetFeatureError(t *testing.T) {
 	p, _ := message.NewSynchronousPact(message.Config{
 		Consumer: "grpcconsumer",
 		Provider: "grpcprovider",
-		PactDir:  filepath.ToSlash(fmt.Sprintf("%s/../pacts", dir)),
+		PactDir:  filepath.ToSlash(dir + "/../pacts"),
 	})
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/routeguide/route_guide.proto", strings.ReplaceAll(dir, "\\", "/"))
+	path := strings.ReplaceAll(dir, "\\", "/") + "/routeguide/route_guide.proto"
 
 	grpcInteraction := `{
 		"pact:proto": "` + path + `",
@@ -162,12 +161,12 @@ func TestSaveFeature(t *testing.T) {
 	p, _ := message.NewSynchronousPact(message.Config{
 		Consumer: "grpcconsumer",
 		Provider: "grpcprovider",
-		PactDir:  filepath.ToSlash(fmt.Sprintf("%s/../pacts", dir)),
+		PactDir:  filepath.ToSlash(dir + "/../pacts"),
 	})
 	require.NoError(t, log.SetLogLevel("INFO"))
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/routeguide/route_guide.proto", strings.ReplaceAll(dir, "\\", "/"))
+	path := strings.ReplaceAll(dir, "\\", "/") + "/routeguide/route_guide.proto"
 
 	grpcInteraction := `{
 		"pact:proto": "` + path + `",

--- a/examples/grpc/grpc_provider_test.go
+++ b/examples/grpc/grpc_provider_test.go
@@ -1,5 +1,4 @@
 //go:build provider
-// +build provider
 
 package grpc
 
@@ -36,7 +35,7 @@ func TestGrpcProvider(t *testing.T) {
 		},
 		Provider: "grpcprovider",
 		PactFiles: []string{
-			filepath.ToSlash(fmt.Sprintf("%s/../pacts/grpcconsumer-grpcprovider.json", dir)),
+			filepath.ToSlash(dir + "/../pacts/grpcconsumer-grpcprovider.json"),
 		},
 	})
 

--- a/examples/grpc/routeguide/server/server.go
+++ b/examples/grpc/routeguide/server/server.go
@@ -75,7 +75,7 @@ type routeGuideServer struct {
 // GetFeature returns the feature at the given point.
 func (s *routeGuideServer) GetFeature(ctx context.Context, point *pb.Point) (*pb.Feature, error) {
 	for _, feature := range s.savedFeatures {
-		if proto.Equal(feature.Location, point) {
+		if proto.Equal(feature.GetLocation(), point) {
 			return feature, nil
 		}
 	}
@@ -92,7 +92,7 @@ func (s *routeGuideServer) SaveFeature(ctx context.Context, feature *pb.Feature)
 // ListFeatures lists all features contained within the given bounding Rectangle.
 func (s *routeGuideServer) ListFeatures(rect *pb.Rectangle, stream pb.RouteGuide_ListFeaturesServer) error {
 	for _, feature := range s.savedFeatures {
-		if inRange(feature.Location, rect) {
+		if inRange(feature.GetLocation(), rect) {
 			err := stream.Send(feature)
 			if err != nil {
 				return err
@@ -127,7 +127,7 @@ func (s *routeGuideServer) RecordRoute(stream pb.RouteGuide_RecordRouteServer) e
 		}
 		pointCount++
 		for _, feature := range s.savedFeatures {
-			if proto.Equal(feature.Location, point) {
+			if proto.Equal(feature.GetLocation(), point) {
 				featureCount++
 			}
 		}
@@ -149,7 +149,7 @@ func (s *routeGuideServer) RouteChat(stream pb.RouteGuide_RouteChatServer) error
 		if err != nil {
 			return err
 		}
-		key := serialize(in.Location)
+		key := serialize(in.GetLocation())
 
 		s.mu.Lock()
 		s.routeNotes[key] = append(s.routeNotes[key], in)
@@ -198,10 +198,10 @@ func toRadians(num float64) float64 {
 func calcDistance(p1 *pb.Point, p2 *pb.Point) int32 {
 	const CordFactor float64 = 1e7
 	const R = float64(6371000) // earth radius in metres
-	lat1 := toRadians(float64(p1.Latitude) / CordFactor)
-	lat2 := toRadians(float64(p2.Latitude) / CordFactor)
-	lng1 := toRadians(float64(p1.Longitude) / CordFactor)
-	lng2 := toRadians(float64(p2.Longitude) / CordFactor)
+	lat1 := toRadians(float64(p1.GetLatitude()) / CordFactor)
+	lat2 := toRadians(float64(p2.GetLatitude()) / CordFactor)
+	lng1 := toRadians(float64(p1.GetLongitude()) / CordFactor)
+	lng2 := toRadians(float64(p2.GetLongitude()) / CordFactor)
 	dlat := lat2 - lat1
 	dlng := lng2 - lng1
 
@@ -215,22 +215,22 @@ func calcDistance(p1 *pb.Point, p2 *pb.Point) int32 {
 }
 
 func inRange(point *pb.Point, rect *pb.Rectangle) bool {
-	left := math.Min(float64(rect.Lo.Longitude), float64(rect.Hi.Longitude))
-	right := math.Max(float64(rect.Lo.Longitude), float64(rect.Hi.Longitude))
-	top := math.Max(float64(rect.Lo.Latitude), float64(rect.Hi.Latitude))
-	bottom := math.Min(float64(rect.Lo.Latitude), float64(rect.Hi.Latitude))
+	left := math.Min(float64(rect.GetLo().GetLongitude()), float64(rect.GetHi().GetLongitude()))
+	right := math.Max(float64(rect.GetLo().GetLongitude()), float64(rect.GetHi().GetLongitude()))
+	top := math.Max(float64(rect.GetLo().GetLatitude()), float64(rect.GetHi().GetLatitude()))
+	bottom := math.Min(float64(rect.GetLo().GetLatitude()), float64(rect.GetHi().GetLatitude()))
 
-	if float64(point.Longitude) >= left &&
-		float64(point.Longitude) <= right &&
-		float64(point.Latitude) >= bottom &&
-		float64(point.Latitude) <= top {
+	if float64(point.GetLongitude()) >= left &&
+		float64(point.GetLongitude()) <= right &&
+		float64(point.GetLatitude()) >= bottom &&
+		float64(point.GetLatitude()) <= top {
 		return true
 	}
 	return false
 }
 
 func serialize(point *pb.Point) string {
-	return fmt.Sprintf("%d %d", point.Latitude, point.Longitude)
+	return fmt.Sprintf("%d %d", point.GetLatitude(), point.GetLongitude())
 }
 
 func NewServer() *routeGuideServer {

--- a/examples/plugin/consumer_plugin_test.go
+++ b/examples/plugin/consumer_plugin_test.go
@@ -1,5 +1,4 @@
 //go:build consumer
-// +build consumer
 
 package plugin
 
@@ -26,7 +25,7 @@ func TestHTTPPlugin(t *testing.T) {
 	mockProvider, err := consumer.NewV4Pact(consumer.MockHTTPProviderConfig{
 		Consumer: "MattConsumer",
 		Provider: "MattProvider",
-		PactDir:  filepath.ToSlash(fmt.Sprintf("%s/../pacts", dir)),
+		PactDir:  filepath.ToSlash(dir + "/../pacts"),
 	})
 	require.NoError(t, err)
 
@@ -62,7 +61,7 @@ func TestTCPPlugin(t *testing.T) {
 	p, _ := message.NewSynchronousPact(message.Config{
 		Consumer: "matttcpconsumer",
 		Provider: "matttcpprovider",
-		PactDir:  filepath.ToSlash(fmt.Sprintf("%s/../pacts", dir)),
+		PactDir:  filepath.ToSlash(dir + "/../pacts"),
 	})
 
 	// MATT is a protocol, where all message start and end with a MATT
@@ -91,7 +90,7 @@ func TestTCPPlugin(t *testing.T) {
 func callMattServiceHTTP(msc consumer.MockServerConfig, message string) (string, error) {
 	client := &http.Client{}
 	req := &http.Request{
-		Method: "POST",
+		Method: http.MethodPost,
 		URL: &url.URL{
 			Host:   fmt.Sprintf("%s:%d", msc.Host, msc.Port),
 			Scheme: "http",

--- a/examples/plugin/provider_plugin_test.go
+++ b/examples/plugin/provider_plugin_test.go
@@ -1,5 +1,4 @@
 //go:build provider
-// +build provider
 
 package plugin
 
@@ -20,7 +19,7 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-var pactDir = fmt.Sprintf("%s/../pacts", dir)
+var pactDir = dir + "/../pacts"
 
 func TestPluginProvider(t *testing.T) {
 	t.Skip()
@@ -38,8 +37,8 @@ func TestPluginProvider(t *testing.T) {
 		ProviderBaseURL: fmt.Sprintf("http://127.0.0.1:%d", httpPort),
 		// Provider:        "provider",
 		PactFiles: []string{
-			filepath.ToSlash(fmt.Sprintf("%s/MattConsumer-MattProvider.json", pactDir)),
-			filepath.ToSlash(fmt.Sprintf("%s/matttcpconsumer-matttcpprovider.json", pactDir)),
+			filepath.ToSlash(pactDir + "/MattConsumer-MattProvider.json"),
+			filepath.ToSlash(pactDir + "/matttcpconsumer-matttcpprovider.json"),
 		},
 		Transports: []provider.Transport{
 			{
@@ -60,7 +59,7 @@ func startHTTPProvider(port int) {
 
 	mux.HandleFunc("/matt", func(w http.ResponseWriter, req *http.Request) {
 		w.Header().Add("Content-Type", "application/matt")
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 		_, err := fmt.Fprintf(w, `MATTworldMATT`)
 		if err != nil {
 			log.Println("ERROR writing response body:", err)

--- a/examples/protobuf-message/protobuf_consumer_test.go
+++ b/examples/protobuf-message/protobuf_consumer_test.go
@@ -1,10 +1,8 @@
 //go:build consumer
-// +build consumer
 
 package protobuf
 
 import (
-	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -20,11 +18,11 @@ func TestPluginMessageConsumer(t *testing.T) {
 	p, _ := message.NewAsynchronousPact(message.Config{
 		Consumer: "protobufmessageconsumer",
 		Provider: "protobufmessageprovider",
-		PactDir:  filepath.ToSlash(fmt.Sprintf("%s/../pacts", dir)),
+		PactDir:  filepath.ToSlash(dir + "/../pacts"),
 	})
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/../grpc/routeguide/route_guide.proto", strings.ReplaceAll(dir, "\\", "/"))
+	path := strings.ReplaceAll(dir, "\\", "/") + "/../grpc/routeguide/route_guide.proto"
 
 	protoMessage := `{
 		"pact:proto": "` + path + `",

--- a/examples/protobuf-message/protobuf_provider_test.go
+++ b/examples/protobuf-message/protobuf_provider_test.go
@@ -1,5 +1,4 @@
 //go:build provider
-// +build provider
 
 package protobuf
 
@@ -22,7 +21,7 @@ import (
 
 func TestPluginMessageProvider(t *testing.T) {
 	dir, _ := os.Getwd()
-	pactDir := fmt.Sprintf("%s/../pacts", dir)
+	pactDir := dir + "/../pacts"
 
 	err := pactlog.SetLogLevel("INFO")
 	require.NoError(t, err)
@@ -49,7 +48,7 @@ func TestPluginMessageProvider(t *testing.T) {
 
 	err = verifier.VerifyProvider(t, provider.VerifyRequest{
 		PactFiles: []string{
-			filepath.ToSlash(fmt.Sprintf("%s/protobufmessageconsumer-protobufmessageprovider.json", pactDir)),
+			filepath.ToSlash(pactDir + "/protobufmessageconsumer-protobufmessageprovider.json"),
 		},
 		Provider:        "protobufmessageprovider",
 		MessageHandlers: functionMappings,

--- a/examples/provider_test.go
+++ b/examples/provider_test.go
@@ -31,6 +31,23 @@ var (
 	stateHandlerCalled  = false
 )
 
+// userFooExistsStateHandler backs the "User foo exists" provider state,
+// shared by both the local-file and broker-published verification runs.
+func userFooExistsStateHandler(setup bool, s models.ProviderState) (models.ProviderStateResponse, error) {
+	stateHandlerCalled = true
+
+	if setup {
+		l.Println("[DEBUG] HOOK calling user foo exists state handler", s)
+	} else {
+		l.Println("[DEBUG] HOOK teardown the 'User foo exists' state")
+	}
+
+	// ... do something, such as create "foo" in the database
+
+	// Optionally (if there are generators in the pact) return provider state values to be used in the verification
+	return models.ProviderStateResponse{"uuid": "1234"}, nil
+}
+
 func TestV3HTTPProvider(t *testing.T) {
 	require.NoError(t, log.SetLogLevel("DEBUG"))
 	version.CheckVersion()
@@ -84,20 +101,7 @@ func TestV3HTTPProvider(t *testing.T) {
 				return nil
 			},
 			StateHandlers: models.StateHandlers{
-				"User foo exists": func(setup bool, s models.ProviderState) (models.ProviderStateResponse, error) {
-					stateHandlerCalled = true
-
-					if setup {
-						l.Println("[DEBUG] HOOK calling user foo exists state handler", s)
-					} else {
-						l.Println("[DEBUG] HOOK teardown the 'User foo exists' state")
-					}
-
-					// ... do something, such as create "foo" in the database
-
-					// Optionally (if there are generators in the pact) return provider state values to be used in the verification
-					return models.ProviderStateResponse{"uuid": "1234"}, nil
-				},
+				"User foo exists": userFooExistsStateHandler,
 			},
 			DisableColoredOutput: true,
 		})
@@ -122,20 +126,7 @@ func TestV3HTTPProvider(t *testing.T) {
 				return nil
 			},
 			StateHandlers: models.StateHandlers{
-				"User foo exists": func(setup bool, s models.ProviderState) (models.ProviderStateResponse, error) {
-					stateHandlerCalled = true
-
-					if setup {
-						l.Println("[DEBUG] HOOK calling user foo exists state handler", s)
-					} else {
-						l.Println("[DEBUG] HOOK teardown the 'User foo exists' state")
-					}
-
-					// ... do something, such as create "foo" in the database
-
-					// Optionally (if there are generators in the pact) return provider state values to be used in the verification
-					return models.ProviderStateResponse{"uuid": "1234"}, nil
-				},
+				"User foo exists": userFooExistsStateHandler,
 			},
 			DisableColoredOutput: true,
 		})

--- a/examples/provider_test.go
+++ b/examples/provider_test.go
@@ -1,5 +1,4 @@
 //go:build provider
-// +build provider
 
 // Package main contains a runnable Provider Pact test example.
 package main
@@ -24,7 +23,7 @@ import (
 
 var (
 	dir, _  = os.Getwd()
-	pactDir = fmt.Sprintf("%s/pacts", dir)
+	pactDir = dir + "/pacts"
 )
 
 var (
@@ -110,8 +109,8 @@ func TestV3HTTPProvider(t *testing.T) {
 			ProviderBaseURL: "http://127.0.0.1:8111",
 			Provider:        "V3Provider",
 			PactFiles: []string{
-				filepath.ToSlash(fmt.Sprintf("%s/PactGoV3Consumer-V3Provider.json", pactDir)),
-				filepath.ToSlash(fmt.Sprintf("%s/PactGoV2ConsumerMatch-V2ProviderMatch.json", pactDir)),
+				filepath.ToSlash(pactDir + "/PactGoV3Consumer-V3Provider.json"),
+				filepath.ToSlash(pactDir + "/PactGoV2ConsumerMatch-V2ProviderMatch.json"),
 			},
 			RequestFilter: f,
 			BeforeEach: func() error {
@@ -197,7 +196,7 @@ func TestV3MessageProvider(t *testing.T) {
 		assert.NoError(t, err)
 	} else {
 		err := verifier.VerifyProvider(t, provider.VerifyRequest{
-			PactFiles:       []string{filepath.ToSlash(fmt.Sprintf("%s/PactGoV3MessageConsumer-V3MessageProvider.json", pactDir))},
+			PactFiles:       []string{filepath.ToSlash(pactDir + "/PactGoV3MessageConsumer-V3MessageProvider.json")},
 			StateHandlers:   stateMappings,
 			Provider:        "V3MessageProvider",
 			MessageHandlers: functionMappings,

--- a/examples/types/repository.go
+++ b/examples/types/repository.go
@@ -15,9 +15,9 @@ func (u *UserRepository) ByUsername(username string) (*User, error) {
 }
 
 // ByID finds a user by their ID.
-func (u *UserRepository) ByID(ID int) (*User, error) {
+func (u *UserRepository) ByID(id int) (*User, error) {
 	for _, user := range u.Users {
-		if user.ID == ID {
+		if user.ID == id {
 			return user, nil
 		}
 	}

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -6,6 +6,7 @@ import (
 	"compress/gzip"
 	"context"
 	"crypto/sha256"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"log"
@@ -609,5 +610,5 @@ func (d *defaultHasher) hash(src string) (string, error) {
 		return "", err
 	}
 
-	return fmt.Sprintf("%x", h.Sum(nil)), nil
+	return hex.EncodeToString(h.Sum(nil)), nil
 }

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -170,24 +170,23 @@ func (i *Installer) CheckPackageInstall() error {
 		// It is helpful because it will prevent issues where the FFI is manually updated without using the `pact-go install` command
 		if len(LibRegistry) == 0 {
 			log.Println("[DEBUG] skip checking ffi version() call because FFI not loaded. This is expected when running the 'pact-go' command.")
-		} else {
-			lib, ok := LibRegistry[pkg]
+			continue
+		}
 
-			if ok {
-				log.Println("[INFO] checking version", lib.Version(), "for lib", info.libName, "within semver range", info.semverRange)
-				err := checkVersion(info.libName, lib.Version(), info.semverRange)
-				if err != nil {
-					return err
-				}
-			} else {
-				log.Println("[DEBUG] unable to determine current version of package", pkg, "in LibRegistry", LibRegistry)
-			}
-
-			// Correct the configuration to reduce drift
-			err := i.updateConfiguration(dst, pkg, info)
+		if lib, ok := LibRegistry[pkg]; ok {
+			log.Println("[INFO] checking version", lib.Version(), "for lib", info.libName, "within semver range", info.semverRange)
+			err := checkVersion(info.libName, lib.Version(), info.semverRange)
 			if err != nil {
 				return err
 			}
+		} else {
+			log.Println("[DEBUG] unable to determine current version of package", pkg, "in LibRegistry", LibRegistry)
+		}
+
+		// Correct the configuration to reduce drift
+		err = i.updateConfiguration(dst, pkg, info)
+		if err != nil {
+			return err
 		}
 	}
 

--- a/internal/native/interaction_given.go
+++ b/internal/native/interaction_given.go
@@ -23,7 +23,7 @@ func interactionGiven(handle C.InteractionHandle, state string) {
 // reason as interactionGiven above. It handles the full params map in one call
 // so that the state C string is allocated only once, matching the performance
 // of the original inline implementation.
-func interactionGivenWithParams(handle C.InteractionHandle, state string, params map[string]interface{}) {
+func interactionGivenWithParams(handle C.InteractionHandle, state string, params map[string]any) {
 	cState := C.CString(state)
 	defer free(cState)
 

--- a/internal/native/message_server.go
+++ b/internal/native/message_server.go
@@ -63,6 +63,7 @@ func (m *MessageServer) WithMetadata(namespace, k, v string) *MessageServer {
 }
 
 // NewMessage initialises a new message for the current contract.
+//
 // Deprecated: use NewAsyncMessageInteraction instead.
 func (m *MessageServer) NewMessage() *Message {
 	// Alias
@@ -319,81 +320,97 @@ func (m *Message) WithPluginInteractionContents(part interactionPart, contentTyp
 func (m *Message) GetMessageRequestContents() ([]byte, error) {
 	log.Println("[DEBUG] GetMessageRequestContents")
 	if m.messageType == MESSAGE_TYPE_ASYNC {
-		iter := C.pactffi_pact_handle_get_message_iter(m.pact.handle)
-		log.Println("[DEBUG] pactffi_pact_handle_get_message_iter")
-		if iter == nil {
-			return nil, errors.New("unable to get a message iterator")
+		return m.getAsyncMessageRequestContents()
+	}
+	return m.getSyncMessageRequestContents()
+}
+
+// getAsyncMessageRequestContents is the MESSAGE_TYPE_ASYNC branch of
+// GetMessageRequestContents, split out to keep both branches readable.
+func (m *Message) getAsyncMessageRequestContents() ([]byte, error) {
+	iter := C.pactffi_pact_handle_get_message_iter(m.pact.handle)
+	log.Println("[DEBUG] pactffi_pact_handle_get_message_iter")
+	if iter == nil {
+		return nil, errors.New("unable to get a message iterator")
+	}
+	log.Println("[DEBUG] pactffi_pact_handle_get_message_iter - OK")
+
+	///////
+	// TODO: some debugging in here to see what's exploding.......
+	///////
+
+	log.Println("[DEBUG] pactffi_pact_handle_get_message_iter - len", len(m.server.messages))
+
+	for i := range len(m.server.messages) {
+		log.Println("[DEBUG] pactffi_pact_handle_get_message_iter - index", i)
+		message := C.pactffi_pact_message_iter_next(iter)
+		log.Println("[DEBUG] pactffi_pact_message_iter_next - message", message)
+
+		if i != m.index {
+			continue
 		}
-		log.Println("[DEBUG] pactffi_pact_handle_get_message_iter - OK")
+		log.Println("[DEBUG] pactffi_pact_message_iter_next - index match", message)
 
-		///////
-		// TODO: some debugging in here to see what's exploding.......
-		///////
-
-		log.Println("[DEBUG] pactffi_pact_handle_get_message_iter - len", len(m.server.messages))
-
-		for i := range len(m.server.messages) {
-			log.Println("[DEBUG] pactffi_pact_handle_get_message_iter - index", i)
-			message := C.pactffi_pact_message_iter_next(iter)
-			log.Println("[DEBUG] pactffi_pact_message_iter_next - message", message)
-
-			if i == m.index {
-				log.Println("[DEBUG] pactffi_pact_message_iter_next - index match", message)
-
-				if message == nil {
-					return nil, errors.New("retrieved a null message pointer")
-				}
-
-				len := C.pactffi_message_get_contents_length(message)
-				log.Println("[DEBUG] pactffi_message_get_contents_length - len", len)
-				if len == 0 {
-					// You can have empty bodies
-					log.Println("[DEBUG] message body is empty")
-					return nil, nil
-				}
-				data := C.pactffi_message_get_contents_bin(message)
-				log.Println("[DEBUG] pactffi_message_get_contents_bin - data", data)
-				if data == nil {
-					// You can have empty bodies
-					log.Println("[DEBUG] message binary contents are empty")
-					return nil, nil
-				}
-				ptr := unsafe.Pointer(data)
-				bytes := C.GoBytes(ptr, C.int(len))
-
-				return bytes, nil
-			}
-		}
-	} else {
-		iter := C.pactffi_pact_handle_get_sync_message_iter(m.pact.handle)
-		if iter == nil {
-			return nil, errors.New("unable to get a message iterator")
+		if message == nil {
+			return nil, errors.New("retrieved a null message pointer")
 		}
 
-		for i := range len(m.server.messages) {
-			message := C.pactffi_pact_sync_message_iter_next(iter)
-
-			if i == m.index {
-				if message == nil {
-					return nil, errors.New("retrieved a null message pointer")
-				}
-
-				len := C.pactffi_sync_message_get_request_contents_length(message)
-				if len == 0 {
-					log.Println("[DEBUG] message body is empty")
-					return nil, nil
-				}
-				data := C.pactffi_sync_message_get_request_contents_bin(message)
-				if data == nil {
-					log.Println("[DEBUG] message binary contents are empty")
-					return nil, nil
-				}
-				ptr := unsafe.Pointer(data)
-				bytes := C.GoBytes(ptr, C.int(len))
-
-				return bytes, nil
-			}
+		len := C.pactffi_message_get_contents_length(message)
+		log.Println("[DEBUG] pactffi_message_get_contents_length - len", len)
+		if len == 0 {
+			// You can have empty bodies
+			log.Println("[DEBUG] message body is empty")
+			return nil, nil
 		}
+		data := C.pactffi_message_get_contents_bin(message)
+		log.Println("[DEBUG] pactffi_message_get_contents_bin - data", data)
+		if data == nil {
+			// You can have empty bodies
+			log.Println("[DEBUG] message binary contents are empty")
+			return nil, nil
+		}
+		ptr := unsafe.Pointer(data)
+		bytes := C.GoBytes(ptr, C.int(len))
+
+		return bytes, nil
+	}
+
+	return nil, errors.New("unable to find the message")
+}
+
+// getSyncMessageRequestContents is the synchronous-message branch of
+// GetMessageRequestContents, split out to keep both branches readable.
+func (m *Message) getSyncMessageRequestContents() ([]byte, error) {
+	iter := C.pactffi_pact_handle_get_sync_message_iter(m.pact.handle)
+	if iter == nil {
+		return nil, errors.New("unable to get a message iterator")
+	}
+
+	for i := range len(m.server.messages) {
+		message := C.pactffi_pact_sync_message_iter_next(iter)
+
+		if i != m.index {
+			continue
+		}
+
+		if message == nil {
+			return nil, errors.New("retrieved a null message pointer")
+		}
+
+		len := C.pactffi_sync_message_get_request_contents_length(message)
+		if len == 0 {
+			log.Println("[DEBUG] message body is empty")
+			return nil, nil
+		}
+		data := C.pactffi_sync_message_get_request_contents_bin(message)
+		if data == nil {
+			log.Println("[DEBUG] message binary contents are empty")
+			return nil, nil
+		}
+		ptr := unsafe.Pointer(data)
+		bytes := C.GoBytes(ptr, C.int(len))
+
+		return bytes, nil
 	}
 
 	return nil, errors.New("unable to find the message")

--- a/internal/native/message_server.go
+++ b/internal/native/message_server.go
@@ -113,7 +113,7 @@ func (m *Message) Given(state string) *Message {
 	return m
 }
 
-func (m *Message) GivenWithParameter(state string, params map[string]interface{}) *Message {
+func (m *Message) GivenWithParameter(state string, params map[string]any) *Message {
 	if len(params) == 0 {
 		interactionGiven(m.handle, state)
 	} else {
@@ -203,7 +203,7 @@ func (m *Message) WithRequestBinaryContentType(contentType string, body []byte) 
 	return m
 }
 
-func (m *Message) WithRequestJSONContents(body interface{}) *Message {
+func (m *Message) WithRequestJSONContents(body any) *Message {
 	value := stringFromInterface(body)
 
 	log.Println("[DEBUG] message WithJSONContents", value)
@@ -221,7 +221,7 @@ func (m *Message) WithResponseBinaryContents(body []byte) *Message {
 	return m
 }
 
-func (m *Message) WithResponseJSONContents(body interface{}) *Message {
+func (m *Message) WithResponseJSONContents(body any) *Message {
 	value := stringFromInterface(body)
 
 	log.Println("[DEBUG] message WithJSONContents", value)
@@ -332,7 +332,7 @@ func (m *Message) GetMessageRequestContents() ([]byte, error) {
 
 		log.Println("[DEBUG] pactffi_pact_handle_get_message_iter - len", len(m.server.messages))
 
-		for i := 0; i < len(m.server.messages); i++ {
+		for i := range len(m.server.messages) {
 			log.Println("[DEBUG] pactffi_pact_handle_get_message_iter - index", i)
 			message := C.pactffi_pact_message_iter_next(iter)
 			log.Println("[DEBUG] pactffi_pact_message_iter_next - message", message)
@@ -370,7 +370,7 @@ func (m *Message) GetMessageRequestContents() ([]byte, error) {
 			return nil, errors.New("unable to get a message iterator")
 		}
 
-		for i := 0; i < len(m.server.messages); i++ {
+		for i := range len(m.server.messages) {
 			message := C.pactffi_pact_sync_message_iter_next(iter)
 
 			if i == m.index {
@@ -413,7 +413,7 @@ func (m *Message) GetMessageResponseContents() ([][]byte, error) {
 		return nil, errors.New("unable to get a message iterator")
 	}
 
-	for i := 0; i < len(m.server.messages); i++ {
+	for i := range len(m.server.messages) {
 		message := C.pactffi_pact_sync_message_iter_next(iter)
 
 		if message == nil {
@@ -438,7 +438,7 @@ func (m *Message) GetMessageResponseContents() ([][]byte, error) {
 
 // StartTransport starts up a mock server on the given address:port for the given transport
 // https://docs.rs/pact_ffi/latest/pact_ffi/mock_server/fn.pactffi_create_mock_server_for_transport.html
-func (m *MessageServer) StartTransport(transport string, address string, port int, config map[string][]interface{}) (int, error) {
+func (m *MessageServer) StartTransport(transport string, address string, port int, config map[string][]any) (int, error) {
 	if len(m.messages) == 0 {
 		return 0, ErrNoInteractions
 	}
@@ -561,7 +561,7 @@ func (m *MessageServer) WritePactFile(dir string, overwrite bool) error {
 	case 2:
 		return ErrHandleNotFound
 	default:
-		return fmt.Errorf("an unknown error occurred when writing to pact file")
+		return errors.New("an unknown error occurred when writing to pact file")
 	}
 }
 
@@ -589,7 +589,7 @@ func (m *MessageServer) WritePactFileForServer(port int, dir string, overwrite b
 	case 3:
 		return ErrHandleNotFound
 	default:
-		return fmt.Errorf("an unknown error occurred when writing to pact file")
+		return errors.New("an unknown error occurred when writing to pact file")
 	}
 }
 

--- a/internal/native/message_server_test.go
+++ b/internal/native/message_server_test.go
@@ -251,7 +251,7 @@ func TestGetPluginSyncMessageContentsAsBytes(t *testing.T) {
 	p := &InitPluginRequest{}
 	err = proto.Unmarshal(bytes, p)
 	require.NoError(t, err)
-	assert.Equal(t, "0.0.0", p.Version)
+	assert.Equal(t, "0.0.0", p.GetVersion())
 
 	// Should be able to convert response into a protobuf
 	response, err := i.GetMessageResponseContents()
@@ -260,7 +260,7 @@ func TestGetPluginSyncMessageContentsAsBytes(t *testing.T) {
 	r := &InitPluginResponse{}
 	err = proto.Unmarshal(response[0], r)
 	require.NoError(t, err)
-	assert.Equal(t, "test", r.Catalogue[0].Key)
+	assert.Equal(t, "test", r.GetCatalogue()[0].GetKey())
 }
 
 func TestGetPluginSyncMessageContentsAsBytes_EmptyResponse(t *testing.T) {
@@ -300,7 +300,7 @@ func TestGetPluginSyncMessageContentsAsBytes_EmptyResponse(t *testing.T) {
 	p := &InitPluginRequest{}
 	err = proto.Unmarshal(bytes, p)
 	require.NoError(t, err)
-	assert.Equal(t, "0.0.0", p.Version)
+	assert.Equal(t, "0.0.0", p.GetVersion())
 
 	// Should be able to convert response into a protobuf
 	response_bytes, err := i.GetMessageResponseContents()
@@ -344,7 +344,7 @@ func TestGetPluginAsyncMessageContentsAsBytes(t *testing.T) {
 	p := &InitPluginRequest{}
 	err = proto.Unmarshal(bytes, p)
 	require.NoError(t, err)
-	assert.Equal(t, "0.0.0", p.Version)
+	assert.Equal(t, "0.0.0", p.GetVersion())
 }
 
 func TestGrpcPluginInteraction(t *testing.T) {

--- a/internal/native/message_server_test.go
+++ b/internal/native/message_server_test.go
@@ -28,7 +28,7 @@ func TestHandleBasedMessageTestsWithString(t *testing.T) {
 
 	m := s.NewMessage().
 		Given("some state").
-		GivenWithParameter("param", map[string]interface{}{
+		GivenWithParameter("param", map[string]any{
 			"foo": "bar",
 		}).
 		ExpectsToReceive("some message").
@@ -54,7 +54,7 @@ func TestHandleBasedMessageTestsWithJSON(t *testing.T) {
 
 	m := s.NewMessage().
 		Given("some state").
-		GivenWithParameter("param", map[string]interface{}{
+		GivenWithParameter("param", map[string]any{
 			"foo": "bar",
 		}).
 		ExpectsToReceive("some message").
@@ -100,7 +100,7 @@ func TestHandleBasedMessageTestsWithBinary(t *testing.T) {
 
 	m := s.NewMessage().
 		Given("some binary state").
-		GivenWithParameter("param", map[string]interface{}{
+		GivenWithParameter("param", map[string]any{
 			"foo": "bar",
 		}).
 		ExpectsToReceive("some binary message").
@@ -130,7 +130,7 @@ func TestGetAsyncMessageContentsAsBytes(t *testing.T) {
 
 	m := s.NewMessage().
 		Given("some state").
-		GivenWithParameter("param", map[string]interface{}{
+		GivenWithParameter("param", map[string]any{
 			"foo": "bar",
 		}).
 		ExpectsToReceive("some message").
@@ -159,7 +159,7 @@ func TestGetSyncMessageContentsAsBytes(t *testing.T) {
 
 	m := s.NewSyncMessageInteraction("").
 		Given("some state").
-		GivenWithParameter("param", map[string]interface{}{
+		GivenWithParameter("param", map[string]any{
 			"foo": "bar",
 		}).
 		ExpectsToReceive("some message").
@@ -191,7 +191,7 @@ func TestGetSyncMessageContentsAsBytes_EmptyResponse(t *testing.T) {
 
 	m := s.NewSyncMessageInteraction("").
 		Given("some state").
-		GivenWithParameter("param", map[string]interface{}{
+		GivenWithParameter("param", map[string]any{
 			"foo": "bar",
 		}).
 		ExpectsToReceive("some message").
@@ -217,7 +217,7 @@ func TestGetPluginSyncMessageContentsAsBytes(t *testing.T) {
 	i := m.NewSyncMessageInteraction("grpc interaction")
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/pact_plugin.proto", strings.ReplaceAll(dir, "\\", "/"))
+	path := strings.ReplaceAll(dir, "\\", "/") + "/pact_plugin.proto"
 
 	grpcInteraction := `{
 			"pact:proto": "` + path + `",
@@ -274,7 +274,7 @@ func TestGetPluginSyncMessageContentsAsBytes_EmptyResponse(t *testing.T) {
 	i := m.NewSyncMessageInteraction("grpc interaction")
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/pact_plugin.proto", strings.ReplaceAll(dir, "\\", "/"))
+	path := strings.ReplaceAll(dir, "\\", "/") + "/pact_plugin.proto"
 
 	grpcInteraction := `{
 			"pact:proto": "` + path + `",
@@ -320,7 +320,7 @@ func TestGetPluginAsyncMessageContentsAsBytes(t *testing.T) {
 	i := m.NewAsyncMessageInteraction("grpc interaction")
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/pact_plugin.proto", strings.ReplaceAll(dir, "\\", "/"))
+	path := strings.ReplaceAll(dir, "\\", "/") + "/pact_plugin.proto"
 
 	protobufInteraction := `{
 			"pact:proto": "` + path + `",
@@ -360,7 +360,7 @@ func TestGrpcPluginInteraction(t *testing.T) {
 	i := m.NewSyncMessageInteraction("grpc interaction")
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/pact_plugin.proto", strings.ReplaceAll(dir, "\\", "/"))
+	path := strings.ReplaceAll(dir, "\\", "/") + "/pact_plugin.proto"
 
 	grpcInteraction := `{
 			"pact:proto": "` + path + `",
@@ -387,7 +387,7 @@ func TestGrpcPluginInteraction(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start the gRPC mock server
-	port, err := m.StartTransport("grpc", "127.0.0.1", 0, make(map[string][]interface{}))
+	port, err := m.StartTransport("grpc", "127.0.0.1", 0, make(map[string][]any))
 	require.NoError(t, err)
 	defer m.CleanupMockServer(port)
 
@@ -439,7 +439,7 @@ func TestGrpcPluginInteraction_ErrorResponse(t *testing.T) {
 	i := m.NewSyncMessageInteraction("grpc interaction")
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/pact_plugin.proto", strings.ReplaceAll(dir, "\\", "/"))
+	path := strings.ReplaceAll(dir, "\\", "/") + "/pact_plugin.proto"
 
 	grpcInteraction := `{
 			"pact:proto": "` + path + `",
@@ -462,7 +462,7 @@ func TestGrpcPluginInteraction_ErrorResponse(t *testing.T) {
 	require.NoError(t, err)
 
 	// Start the gRPC mock server
-	port, err := m.StartTransport("grpc", "127.0.0.1", 0, make(map[string][]interface{}))
+	port, err := m.StartTransport("grpc", "127.0.0.1", 0, make(map[string][]any))
 	require.NoError(t, err)
 	defer m.CleanupMockServer(port)
 

--- a/internal/native/mismatch.go
+++ b/internal/native/mismatch.go
@@ -6,7 +6,7 @@ type Request struct {
 	Path    string            `json:"path"`
 	Query   string            `json:"query,omitempty"`
 	Headers map[string]string `json:"headers,omitempty"`
-	Body    interface{}       `json:"body,omitempty"`
+	Body    any               `json:"body,omitempty"`
 }
 
 // [

--- a/internal/native/mock_server.go
+++ b/internal/native/mock_server.go
@@ -9,6 +9,7 @@ import (
 	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"net"
@@ -209,7 +210,7 @@ func (m *MockServer) WritePactFile(port int, dir string) error {
 	case 3:
 		return ErrMockServerNotfound
 	default:
-		return fmt.Errorf("an unknown error occurred when writing to pact file")
+		return errors.New("an unknown error occurred when writing to pact file")
 	}
 }
 
@@ -298,7 +299,7 @@ func (m *MockServer) Start(address string, tls bool) (int, error) {
 
 // StartTransport starts up a mock server on the given address:port for the given transport
 // https://docs.rs/pact_ffi/latest/pact_ffi/mock_server/fn.pactffi_create_mock_server_for_transport.html
-func (m *MockServer) StartTransport(transport string, address string, port int, config map[string][]interface{}) (int, error) {
+func (m *MockServer) StartTransport(transport string, address string, port int, config map[string][]any) (int, error) {
 	if len(m.interactions) == 0 {
 		return 0, ErrNoInteractions
 	}
@@ -459,13 +460,13 @@ func (i *Interaction) Given(state string) *Interaction {
 	return i
 }
 
-func (i *Interaction) GivenWithParameter(state string, params map[string]interface{}) *Interaction {
+func (i *Interaction) GivenWithParameter(state string, params map[string]any) *Interaction {
 	interactionGivenWithParams(i.handle, state, params)
 
 	return i
 }
 
-func (i *Interaction) WithRequest(method string, pathOrMatcher interface{}) *Interaction {
+func (i *Interaction) WithRequest(method string, pathOrMatcher any) *Interaction {
 	cMethod := C.CString(method)
 	defer free(cMethod)
 
@@ -478,15 +479,15 @@ func (i *Interaction) WithRequest(method string, pathOrMatcher interface{}) *Int
 	return i
 }
 
-func (i *Interaction) WithRequestHeaders(valueOrMatcher map[string][]interface{}) *Interaction {
+func (i *Interaction) WithRequestHeaders(valueOrMatcher map[string][]any) *Interaction {
 	return i.withHeaders(INTERACTION_PART_REQUEST, valueOrMatcher)
 }
 
-func (i *Interaction) WithResponseHeaders(valueOrMatcher map[string][]interface{}) *Interaction {
+func (i *Interaction) WithResponseHeaders(valueOrMatcher map[string][]any) *Interaction {
 	return i.withHeaders(INTERACTION_PART_RESPONSE, valueOrMatcher)
 }
 
-func (i *Interaction) withHeaders(part interactionPart, valueOrMatcher map[string][]interface{}) *Interaction {
+func (i *Interaction) withHeaders(part interactionPart, valueOrMatcher map[string][]any) *Interaction {
 	for k, v := range valueOrMatcher {
 		cName := C.CString(k)
 
@@ -505,7 +506,7 @@ func (i *Interaction) withHeaders(part interactionPart, valueOrMatcher map[strin
 	return i
 }
 
-func (i *Interaction) WithQuery(valueOrMatcher map[string][]interface{}) *Interaction {
+func (i *Interaction) WithQuery(valueOrMatcher map[string][]any) *Interaction {
 	for k, values := range valueOrMatcher {
 		cName := C.CString(k)
 
@@ -524,15 +525,15 @@ func (i *Interaction) WithQuery(valueOrMatcher map[string][]interface{}) *Intera
 	return i
 }
 
-func (i *Interaction) WithJSONRequestBody(body interface{}) *Interaction {
+func (i *Interaction) WithJSONRequestBody(body any) *Interaction {
 	return i.withJSONBody(body, INTERACTION_PART_REQUEST)
 }
 
-func (i *Interaction) WithJSONResponseBody(body interface{}) *Interaction {
+func (i *Interaction) WithJSONResponseBody(body any) *Interaction {
 	return i.withJSONBody(body, INTERACTION_PART_RESPONSE)
 }
 
-func (i *Interaction) withJSONBody(body interface{}, part interactionPart) *Interaction {
+func (i *Interaction) withJSONBody(body any, part interactionPart) *Interaction {
 	cHeader := C.CString("application/json")
 	defer free(cHeader)
 
@@ -632,7 +633,7 @@ type stringLike interface {
 	String() string
 }
 
-func stringFromInterface(obj interface{}) string {
+func stringFromInterface(obj any) string {
 	switch t := obj.(type) {
 	case string:
 		return t
@@ -720,54 +721,54 @@ func logResultToError(res int) error {
 	case -7:
 		return ErrCantConstructSink
 	default:
-		return fmt.Errorf("an unknown error occurred when writing to pact file")
+		return errors.New("an unknown error occurred when writing to pact file")
 	}
 }
 
 // Errors.
 var (
 	// ErrHandleNotFound indicates the underlying handle was not found, and a logic error in the framework.
-	ErrHandleNotFound = fmt.Errorf("unable to find the native interface handle (this indicates a defect in the framework)")
+	ErrHandleNotFound = errors.New("unable to find the native interface handle (this indicates a defect in the framework)")
 
 	// ErrMockServerPanic indicates a panic occurred when invoking the remote Mock Server.
-	ErrMockServerPanic = fmt.Errorf("a general panic occurred when starting/invoking mock service (this indicates a defect in the framework)")
+	ErrMockServerPanic = errors.New("a general panic occurred when starting/invoking mock service (this indicates a defect in the framework)")
 
 	// ErrUnableToWritePactFile indicates an error when writing the pact file to disk.
-	ErrUnableToWritePactFile = fmt.Errorf("unable to write to file")
+	ErrUnableToWritePactFile = errors.New("unable to write to file")
 
 	// ErrMockServerNotfound indicates the Mock Server could not be found.
-	ErrMockServerNotfound = fmt.Errorf("unable to find mock server with the given port")
+	ErrMockServerNotfound = errors.New("unable to find mock server with the given port")
 
 	// ErrInvalidMockServerConfig indicates an issue configuring the mock server.
-	ErrInvalidMockServerConfig = fmt.Errorf("configuration for the mock server was invalid and an unknown error occurred (this is most likely a defect in the framework)")
+	ErrInvalidMockServerConfig = errors.New("configuration for the mock server was invalid and an unknown error occurred (this is most likely a defect in the framework)")
 
 	// ErrInvalidPact indicates the pact file provided to the mock server was not a valid pact file.
-	ErrInvalidPact = fmt.Errorf("pact given to mock server is invalid")
+	ErrInvalidPact = errors.New("pact given to mock server is invalid")
 
 	// ErrMockServerUnableToStart means the mock server could not be started in the rust library.
-	ErrMockServerUnableToStart = fmt.Errorf("unable to start the mock server")
+	ErrMockServerUnableToStart = errors.New("unable to start the mock server")
 
 	// ErrInvalidAddress means the address provided to the mock server was invalid and could not be understood.
-	ErrInvalidAddress = fmt.Errorf("invalid address provided to the mock server")
+	ErrInvalidAddress = errors.New("invalid address provided to the mock server")
 
 	// ErrMockServerTLSConfiguration indicates a TLS mock server could not be started
 	// and is likely a framework level problem.
-	ErrMockServerTLSConfiguration = fmt.Errorf("a tls mock server could not be started (this is likely a defect in the framework)")
+	ErrMockServerTLSConfiguration = errors.New("a tls mock server could not be started (this is likely a defect in the framework)")
 
 	// ErrNoInteractions indicates no Interactions have been registered to a mock server, and cannot be started/stopped until at least one is added.
-	ErrNoInteractions = fmt.Errorf("no interactions have been registered for the mock server")
+	ErrNoInteractions = errors.New("no interactions have been registered for the mock server")
 
 	// ErrPluginFailed indicates the plugin could not be started.
-	ErrPluginFailed = fmt.Errorf("the plugin could not be started")
+	ErrPluginFailed = errors.New("the plugin could not be started")
 )
 
 // Log Errors.
 var (
-	ErrCantSetLogger      = fmt.Errorf("can't set logger (applying the logger failed, perhaps because one is applied already)")
-	ErrNoLogger           = fmt.Errorf("no logger has been initialized (call `logger_init` before any other log function)")
-	ErrSpecifierNotUtf8   = fmt.Errorf("the sink specifier was not UTF-8 encoded")
-	ErrUnknownSinkType    = fmt.Errorf(`the sink type specified is not a known type (known types: "buffer", "stdout", "stderr", or "file /some/path")`)
-	ErrMissingFilePath    = fmt.Errorf("no file path was specified in a file-type sink specification")
-	ErrCantOpenSinkToFile = fmt.Errorf("opening a sink to the specified file path failed (check permissions)")
-	ErrCantConstructSink  = fmt.Errorf("can't construct the log sink")
+	ErrCantSetLogger      = errors.New("can't set logger (applying the logger failed, perhaps because one is applied already)")
+	ErrNoLogger           = errors.New("no logger has been initialized (call `logger_init` before any other log function)")
+	ErrSpecifierNotUtf8   = errors.New("the sink specifier was not UTF-8 encoded")
+	ErrUnknownSinkType    = errors.New(`the sink type specified is not a known type (known types: "buffer", "stdout", "stderr", or "file /some/path")`)
+	ErrMissingFilePath    = errors.New("no file path was specified in a file-type sink specification")
+	ErrCantOpenSinkToFile = errors.New("opening a sink to the specified file path failed (check permissions)")
+	ErrCantConstructSink  = errors.New("can't construct the log sink")
 )

--- a/internal/native/mock_server.go
+++ b/internal/native/mock_server.go
@@ -88,26 +88,28 @@ func Init(logLevel string) {
 
 	if loggingInitialised != "" {
 		log.Printf("log level ('%s') cannot be set to '%s' after initialisation\n", loggingInitialised, logLevel)
-	} else {
-		l, ok := logLevelStringToInt[logLevel]
-		if !ok {
-			l = LOG_LEVEL_INFO
-		}
-		log.Printf("[DEBUG] initialised native log level to %s (%d)", logLevel, l)
+		return
+	}
 
-		if os.Getenv("PACT_LOG_PATH") != "" {
-			log.Println("[DEBUG] initialised native log to log to file:", os.Getenv("PACT_LOG_PATH"))
-			err := logToFile(os.Getenv("PACT_LOG_PATH"), l)
-			if err != nil {
-				log.Println("[ERROR] failed to log to file:", err)
-			}
-		} else {
-			log.Println("[DEBUG] initialised native log to log to stdout")
-			err := logToStdout(l)
-			if err != nil {
-				log.Println("[ERROR] failed to log to stdout:", err)
-			}
+	l, ok := logLevelStringToInt[logLevel]
+	if !ok {
+		l = LOG_LEVEL_INFO
+	}
+	log.Printf("[DEBUG] initialised native log level to %s (%d)", logLevel, l)
+
+	if os.Getenv("PACT_LOG_PATH") != "" {
+		log.Println("[DEBUG] initialised native log to log to file:", os.Getenv("PACT_LOG_PATH"))
+		err := logToFile(os.Getenv("PACT_LOG_PATH"), l)
+		if err != nil {
+			log.Println("[ERROR] failed to log to file:", err)
 		}
+		return
+	}
+
+	log.Println("[DEBUG] initialised native log to log to stdout")
+	err := logToStdout(l)
+	if err != nil {
+		log.Println("[ERROR] failed to log to stdout:", err)
 	}
 }
 

--- a/internal/native/mock_server_test.go
+++ b/internal/native/mock_server_test.go
@@ -74,7 +74,7 @@ func TestMockServer_MismatchesSuccess(t *testing.T) {
 	}
 	defer func() { _ = res.Body.Close() }()
 
-	if res.StatusCode != 200 {
+	if res.StatusCode != http.StatusOK {
 		t.Fatalf("want '200', got '%d'", res.StatusCode)
 	}
 
@@ -209,7 +209,7 @@ func TestPluginInteraction(t *testing.T) {
 	i := m.NewInteraction("some plugin interaction")
 
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/pact_plugin.proto", strings.ReplaceAll(dir, "\\", "/"))
+	path := strings.ReplaceAll(dir, "\\", "/") + "/pact_plugin.proto"
 
 	protobufInteraction := `{
 			"pact:proto": "` + path + `",

--- a/internal/native/mock_server_test.go
+++ b/internal/native/mock_server_test.go
@@ -241,8 +241,8 @@ func TestPluginInteraction(t *testing.T) {
 	err = proto.Unmarshal(bytes, initPluginRequest)
 	require.NoError(t, err)
 
-	assert.Equal(t, "pact-go-driver", initPluginRequest.Implementation)
-	assert.Equal(t, "0.0.0", initPluginRequest.Version)
+	assert.Equal(t, "pact-go-driver", initPluginRequest.GetImplementation())
+	assert.Equal(t, "0.0.0", initPluginRequest.GetVersion())
 
 	mismatches := m.MockServerMismatchedRequests(port)
 	if len(mismatches) != 0 {

--- a/internal/native/plugin.go
+++ b/internal/native/plugin.go
@@ -1,13 +1,13 @@
 package native
 
-import "fmt"
+import "errors"
 
 // Plugin Errors.
 var (
-	ErrPluginGenericPanic             = fmt.Errorf("a general panic was caught")
-	ErrPluginMockServerStarted        = fmt.Errorf("the mock server has already been started")
-	ErrPluginInteractionHandleInvalid = fmt.Errorf("the interaction handle is invalid")
-	ErrPluginInvalidContentType       = fmt.Errorf("the content type is not valid")
-	ErrPluginInvalidJson              = fmt.Errorf("the contents JSON is not valid JSON")
-	ErrPluginSpecificError            = fmt.Errorf("the plugin returned an error")
+	ErrPluginGenericPanic             = errors.New("a general panic was caught")
+	ErrPluginMockServerStarted        = errors.New("the mock server has already been started")
+	ErrPluginInteractionHandleInvalid = errors.New("the interaction handle is invalid")
+	ErrPluginInvalidContentType       = errors.New("the content type is not valid")
+	ErrPluginInvalidJson              = errors.New("the contents JSON is not valid JSON")
+	ErrPluginSpecificError            = errors.New("the plugin returned an error")
 )

--- a/internal/native/verifier.go
+++ b/internal/native/verifier.go
@@ -6,6 +6,7 @@ package native
 import "C"
 
 import (
+	"errors"
 	"fmt"
 	"log"
 	"unsafe"
@@ -22,18 +23,18 @@ func (v *Verifier) Version() string {
 
 var (
 	// ErrVerifierPanic indicates a panic occurred when invoking the verifier.
-	ErrVerifierPanic = fmt.Errorf("a general panic occurred when starting/invoking verifier (this indicates a defect in the framework)")
+	ErrVerifierPanic = errors.New("a general panic occurred when starting/invoking verifier (this indicates a defect in the framework)")
 
 	// ErrInvalidVerifierConfig indicates an issue configuring the verifier.
-	ErrInvalidVerifierConfig = fmt.Errorf("configuration for the verifier was invalid and an unknown error occurred (this is most likely a defect in the framework)")
+	ErrInvalidVerifierConfig = errors.New("configuration for the verifier was invalid and an unknown error occurred (this is most likely a defect in the framework)")
 
 	// ErrVerifierFailed and ErrVerifierFailedToRun are mutually exclusive: a
 	// single Verifier call returns one or the other, never both.
 	//
 	//ErrVerifierFailed is the standard error if a verification failed (e.g. beacause the pact verification was not successful).
-	ErrVerifierFailed = fmt.Errorf("the verifier failed to successfully verify the pacts, this indicates an issue with the provider API")
+	ErrVerifierFailed = errors.New("the verifier failed to successfully verify the pacts, this indicates an issue with the provider API")
 	// ErrVerifierFailedToRun indicates the verification process was unable to run.
-	ErrVerifierFailedToRun = fmt.Errorf("the verifier failed to execute (this is most likely a defect in the framework)")
+	ErrVerifierFailedToRun = errors.New("the verifier failed to execute (this is most likely a defect in the framework)")
 )
 
 func NewVerifier(name string, version string) *Verifier {

--- a/internal/native/verifier.go
+++ b/internal/native/verifier.go
@@ -31,7 +31,7 @@ var (
 	// ErrVerifierFailed and ErrVerifierFailedToRun are mutually exclusive: a
 	// single Verifier call returns one or the other, never both.
 	//
-	//ErrVerifierFailed is the standard error if a verification failed (e.g. beacause the pact verification was not successful).
+	// ErrVerifierFailed is the standard error if a verification failed (e.g. beacause the pact verification was not successful).
 	ErrVerifierFailed = errors.New("the verifier failed to successfully verify the pacts, this indicates an issue with the provider API")
 	// ErrVerifierFailedToRun indicates the verification process was unable to run.
 	ErrVerifierFailedToRun = errors.New("the verifier failed to execute (this is most likely a defect in the framework)")

--- a/internal/native/verifier_test.go
+++ b/internal/native/verifier_test.go
@@ -1,5 +1,4 @@
 //go:build provider
-// +build provider
 
 package native
 

--- a/matchers/matcher.go
+++ b/matchers/matcher.go
@@ -417,8 +417,8 @@ func pluckParams(srcType reflect.Type, pactTag string) params {
 			triggerInvalidPactTagPanic(pactTag, err)
 		}
 	case reflect.String:
-		fullRegex, _ := regexp.Compile(`regex=(.*)$`)
-		exampleRegex, _ := regexp.Compile(`^example=(.*)`)
+		fullRegex := regexp.MustCompile(`regex=(.*)$`)
+		exampleRegex := regexp.MustCompile(`^example=(.*)`)
 
 		if fullRegex.MatchString(pactTag) {
 			components := strings.Split(pactTag, ",regex=")

--- a/matchers/matcher.go
+++ b/matchers/matcher.go
@@ -2,6 +2,7 @@ package matchers
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"reflect"
@@ -26,11 +27,11 @@ const (
 var timeExample = time.Date(2000, 2, 1, 12, 30, 0, 0, time.UTC)
 
 type eachLike struct {
-	Value interface{} `json:"value"`
-	Min   int         `json:"min"`
+	Value any `json:"value"`
+	Min   int `json:"min"`
 }
 
-func (m eachLike) GetValue() interface{} {
+func (m eachLike) GetValue() any {
 	return m.Value
 }
 
@@ -49,10 +50,10 @@ func (m eachLike) MarshalJSON() ([]byte, error) {
 type like struct {
 	Specification models.SpecificationVersion `json:"specification"`
 	Type          string                      `json:"pact:matcher:type"`
-	Value         interface{}                 `json:"value"`
+	Value         any                         `json:"value"`
 }
 
-func (m like) GetValue() interface{} {
+func (m like) GetValue() any {
 	return m.Value
 }
 
@@ -65,7 +66,7 @@ type term struct {
 	Regex string `json:"regex"` // TODO: should this be a golang regex?!
 }
 
-func (m term) GetValue() interface{} {
+func (m term) GetValue() any {
 	return m.Value
 }
 
@@ -83,13 +84,13 @@ func (m term) MarshalJSON() ([]byte, error) {
 
 // EachLike specifies that a given element in a JSON body can be repeated
 // "minRequired" times. Number needs to be 1 or greater.
-func EachLike(content interface{}, minRequired int) Matcher {
+func EachLike(content any, minRequired int) Matcher {
 	if minRequired < 1 {
 		log.Println("[WARN] min value to an array matcher can't be less than one")
 		minRequired = 1
 	}
-	examples := make([]interface{}, minRequired)
-	for i := 0; i < minRequired; i++ {
+	examples := make([]any, minRequired)
+	for i := range minRequired {
 		examples[i] = content
 	}
 	return eachLike{
@@ -102,7 +103,7 @@ var ArrayMinLike = EachLike
 
 // Like specifies that the given content type should be matched based
 // on type (int, string etc.) instead of a verbatim match.
-func Like(content interface{}) Matcher {
+func Like(content any) Matcher {
 	return like{
 		Specification: models.V2,
 		Type:          "type",
@@ -179,7 +180,7 @@ type Matcher interface {
 
 	// GetValue returns the raw generated value for the matcher
 	// without any of the matching detail context
-	GetValue() interface{}
+	GetValue() any
 }
 
 // S is the string primitive wrapper (alias) for the Matcher type,
@@ -192,7 +193,7 @@ func (s S) isMatcher() {}
 
 // GetValue returns the raw generated value for the matcher
 // without any of the matching detail context.
-func (s S) GetValue() interface{} {
+func (s S) GetValue() any {
 	return s
 }
 
@@ -212,7 +213,7 @@ func (s String) isMatcher() {}
 
 // GetValue returns the raw generated value for the matcher
 // without any of the matching detail context.
-func (s String) GetValue() interface{} {
+func (s String) GetValue() any {
 	return s
 }
 
@@ -226,13 +227,13 @@ func (s String) MarshalJSON() ([]byte, error) {
 
 // StructMatcher matches a complex object structure, which may itself
 // contain nested Matchers.
-type StructMatcher map[string]interface{}
+type StructMatcher map[string]any
 
 func (m StructMatcher) isMatcher() {}
 
 // GetValue returns the raw generated value for the matcher
 // without any of the matching detail context.
-func (m StructMatcher) GetValue() interface{} {
+func (m StructMatcher) GetValue() any {
 	return nil
 }
 
@@ -271,7 +272,7 @@ type (
 type QueryMatcher map[string][]Matcher
 
 // Takes an object and converts it to a JSON representation.
-func objectToString(obj interface{}) string {
+func objectToString(obj any) string {
 	switch content := obj.(type) {
 	case string:
 		return content
@@ -295,7 +296,7 @@ func objectToString(obj interface{}) string {
 // Supported Tag Formats
 // Minimum Slice Size: `pact:"min=2"`
 // String RegEx:       `pact:"example=2000-01-01,regex=^\\d{4}-\\d{2}-\\d{2}$"`.
-func MatchV2(src interface{}) Matcher {
+func MatchV2(src any) Matcher {
 	return match(reflect.TypeOf(src), getDefaults())
 }
 
@@ -310,7 +311,7 @@ func match(srcType reflect.Type, params params) Matcher {
 	case reflect.Struct:
 		result := StructMatcher{}
 
-		for i := 0; i < srcType.NumField(); i++ {
+		for i := range srcType.NumField() {
 			field := srcType.Field(i)
 			result[strings.Split(field.Tag.Get("json"), ",")[0]] = match(field.Type, pluckParams(field.Type, field.Tag.Get("pact")))
 		}
@@ -419,11 +420,11 @@ func pluckParams(srcType reflect.Type, pactTag string) params {
 		fullRegex, _ := regexp.Compile(`regex=(.*)$`)
 		exampleRegex, _ := regexp.Compile(`^example=(.*)`)
 
-		if fullRegex.Match([]byte(pactTag)) {
+		if fullRegex.MatchString(pactTag) {
 			components := strings.Split(pactTag, ",regex=")
 
 			if len(components[1]) == 0 {
-				triggerInvalidPactTagPanic(pactTag, fmt.Errorf("invalid format: regex must not be empty"))
+				triggerInvalidPactTagPanic(pactTag, errors.New("invalid format: regex must not be empty"))
 			}
 
 			_, err := fmt.Sscanf(components[0], "example=%s", &params.str.example)
@@ -431,11 +432,11 @@ func pluckParams(srcType reflect.Type, pactTag string) params {
 				triggerInvalidPactTagPanic(pactTag, err)
 			}
 			params.str.regEx = components[1]
-		} else if exampleRegex.Match([]byte(pactTag)) {
+		} else if exampleRegex.MatchString(pactTag) {
 			components := strings.Split(pactTag, "example=")
 
 			if len(components) != 2 || strings.TrimSpace(components[1]) == "" {
-				triggerInvalidPactTagPanic(pactTag, fmt.Errorf("invalid format: example must not be empty"))
+				triggerInvalidPactTagPanic(pactTag, errors.New("invalid format: example must not be empty"))
 			}
 
 			params.str.example = components[1]

--- a/matchers/matcher_test.go
+++ b/matchers/matcher_test.go
@@ -185,7 +185,7 @@ func TestMatcher_EachLikeArray(t *testing.T) {
 }
 
 func TestMatcher_EachLikeGetValue(t *testing.T) {
-	expected := []interface{}{"42"}
+	expected := []any{"42"}
 	match := EachLike("42", 1).GetValue()
 
 	assert.Equal(t, expected, match)
@@ -342,7 +342,7 @@ func TestMatcher_NestAllTheThings(t *testing.T) {
 }
 
 // Format a JSON document to make comparison easier.
-func formatJSON(object interface{}) interface{} {
+func formatJSON(object any) any {
 	var out bytes.Buffer
 	switch content := object.(type) {
 	case string:
@@ -352,7 +352,7 @@ func formatJSON(object interface{}) interface{} {
 		if err != nil {
 			log.Println("[ERROR] unable to marshal json:", err)
 		}
-		_ = json.Indent(&out, []byte(jsonString), "", "\t")
+		_ = json.Indent(&out, jsonString, "", "\t")
 	}
 
 	return out.String()
@@ -360,7 +360,7 @@ func formatJSON(object interface{}) interface{} {
 
 // Instrument the StructMatcher type to be able to assert the
 // values and regexs contained within!
-func getMatcherValue(m interface{}) interface{} {
+func getMatcherValue(m any) any {
 	mString := objectToString(m)
 
 	// try like
@@ -383,12 +383,12 @@ func getMatcherValue(m interface{}) interface{} {
 func TestMatcher_SugarMatchers(t *testing.T) {
 	type matcherTestCase struct {
 		matcher  Matcher
-		testCase func(val interface{}) error
+		testCase func(val any) error
 	}
 	matchers := map[string]matcherTestCase{
 		"HexValue": {
 			matcher: HexValue(),
-			testCase: func(v interface{}) (err error) {
+			testCase: func(v any) (err error) {
 				s, valid := v.(string)
 				if !valid || s != "3F" {
 					err = fmt.Errorf("want '3F', got '%v'", reflect.TypeOf(v))
@@ -398,7 +398,7 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 		},
 		"Identifier": {
 			matcher: Identifier(),
-			testCase: func(v interface{}) (err error) {
+			testCase: func(v any) (err error) {
 				_, valid := v.(float64) // JSON converts numbers to float64 in anonymous structs
 				if !valid {
 					err = fmt.Errorf("want int, got '%v'", reflect.TypeOf(v))
@@ -408,7 +408,7 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 		},
 		"Integer": {
 			matcher: Integer(1),
-			testCase: func(v interface{}) (err error) {
+			testCase: func(v any) (err error) {
 				_, valid := v.(float64) // JSON converts numbers to float64 in anonymous structs
 				if !valid {
 					err = fmt.Errorf("want int, got '%v'", reflect.TypeOf(v))
@@ -418,7 +418,7 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 		},
 		"IPAddress": {
 			matcher: IPAddress(),
-			testCase: func(v interface{}) (err error) {
+			testCase: func(v any) (err error) {
 				s, valid := v.(string)
 				if !valid || s != "127.0.0.1" {
 					err = fmt.Errorf("want '127.0.0.1', got '%v'", reflect.TypeOf(v))
@@ -428,7 +428,7 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 		},
 		"IPv4Address": {
 			matcher: IPv4Address(),
-			testCase: func(v interface{}) (err error) {
+			testCase: func(v any) (err error) {
 				s, valid := v.(string)
 				if !valid || s != "127.0.0.1" {
 					err = fmt.Errorf("want '127.0.0.1', got '%v'", reflect.TypeOf(v))
@@ -438,7 +438,7 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 		},
 		"IPv6Address": {
 			matcher: IPv6Address(),
-			testCase: func(v interface{}) (err error) {
+			testCase: func(v any) (err error) {
 				s, valid := v.(string)
 				if !valid || s != "::ffff:192.0.2.128" {
 					err = fmt.Errorf("want '::ffff:192.0.2.128', got '%v'", reflect.TypeOf(v))
@@ -448,7 +448,7 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 		},
 		"Decimal": {
 			matcher: Decimal(27.3),
-			testCase: func(v interface{}) (err error) {
+			testCase: func(v any) (err error) {
 				_, valid := v.(float64)
 				if !valid {
 					err = fmt.Errorf("want float64, got '%v'", reflect.TypeOf(v))
@@ -458,7 +458,7 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 		},
 		"Timestamp": {
 			matcher: Timestamp(),
-			testCase: func(v interface{}) (err error) {
+			testCase: func(v any) (err error) {
 				_, valid := v.(string)
 				if !valid {
 					err = fmt.Errorf("want string, got '%v'", reflect.TypeOf(v))
@@ -468,7 +468,7 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 		},
 		"Date": {
 			matcher: Date(),
-			testCase: func(v interface{}) (err error) {
+			testCase: func(v any) (err error) {
 				_, valid := v.(string)
 				if !valid {
 					err = fmt.Errorf("want string, got '%v'", reflect.TypeOf(v))
@@ -478,7 +478,7 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 		},
 		"Time": {
 			matcher: Time(),
-			testCase: func(v interface{}) (err error) {
+			testCase: func(v any) (err error) {
 				_, valid := v.(string)
 				if !valid {
 					err = fmt.Errorf("want string, got '%v'", reflect.TypeOf(v))
@@ -488,7 +488,7 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 		},
 		"UUID": {
 			matcher: UUID(),
-			testCase: func(v interface{}) (err error) {
+			testCase: func(v any) (err error) {
 				s, valid := v.(string)
 				if !valid {
 					return fmt.Errorf("want string, got '%v'", reflect.TypeOf(v))
@@ -595,7 +595,7 @@ func TestMatch(t *testing.T) {
 	}
 	str := "str"
 	type args struct {
-		src interface{}
+		src any
 	}
 	tests := []struct {
 		name      string
@@ -822,7 +822,7 @@ func Test_pluckParams(t *testing.T) {
 		{
 			name: "expected use - slice tag",
 			args: args{
-				srcType: reflect.TypeOf([]string{}),
+				srcType: reflect.TypeFor[[]string](),
 				pactTag: "min=2",
 			},
 			want: params{
@@ -838,7 +838,7 @@ func Test_pluckParams(t *testing.T) {
 		{
 			name: "empty slice tag",
 			args: args{
-				srcType: reflect.TypeOf([]string{}),
+				srcType: reflect.TypeFor[[]string](),
 				pactTag: "",
 			},
 			want: getDefaults(),
@@ -846,7 +846,7 @@ func Test_pluckParams(t *testing.T) {
 		{
 			name: "invalid slice tag - no min",
 			args: args{
-				srcType: reflect.TypeOf([]string{}),
+				srcType: reflect.TypeFor[[]string](),
 				pactTag: "min=",
 			},
 			wantPanic: true,
@@ -854,7 +854,7 @@ func Test_pluckParams(t *testing.T) {
 		{
 			name: "invalid slice tag - min typo capital letter",
 			args: args{
-				srcType: reflect.TypeOf([]string{}),
+				srcType: reflect.TypeFor[[]string](),
 				pactTag: "Min=2",
 			},
 			wantPanic: true,
@@ -862,7 +862,7 @@ func Test_pluckParams(t *testing.T) {
 		{
 			name: "invalid slice tag - min typo non-number",
 			args: args{
-				srcType: reflect.TypeOf([]string{}),
+				srcType: reflect.TypeFor[[]string](),
 				pactTag: "min=a",
 			},
 			wantPanic: true,
@@ -870,7 +870,7 @@ func Test_pluckParams(t *testing.T) {
 		{
 			name: "expected use - string tag",
 			args: args{
-				srcType: reflect.TypeOf(""),
+				srcType: reflect.TypeFor[string](),
 				pactTag: "example=aBcD123,regex=[A-Za-z0-9]",
 			},
 			want: params{
@@ -886,7 +886,7 @@ func Test_pluckParams(t *testing.T) {
 		{
 			name: "expected use - string tag with backslash",
 			args: args{
-				srcType: reflect.TypeOf(""),
+				srcType: reflect.TypeFor[string](),
 				pactTag: "example=33,regex=\\d{2}",
 			},
 			want: params{
@@ -902,7 +902,7 @@ func Test_pluckParams(t *testing.T) {
 		{
 			name: "expected use - string tag with complex string",
 			args: args{
-				srcType: reflect.TypeOf(""),
+				srcType: reflect.TypeFor[string](),
 				pactTag: "example=Jean-Marie de La Beaujardière😀😍",
 			},
 			want: params{
@@ -917,7 +917,7 @@ func Test_pluckParams(t *testing.T) {
 		{
 			name: "expected use - example with no regex",
 			args: args{
-				srcType: reflect.TypeOf(""),
+				srcType: reflect.TypeFor[string](),
 				pactTag: "example=aBcD123",
 			},
 			want: params{
@@ -933,7 +933,7 @@ func Test_pluckParams(t *testing.T) {
 		{
 			name: "empty string tag",
 			args: args{
-				srcType: reflect.TypeOf(""),
+				srcType: reflect.TypeFor[string](),
 				pactTag: "",
 			},
 			want: getDefaults(),
@@ -941,7 +941,7 @@ func Test_pluckParams(t *testing.T) {
 		{
 			name: "invalid string tag - no example value",
 			args: args{
-				srcType: reflect.TypeOf(""),
+				srcType: reflect.TypeFor[string](),
 				pactTag: "example=,regex=[A-Za-z0-9]",
 			},
 			wantPanic: true,
@@ -949,7 +949,7 @@ func Test_pluckParams(t *testing.T) {
 		{
 			name: "invalid string tag - no example",
 			args: args{
-				srcType: reflect.TypeOf(""),
+				srcType: reflect.TypeFor[string](),
 				pactTag: "regex=[A-Za-z0-9]",
 			},
 			wantPanic: true,
@@ -957,7 +957,7 @@ func Test_pluckParams(t *testing.T) {
 		{
 			name: "invalid string tag - empty example",
 			args: args{
-				srcType: reflect.TypeOf(""),
+				srcType: reflect.TypeFor[string](),
 				pactTag: "example=",
 			},
 			wantPanic: true,
@@ -965,7 +965,7 @@ func Test_pluckParams(t *testing.T) {
 		{
 			name: "invalid string tag - example typo",
 			args: args{
-				srcType: reflect.TypeOf(""),
+				srcType: reflect.TypeFor[string](),
 				pactTag: "exmple=aBcD123,regex=[A-Za-z0-9]",
 			},
 			wantPanic: true,
@@ -973,7 +973,7 @@ func Test_pluckParams(t *testing.T) {
 		{
 			name: "invalid string tag - no regex value",
 			args: args{
-				srcType: reflect.TypeOf(""),
+				srcType: reflect.TypeFor[string](),
 				pactTag: "example=aBcD123,regex=",
 			},
 			wantPanic: true,
@@ -981,7 +981,7 @@ func Test_pluckParams(t *testing.T) {
 		{
 			name: "invalid string tag - space inserted",
 			args: args{
-				srcType: reflect.TypeOf(""),
+				srcType: reflect.TypeFor[string](),
 				pactTag: "example=aBcD123 regex=[A-Za-z0-9]",
 			},
 			wantPanic: true,

--- a/matchers/matcher_v3.go
+++ b/matchers/matcher_v3.go
@@ -28,7 +28,7 @@ func Integer(example int) Matcher {
 // Null is a matcher that only accepts nulls.
 type Null struct{}
 
-func (n Null) GetValue() interface{} {
+func (n Null) GetValue() any {
 	return nil
 }
 
@@ -49,10 +49,10 @@ func (n Null) MarshalJSON() ([]byte, error) {
 type equality struct {
 	Specification models.SpecificationVersion `json:"pact:specification"`
 	Type          string                      `json:"pact:matcher:type"`
-	Contents      interface{}                 `json:"value"`
+	Contents      any                         `json:"value"`
 }
 
-func (e equality) GetValue() interface{} {
+func (e equality) GetValue() any {
 	return e.Contents
 }
 
@@ -60,7 +60,7 @@ func (e equality) isMatcher() {}
 
 // Equality resets matching cascades back to equality
 // see https://github.com/pact-foundation/pact-specification/tree/version-3#add-an-equality-matcher
-func Equality(content interface{}) Matcher {
+func Equality(content any) Matcher {
 	return equality{
 		Specification: models.V3,
 		Contents:      content,
@@ -76,7 +76,7 @@ type includes struct {
 	Contents      string                      `json:"value"`
 }
 
-func (i includes) GetValue() interface{} {
+func (i includes) GetValue() any {
 	return i.Contents
 }
 
@@ -98,7 +98,7 @@ type fromProviderState struct {
 	Value         string                      `json:"value"`
 }
 
-func (s fromProviderState) GetValue() interface{} {
+func (s fromProviderState) GetValue() any {
 	return s.Value
 }
 
@@ -122,10 +122,10 @@ func FromProviderState(expression, example string) Matcher {
 type eachKeyLike struct {
 	Specification models.SpecificationVersion `json:"pact:specification"`
 	Type          string                      `json:"pact:matcher:type"`
-	Contents      interface{}                 `json:"value"`
+	Contents      any                         `json:"value"`
 }
 
-func (e eachKeyLike) GetValue() interface{} {
+func (e eachKeyLike) GetValue() any {
 	return e.Contents
 }
 
@@ -135,7 +135,7 @@ func (e eachKeyLike) isMatcher() {}
 //
 // key - Example key to use (which will be ignored)
 // template - Example value template to base the comparison on.
-func EachKeyLike(key string, template interface{}) Matcher {
+func EachKeyLike(key string, template any) Matcher {
 	return eachKeyLike{
 		Specification: models.V3,
 		Type:          "values",
@@ -146,10 +146,10 @@ func EachKeyLike(key string, template interface{}) Matcher {
 type arrayContaining struct {
 	Specification models.SpecificationVersion `json:"pact:specification"`
 	Type          string                      `json:"pact:matcher:type"`
-	Variants      []interface{}               `json:"variants"`
+	Variants      []any                       `json:"variants"`
 }
 
-func (a arrayContaining) GetValue() interface{} {
+func (a arrayContaining) GetValue() any {
 	return a.Variants
 }
 
@@ -158,7 +158,7 @@ func (a arrayContaining) isMatcher() {}
 // ArrayContaining allows heterogenous items to be matched within a list.
 // Unlike EachLike which must be an array with elements of the same shape,
 // ArrayContaining allows objects of different types and shapes.
-func ArrayContaining(variants []interface{}) Matcher {
+func ArrayContaining(variants []any) Matcher {
 	return arrayContaining{
 		Specification: models.V3,
 		Type:          "arrayContains",
@@ -169,12 +169,12 @@ func ArrayContaining(variants []interface{}) Matcher {
 type minMaxLike struct {
 	Specification models.SpecificationVersion `json:"pact:specification"`
 	Type          string                      `json:"pact:matcher:type"`
-	Contents      interface{}                 `json:"value"`
+	Contents      any                         `json:"value"`
 	Min           int                         `json:"min,omitempty"`
 	Max           int                         `json:"max,omitempty"` // NOTE: only used for V3
 }
 
-func (m minMaxLike) GetValue() interface{} {
+func (m minMaxLike) GetValue() any {
 	return m.Contents
 }
 
@@ -182,13 +182,13 @@ func (m minMaxLike) isMatcher() {}
 
 // ArrayMinMaxLike is like EachLike except has a bounds on the max and the min
 // https://github.com/pact-foundation/pact-specification/tree/version-3#add-a-minmax-type-matcher
-func ArrayMinMaxLike(content interface{}, min int, max int) Matcher {
+func ArrayMinMaxLike(content any, min int, max int) Matcher {
 	if min < 1 {
 		log.Println("[WARN] min value to an array matcher can't be less than one")
 		min = 1
 	}
-	examples := make([]interface{}, max)
-	for i := 0; i < max; i++ {
+	examples := make([]any, max)
+	for i := range max {
 		examples[i] = content
 	}
 	return minMaxLike{
@@ -202,9 +202,9 @@ func ArrayMinMaxLike(content interface{}, min int, max int) Matcher {
 
 // ArrayMaxLike is like EachLike except has a bounds on the max
 // https://github.com/pact-foundation/pact-specification/tree/version-3#add-a-minmax-type-matcher
-func ArrayMaxLike(content interface{}, max int) Matcher {
-	examples := make([]interface{}, max)
-	for i := 0; i < max; i++ {
+func ArrayMaxLike(content any, max int) Matcher {
+	examples := make([]any, max)
+	for i := range max {
 		examples[i] = content
 	}
 
@@ -225,7 +225,7 @@ type stringGenerator struct {
 	Generator     string                      `json:"pact:generator:type"`
 }
 
-func (s stringGenerator) GetValue() interface{} {
+func (s stringGenerator) GetValue() any {
 	return s.Contents
 }
 

--- a/message/message.go
+++ b/message/message.go
@@ -5,8 +5,8 @@ import (
 )
 
 type (
-	Body     interface{}
-	Metadata map[string]interface{}
+	Body     any
+	Metadata map[string]any
 )
 
 // Handler is a provider function that generates a

--- a/message/v3/asynchronous_message.go
+++ b/message/v3/asynchronous_message.go
@@ -2,6 +2,7 @@ package v3
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log"
 	"os"
@@ -27,7 +28,7 @@ type AsynchronousMessageBuilder struct {
 
 	// Type to Marshal content into when sending back to the consumer
 	// Defaults to interface{}
-	Type interface{}
+	Type any
 
 	// The handler for this message
 	handler AsynchronousConsumer
@@ -94,7 +95,7 @@ func (m *UnconfiguredAsynchronousMessageBuilder) WithContent(contentType string,
 
 // WithJSONContent specifies the payload as an object (to be marshalled to WithJSONContent) that
 // is expected to be consumed.
-func (m *UnconfiguredAsynchronousMessageBuilder) WithJSONContent(content interface{}) *AsynchronousMessageBuilderWithContents {
+func (m *UnconfiguredAsynchronousMessageBuilder) WithJSONContent(content any) *AsynchronousMessageBuilderWithContents {
 	m.rootBuilder.messageHandle.WithRequestJSONContents(content)
 
 	return &AsynchronousMessageBuilderWithContents{
@@ -104,7 +105,7 @@ func (m *UnconfiguredAsynchronousMessageBuilder) WithJSONContent(content interfa
 
 // // AsType specifies that the content sent through to the
 // consumer handler should be sent as the given type.
-func (m *AsynchronousMessageBuilderWithContents) AsType(t interface{}) *AsynchronousMessageBuilderWithContents {
+func (m *AsynchronousMessageBuilderWithContents) AsType(t any) *AsynchronousMessageBuilderWithContents {
 	log.Println("[DEBUG] setting Message decoding to type:", reflect.TypeOf(t))
 	m.rootBuilder.Type = t
 
@@ -203,7 +204,7 @@ func (p *AsynchronousPact) verifyMessageConsumerRaw(messageToVerify *Asynchronou
 	body, err := messageToVerify.messageHandle.GetMessageRequestContents()
 	log.Println("[DEBUG] reified message raw", string(body))
 	if err != nil {
-		return fmt.Errorf("unexpected response from message server, this is a bug in the framework")
+		return errors.New("unexpected response from message server, this is a bug in the framework")
 	}
 
 	log.Println("[DEBUG] reified message raw", string(body))

--- a/message/v3/asynchronous_message.go
+++ b/message/v3/asynchronous_message.go
@@ -171,6 +171,7 @@ func (p *AsynchronousPact) validateConfig() error {
 }
 
 // AddMessage creates a new asynchronous consumer expectation
+//
 // Deprecated: use AddAsynchronousMessage() instead.
 func (p *AsynchronousPact) AddMessage() *AsynchronousMessageBuilder {
 	return p.AddAsynchronousMessage()
@@ -180,7 +181,7 @@ func (p *AsynchronousPact) AddMessage() *AsynchronousMessageBuilder {
 func (p *AsynchronousPact) AddAsynchronousMessage() *AsynchronousMessageBuilder {
 	log.Println("[DEBUG] add message")
 
-	message := p.messageserver.NewMessage()
+	message := p.messageserver.NewAsyncMessageInteraction("")
 
 	m := &AsynchronousMessageBuilder{
 		messageHandle: message,

--- a/message/v3/message.go
+++ b/message/v3/message.go
@@ -1,8 +1,8 @@
 package v3
 
 type (
-	Body     interface{}
-	Metadata map[string]interface{}
+	Body     any
+	Metadata map[string]any
 )
 
 // AsynchronousConsumer receives a message and must be able to parse

--- a/message/v4/asynchronous_message.go
+++ b/message/v4/asynchronous_message.go
@@ -26,7 +26,7 @@ type AsynchronousMessageBuilder struct {
 
 	// Type to Marshal content into when sending back to the consumer
 	// Defaults to interface{}
-	Type interface{}
+	Type any
 
 	// The handler for this message
 	handler AsynchronousConsumer
@@ -120,8 +120,8 @@ func (s *AsynchronousMessageWithPluginContents) ExecuteTest(t *testing.T, integr
 	return s.rootBuilder.pact.messageserver.WritePactFile(s.rootBuilder.pact.config.PactDir, false)
 }
 
-func (s *AsynchronousMessageWithPluginContents) StartTransport(transport string, address string, config map[string][]interface{}) *AsynchronousMessageWithTransport {
-	port, err := s.rootBuilder.pact.messageserver.StartTransport(transport, address, 0, make(map[string][]interface{}))
+func (s *AsynchronousMessageWithPluginContents) StartTransport(transport string, address string, config map[string][]any) *AsynchronousMessageWithTransport {
+	port, err := s.rootBuilder.pact.messageserver.StartTransport(transport, address, 0, make(map[string][]any))
 	if err != nil {
 		log.Fatalln("unable to start plugin transport:", err)
 	}
@@ -186,7 +186,7 @@ func (m *UnconfiguredAsynchronousMessageBuilder) WithContent(contentType string,
 
 // WithJSONContent specifies the payload as an object (to be marshalled to WithJSONContent) that
 // is expected to be consumed.
-func (m *UnconfiguredAsynchronousMessageBuilder) WithJSONContent(content interface{}) *AsynchronousMessageWithContents {
+func (m *UnconfiguredAsynchronousMessageBuilder) WithJSONContent(content any) *AsynchronousMessageWithContents {
 	m.rootBuilder.messageHandle.WithRequestJSONContents(content)
 
 	return &AsynchronousMessageWithContents{
@@ -196,7 +196,7 @@ func (m *UnconfiguredAsynchronousMessageBuilder) WithJSONContent(content interfa
 
 // AsType specifies that the content sent through to the
 // consumer handler should be sent as the given type.
-func (m *AsynchronousMessageWithContents) AsType(t interface{}) *AsynchronousMessageWithContents {
+func (m *AsynchronousMessageWithContents) AsType(t any) *AsynchronousMessageWithContents {
 	log.Println("[DEBUG] setting Message decoding to type:", reflect.TypeOf(t))
 	m.rootBuilder.Type = t
 
@@ -325,7 +325,7 @@ func getAsynchronousMessageWithContents(message *native.Message) (AsynchronousMe
 	}, nil
 }
 
-func getAsynchronousMessageWithReifiedContents(message *native.Message, reifiedType interface{}) (AsynchronousMessage, error) {
+func getAsynchronousMessageWithReifiedContents(message *native.Message, reifiedType any) (AsynchronousMessage, error) {
 	var m AsynchronousMessage
 	var err error
 

--- a/message/v4/asynchronous_message.go
+++ b/message/v4/asynchronous_message.go
@@ -260,6 +260,7 @@ func (p *AsynchronousPact) validateConfig() error {
 }
 
 // AddMessage creates a new asynchronous consumer expectation
+//
 // Deprecated: use AddAsynchronousMessage() instead.
 func (p *AsynchronousPact) AddMessage() *AsynchronousMessageBuilder {
 	return p.AddAsynchronousMessage()
@@ -269,7 +270,7 @@ func (p *AsynchronousPact) AddMessage() *AsynchronousMessageBuilder {
 func (p *AsynchronousPact) AddAsynchronousMessage() *AsynchronousMessageBuilder {
 	log.Println("[DEBUG] add message")
 
-	message := p.messageserver.NewMessage()
+	message := p.messageserver.NewAsyncMessageInteraction("")
 
 	return &AsynchronousMessageBuilder{
 		messageHandle: message,

--- a/message/v4/message.go
+++ b/message/v4/message.go
@@ -1,6 +1,6 @@
 package v4
 
-type Metadata map[string]interface{}
+type Metadata map[string]any
 
 // AsynchronousMessage is a representation of a single, unidirectional message
 // e.g. MQ, pub/sub, Websocket, Lambda
@@ -18,7 +18,7 @@ type MessageContents struct {
 
 	// Body is the attempt to reify the message body back into a specified type
 	// Not populated for synchronous  messages
-	Body interface{} `json:"contents"`
+	Body any `json:"contents"`
 
 	// Message metadata. Currently not populated for synchronous messages
 	// Metadata field (type Metadata): `json:"metadata"`

--- a/message/v4/synchronous_message.go
+++ b/message/v4/synchronous_message.go
@@ -137,7 +137,7 @@ func (m *SynchronousMessageWithRequestBuilder) WithContent(contentType string, b
 
 // WithJSONContent specifies the payload as an object (to be marshalled to WithJSONContent) that
 // is expected to be consumed.
-func (m *SynchronousMessageWithRequestBuilder) WithJSONContent(content interface{}) *SynchronousMessageWithRequestBuilder {
+func (m *SynchronousMessageWithRequestBuilder) WithJSONContent(content any) *SynchronousMessageWithRequestBuilder {
 	m.messageHandle.WithRequestJSONContents(content)
 
 	return m
@@ -186,7 +186,7 @@ func (m *SynchronousMessageWithResponseBuilder) WithContent(contentType string, 
 
 // WithJSONContent specifies the payload as an object (to be marshalled to WithJSONContent) that
 // is expected to be consumed.
-func (m *SynchronousMessageWithResponseBuilder) WithJSONContent(content interface{}) *SynchronousMessageWithResponseBuilder {
+func (m *SynchronousMessageWithResponseBuilder) WithJSONContent(content any) *SynchronousMessageWithResponseBuilder {
 	m.messageHandle.WithResponseJSONContents(content)
 
 	return m
@@ -230,8 +230,8 @@ func (m *SynchronousMessageWithPluginContents) ExecuteTest(t *testing.T, integra
 	return m.pact.mockserver.WritePactFile(m.pact.config.PactDir, false)
 }
 
-func (s *SynchronousMessageWithPluginContents) StartTransport(transport string, address string, config map[string][]interface{}) *SynchronousMessageWithTransport {
-	port, err := s.pact.mockserver.StartTransport(transport, address, 0, make(map[string][]interface{}))
+func (s *SynchronousMessageWithPluginContents) StartTransport(transport string, address string, config map[string][]any) *SynchronousMessageWithTransport {
+	port, err := s.pact.mockserver.StartTransport(transport, address, 0, make(map[string][]any))
 	if err != nil {
 		log.Fatalln("unable to start plugin transport:", err)
 	}

--- a/message/v4/synchronous_message_test.go
+++ b/message/v4/synchronous_message_test.go
@@ -108,7 +108,7 @@ func TestSyncTypeSystem_ProtobufPlugin_Matcher_Transport(t *testing.T) {
 		PactDir:  "/tmp/",
 	})
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/../../internal/native/pact_plugin.proto", strings.ReplaceAll(dir, "\\", "/"))
+	path := strings.ReplaceAll(dir, "\\", "/") + "/../../internal/native/pact_plugin.proto"
 
 	grpcInteraction := `{
 		"pact:proto": "` + path + `",
@@ -166,7 +166,7 @@ func TestSyncTypeSystem_ProtobufPlugin_Matcher_Transport_Fail(t *testing.T) {
 	})
 	_ = log.SetLogLevel("INFO")
 	dir, _ := os.Getwd()
-	path := fmt.Sprintf("%s/../../internal/native/pact_plugin.proto", strings.ReplaceAll(dir, "\\", "/"))
+	path := strings.ReplaceAll(dir, "\\", "/") + "/../../internal/native/pact_plugin.proto"
 
 	grpcInteraction := `{
 		"pact:proto": "` + path + `",

--- a/message/verifier.go
+++ b/message/verifier.go
@@ -69,77 +69,77 @@ func stringMetadataValue(metadata Metadata, keys ...string) (string, bool) {
 func CreateMessageHandler(messageHandlers Handlers) proxy.Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == "/__messages" {
-				log.Printf("[TRACE] message verification handler")
+			if r.URL.Path != "/__messages" {
+				log.Println("[TRACE] skipping message handler for request", strconv.Quote(r.RequestURI))
 
-				// Extract message
-				var message messageVerificationHandlerRequest
-				body, err := io.ReadAll(r.Body)
-				closeErr := r.Body.Close()
-				if closeErr != nil {
-					log.Println("[WARN] failed to close request body:", closeErr)
-				}
-				log.Printf("[TRACE] message verification handler received request: %s, %s", strconv.Quote(string(body)), strconv.Quote(r.URL.Path))
-
-				if err != nil {
-					log.Printf("[ERROR] unable to parse message verification request: %s", err)
-					w.WriteHeader(http.StatusBadRequest)
-					return
-				}
-
-				err = json.Unmarshal(body, &message)
-				if err != nil {
-					log.Printf("[ERROR] unable to parse message verification request: %s", err)
-					w.WriteHeader(http.StatusBadRequest)
-					return
-				}
-
-				// Lookup key in function mapping
-				f, messageFound := messageHandlers[message.Description]
-
-				if !messageFound {
-					log.Printf("[ERROR] message handler not found for message description: %v", message.Description)
-					w.WriteHeader(http.StatusNotFound)
-					return
-				}
-
-				// Execute function handler
-				res, metadata, handlerErr := f(message.States)
-
-				if handlerErr != nil {
-					log.Printf("[ERROR] error executive message handler %s", handlerErr)
-					w.WriteHeader(http.StatusServiceUnavailable)
-					return
-				}
-
-				// Write the body back
-				appendMetadataToResponseHeaders(metadata, w)
-
-				if bytes, ok := res.([]byte); ok {
-					log.Println("[DEBUG] checking type of message is []byte")
-					body = bytes
-				} else {
-					log.Println("[DEBUG] message body is not []byte, serialising as JSON")
-					body, err = json.Marshal(res)
-					if err != nil {
-						w.WriteHeader(http.StatusServiceUnavailable)
-						log.Println("[ERROR] error marshalling object:", err)
-						return
-					}
-				}
-
-				w.WriteHeader(http.StatusOK)
-				_, err = w.Write(body)
-				if err != nil {
-					log.Println("[ERROR] failed to write body response:", err)
-				}
-
+				// Pass through to application
+				next.ServeHTTP(w, r)
 				return
 			}
-			log.Println("[TRACE] skipping message handler for request", strconv.Quote(r.RequestURI))
 
-			// Pass through to application
-			next.ServeHTTP(w, r)
+			log.Printf("[TRACE] message verification handler")
+
+			// Extract message
+			var message messageVerificationHandlerRequest
+			body, err := io.ReadAll(r.Body)
+			closeErr := r.Body.Close()
+			if closeErr != nil {
+				log.Println("[WARN] failed to close request body:", closeErr)
+			}
+			log.Printf("[TRACE] message verification handler received request: %s, %s", strconv.Quote(string(body)), strconv.Quote(r.URL.Path))
+
+			if err != nil {
+				log.Printf("[ERROR] unable to parse message verification request: %s", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			err = json.Unmarshal(body, &message)
+			if err != nil {
+				log.Printf("[ERROR] unable to parse message verification request: %s", err)
+				w.WriteHeader(http.StatusBadRequest)
+				return
+			}
+
+			// Lookup key in function mapping
+			f, messageFound := messageHandlers[message.Description]
+
+			if !messageFound {
+				log.Printf("[ERROR] message handler not found for message description: %v", message.Description)
+				w.WriteHeader(http.StatusNotFound)
+				return
+			}
+
+			// Execute function handler
+			res, metadata, handlerErr := f(message.States)
+
+			if handlerErr != nil {
+				log.Printf("[ERROR] error executive message handler %s", handlerErr)
+				w.WriteHeader(http.StatusServiceUnavailable)
+				return
+			}
+
+			// Write the body back
+			appendMetadataToResponseHeaders(metadata, w)
+
+			if bytes, ok := res.([]byte); ok {
+				log.Println("[DEBUG] checking type of message is []byte")
+				body = bytes
+			} else {
+				log.Println("[DEBUG] message body is not []byte, serialising as JSON")
+				body, err = json.Marshal(res)
+				if err != nil {
+					w.WriteHeader(http.StatusServiceUnavailable)
+					log.Println("[ERROR] error marshalling object:", err)
+					return
+				}
+			}
+
+			w.WriteHeader(http.StatusOK)
+			_, err = w.Write(body)
+			if err != nil {
+				log.Println("[ERROR] failed to write body response:", err)
+			}
 		})
 	}
 }

--- a/models/provider_state.go
+++ b/models/provider_state.go
@@ -2,13 +2,13 @@ package models
 
 // ProviderState allows parameters and a description to be passed to the verification process.
 type ProviderState struct {
-	Name       string                 `json:"name"`
-	Parameters map[string]interface{} `json:"params,omitempty"`
+	Name       string         `json:"name"`
+	Parameters map[string]any `json:"params,omitempty"`
 }
 
 // ProviderStateResponse may return values in the state setup
 // for the "value from provider state" feature.
-type ProviderStateResponse map[string]interface{}
+type ProviderStateResponse map[string]any
 
 // StateHandler is a provider function that sets up a given state before
 // the provider interaction is validated

--- a/provider/consumer_version_selector.go
+++ b/provider/consumer_version_selector.go
@@ -26,7 +26,7 @@ type ConsumerVersionSelector struct {
 func (c *ConsumerVersionSelector) IsSelector() {
 }
 
-type UntypedConsumerVersionSelector map[string]interface{}
+type UntypedConsumerVersionSelector map[string]any
 
 // Type marker.
 func (c *UntypedConsumerVersionSelector) IsSelector() {

--- a/provider/errors_test.go
+++ b/provider/errors_test.go
@@ -2,7 +2,6 @@ package provider
 
 import (
 	"errors"
-	"fmt"
 	"testing"
 
 	"github.com/pact-foundation/pact-go/v2/internal/native"
@@ -24,7 +23,7 @@ func TestErrVerificationFailed_IsNativeSentinel(t *testing.T) {
 // TestErrVerificationFailed_DiscriminatesFromGenericError makes sure the
 // sentinels are not confused with arbitrary error values.
 func TestErrVerificationFailed_DiscriminatesFromGenericError(t *testing.T) {
-	generic := fmt.Errorf("something else broke")
+	generic := errors.New("something else broke")
 	if errors.Is(generic, ErrVerificationFailed) {
 		t.Error("generic error should not match ErrVerificationFailed")
 	}

--- a/provider/verifier.go
+++ b/provider/verifier.go
@@ -242,9 +242,9 @@ func beforeEachMiddleware(BeforeEach Hook) proxy.Middleware {
 
 // {"action":"teardown","id":"foo","state":"User foo exists"}.
 type stateHandlerAction struct {
-	Action string                 `json:"action"`
-	State  string                 `json:"state"`
-	Params map[string]interface{} `json:"params"`
+	Action string         `json:"action"`
+	State  string         `json:"state"`
+	Params map[string]any `json:"params"`
 }
 
 func getStateFromRequest(r *http.Request) (stateHandlerAction, error) {

--- a/provider/verifier.go
+++ b/provider/verifier.go
@@ -219,7 +219,7 @@ func (v *Verifier) VerifyProvider(t *testing.T, request VerifyRequest) error {
 
 // beforeEachMiddleware is invoked before any other, only on the __setup
 // request (to avoid duplication).
-func beforeEachMiddleware(BeforeEach Hook) proxy.Middleware {
+func beforeEachMiddleware(beforeEach Hook) proxy.Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.URL.Path == providerStatesSetupPath {
@@ -228,7 +228,7 @@ func beforeEachMiddleware(BeforeEach Hook) proxy.Middleware {
 				// Before each should only fire on the "setup" phase
 				if err == nil && state.Action == "setup" {
 					log.Println("[DEBUG] executing before hook")
-					err := BeforeEach()
+					err := beforeEach()
 					if err != nil {
 						log.Println("[ERROR] error executing before hook:", err)
 						w.WriteHeader(http.StatusInternalServerError)
@@ -282,95 +282,96 @@ func getStateFromRequest(r *http.Request) (stateHandlerAction, error) {
 func stateHandlerMiddleware(stateHandlers models.StateHandlers, afterEach Hook) proxy.Middleware {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.URL.Path == providerStatesSetupPath {
-				log.Println("[INFO] executing state handler middleware")
-				var state stateHandlerAction
-				buf := new(strings.Builder)
-				tr := io.TeeReader(r.Body, buf)
-				// TODO: should return an error if unable to read ?
-				_, _ = io.ReadAll(tr)
+			if r.URL.Path != providerStatesSetupPath {
+				log.Println("[TRACE] skipping state handler for request", strconv.Quote(r.RequestURI))
 
-				// Body is consumed above, need to put it back after ;P
-				r.Body = io.NopCloser(strings.NewReader(buf.String()))
-				log.Println("[TRACE] state handler received raw input", buf.String())
+				// Pass through to application
+				next.ServeHTTP(w, r)
+				return
+			}
 
-				err := json.Unmarshal([]byte(buf.String()), &state)
-				log.Println("[TRACE] state handler parsed input (without params)", state)
+			log.Println("[INFO] executing state handler middleware")
+			var state stateHandlerAction
+			buf := new(strings.Builder)
+			tr := io.TeeReader(r.Body, buf)
+			// TODO: should return an error if unable to read ?
+			_, _ = io.ReadAll(tr)
 
-				if err != nil {
-					log.Println("[ERROR] unable to decode incoming state change payload", err)
-					w.WriteHeader(http.StatusInternalServerError)
-					return
-				}
+			// Body is consumed above, need to put it back after ;P
+			r.Body = io.NopCloser(strings.NewReader(buf.String()))
+			log.Println("[TRACE] state handler received raw input", buf.String())
 
-				// Extract the params from the payload. They are in the root, so we need to do some more work to achieve this
-				var params models.ProviderStateResponse
-				err = json.Unmarshal([]byte(buf.String()), &params)
-				if err != nil {
-					log.Println("[ERROR] unable to decode incoming state change payload", err)
-					w.WriteHeader(http.StatusInternalServerError)
-					return
-				}
+			err := json.Unmarshal([]byte(buf.String()), &state)
+			log.Println("[TRACE] state handler parsed input (without params)", state)
 
-				// TODO: update rust code - params should be in a sub-property, to avoid top-level key conflicts
-				// i.e. it's possible action/state are actually something a users wants to supply
-				delete(params, "action")
-				delete(params, "state")
-				state.Params = params
-				log.Println("[TRACE] state handler completed parsing input (with params)", state)
+			if err != nil {
+				log.Println("[ERROR] unable to decode incoming state change payload", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
 
-				// Find the provider state handler
-				sf, stateFound := stateHandlers[state.State]
+			// Extract the params from the payload. They are in the root, so we need to do some more work to achieve this
+			var params models.ProviderStateResponse
+			err = json.Unmarshal([]byte(buf.String()), &params)
+			if err != nil {
+				log.Println("[ERROR] unable to decode incoming state change payload", err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
 
-				if !stateFound {
-					log.Printf("[WARN] no state handler found for state: %v", state.State)
-				} else {
-					// Execute state handler
-					res, err := sf(state.Action == "setup", models.ProviderState{Name: state.State, Parameters: state.Params})
-					if err != nil {
-						log.Printf("[ERROR] state handler for '%v' errored: %v", state.State, err)
-						w.WriteHeader(http.StatusInternalServerError)
-						return
-					}
+			// TODO: update rust code - params should be in a sub-property, to avoid top-level key conflicts
+			// i.e. it's possible action/state are actually something a users wants to supply
+			delete(params, "action")
+			delete(params, "state")
+			state.Params = params
+			log.Println("[TRACE] state handler completed parsing input (with params)", state)
 
-					if state.Action == "teardown" && afterEach != nil {
-						err := afterEach()
-						if err != nil {
-							log.Printf("[ERROR] after each hook for test errored: %v", err)
-							w.WriteHeader(http.StatusInternalServerError)
-							return
-						}
-					}
+			// Find the provider state handler
+			sf, stateFound := stateHandlers[state.State]
 
-					// Return provider state values for generator
-					if res != nil {
-						log.Println("[TRACE] returning values from provider state (raw)", res)
-						resBody, err := json.Marshal(res)
-						log.Println("[TRACE] returning values from provider state (JSON)", string(resBody))
-
-						if err != nil {
-							log.Printf("[ERROR] state handler for '%v' errored: %v", state.State, err)
-							w.WriteHeader(http.StatusInternalServerError)
-
-							return
-						}
-
-						w.Header().Add("content-type", "application/json")
-						w.WriteHeader(http.StatusOK)
-						// TODO: return interal server error if unable to write ?
-						_, _ = w.Write(resBody)
-						return
-					}
-				}
-
+			if !stateFound {
+				log.Printf("[WARN] no state handler found for state: %v", state.State)
 				w.WriteHeader(http.StatusOK)
 				return
 			}
 
-			log.Println("[TRACE] skipping state handler for request", strconv.Quote(r.RequestURI))
+			// Execute state handler
+			res, err := sf(state.Action == "setup", models.ProviderState{Name: state.State, Parameters: state.Params})
+			if err != nil {
+				log.Printf("[ERROR] state handler for '%v' errored: %v", state.State, err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
 
-			// Pass through to application
-			next.ServeHTTP(w, r)
+			if state.Action == "teardown" && afterEach != nil {
+				err := afterEach()
+				if err != nil {
+					log.Printf("[ERROR] after each hook for test errored: %v", err)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+			}
+
+			// Return provider state values for generator
+			if res == nil {
+				w.WriteHeader(http.StatusOK)
+				return
+			}
+
+			log.Println("[TRACE] returning values from provider state (raw)", res)
+			resBody, err := json.Marshal(res)
+			log.Println("[TRACE] returning values from provider state (JSON)", string(resBody))
+
+			if err != nil {
+				log.Printf("[ERROR] state handler for '%v' errored: %v", state.State, err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+
+			w.Header().Add("content-type", "application/json")
+			w.WriteHeader(http.StatusOK)
+			// TODO: return interal server error if unable to write ?
+			_, _ = w.Write(resBody)
 		})
 	}
 }

--- a/provider/verify_request.go
+++ b/provider/verify_request.go
@@ -85,6 +85,7 @@ type VerifyRequest struct {
 
 	// ProviderStatesSetupURL is the endpoint to post current provider state
 	// to on the Provider API.
+	//
 	// Deprecated: For backward compatibility ProviderStatesSetupURL is
 	// still supported. Use StateHandlers instead.
 	ProviderStatesSetupURL string

--- a/provider/verify_request.go
+++ b/provider/verify_request.go
@@ -191,7 +191,7 @@ type VerifyRequest struct {
 // Validate checks that the minimum fields are provided.
 func (v *VerifyRequest) validate(handle *native.Verifier) error {
 	if v.ProviderBaseURL == "" {
-		logging.PactCrash(fmt.Errorf("ProviderBaseURL is a required field"))
+		logging.PactCrash(errors.New("ProviderBaseURL is a required field"))
 	} else {
 		url, err := url.Parse(v.ProviderBaseURL)
 		if err != nil {
@@ -218,7 +218,7 @@ func (v *VerifyRequest) validate(handle *native.Verifier) error {
 
 	filterDescription := valueOrFromEnvironment(v.FilterDescription, "PACT_DESCRIPTION")
 	filterState := valueOrFromEnvironment(v.FilterState, "PACT_PROVIDER_STATE")
-	filterNoState := valueOrFromEnvironment(fmt.Sprintf("%t", v.FilterNoState), "PACT_PROVIDER_NO_STATE") == "true"
+	filterNoState := valueOrFromEnvironment(strconv.FormatBool(v.FilterNoState), "PACT_PROVIDER_NO_STATE") == "true"
 
 	if filterDescription != "" || filterState != "" || os.Getenv("PACT_PROVIDER_NO_STATE") != "" {
 		handle.SetFilterInfo(filterDescription, filterState, filterNoState)
@@ -254,7 +254,7 @@ func (v *VerifyRequest) validate(handle *native.Verifier) error {
 	}
 
 	if len(v.PactURLs) == 0 && len(v.PactFiles) == 0 && len(v.PactDirs) == 0 && v.BrokerURL == "" {
-		return fmt.Errorf("one of 'PactURLs', 'PactFiles', 'PactDIRs' or 'BrokerURL' must be specified")
+		return errors.New("one of 'PactURLs', 'PactFiles', 'PactDIRs' or 'BrokerURL' must be specified")
 	}
 
 	selectors := make([]string, len(v.ConsumerVersionSelectors))
@@ -311,7 +311,7 @@ func valueOrFromEnvironment(value string, envKey string) string {
 }
 
 type outputWriter interface {
-	Log(args ...interface{})
+	Log(args ...any)
 }
 
 func (v *VerifyRequest) Verify(handle *native.Verifier, writer outputWriter) error {

--- a/proxy/http.go
+++ b/proxy/http.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"slices"
 	"strconv"
 	"strings"
 	"time"
@@ -62,8 +63,8 @@ func chainHandlers(mw ...Middleware) Middleware {
 	return func(final http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			last := final
-			for i := len(mw) - 1; i >= 0; i-- {
-				last = mw[i](last)
+			for _, m := range slices.Backward(mw) {
+				last = m(last)
 			}
 			last.ServeHTTP(w, r)
 		})

--- a/proxy/http_test.go
+++ b/proxy/http_test.go
@@ -23,7 +23,7 @@ func DummyMiddleware(header string) Middleware {
 }
 
 func TestLoggingMiddleware(t *testing.T) {
-	req, err := http.NewRequestWithContext(context.Background(), "GET", "/x", nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/x", nil)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -39,7 +39,7 @@ func TestLoggingMiddleware(t *testing.T) {
 }
 
 func TestChainHandlers(t *testing.T) {
-	req, err := http.NewRequestWithContext(context.Background(), "GET", "/health-check", nil)
+	req, err := http.NewRequestWithContext(context.Background(), http.MethodGet, "/health-check", nil)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/utils/json_utils.go
+++ b/utils/json_utils.go
@@ -18,7 +18,7 @@ func FormatJSONString(object string) string {
 }
 
 // Format a JSON document for creating Pact files.
-func FormatJSONObject(object interface{}) string {
+func FormatJSONObject(object any) string {
 	out, err := json.Marshal(object)
 	if err != nil {
 		log.Println("[ERROR] failed to encode string to json:", err)
@@ -29,18 +29,18 @@ func FormatJSONObject(object interface{}) string {
 
 // Checks to see if someone has tried to submit a JSON string
 // for an object, which is no longer supported.
-func IsJSONFormattedObject(stringOrObject interface{}) bool {
+func IsJSONFormattedObject(stringOrObject any) bool {
 	switch content := stringOrObject.(type) {
 	case []byte:
 	case string:
-		var obj interface{}
+		var obj any
 		err := json.Unmarshal([]byte(content), &obj)
 		if err != nil {
 			return false
 		}
 
 		// Check if a map type
-		if _, ok := obj.(map[string]interface{}); ok {
+		if _, ok := obj.(map[string]any); ok {
 			return true
 		}
 	}

--- a/utils/port.go
+++ b/utils/port.go
@@ -38,8 +38,8 @@ func GetFreePort() (int, error) {
 func FindPortInRange(s string) (int, error) {
 	// Take care of csv and single value
 	if !strings.Contains(s, "-") {
-		ports := strings.Split(strings.TrimSpace(s), ",")
-		for _, p := range ports {
+		ports := strings.SplitSeq(strings.TrimSpace(s), ",")
+		for p := range ports {
 			i, err := strconv.Atoi(p)
 			if err != nil {
 				return 0, err


### PR DESCRIPTION
## Summary

Enables the modernisation linter group, `gocritic`, `nestif` and `protogetter`, and fixes every finding.

## Motivation

Mechanical modernisation: `interface{}` → `any`, range-over-int, `slices`/`maps` helpers, and generated getters for proto field reads. No public API changes — `any` is an alias, so signatures are identical to callers.

## Notes for reviewers

The only non-mechanical part is the `nestif` restructure of `stateHandlerMiddleware` and `CreateMessageHandler`, which is covered by the characterisation tests added in #614.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
