### PR TITLE
refactor: enable structure linters and reorder declarations

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -9,13 +9,17 @@ issues:
 linters:
   enable:
     - bodyclose
+    - dogsled
     - dupword
+    - embeddedstructfieldcheck
     - errorlint
     - exhaustive
     - forcetypeassert
+    - funcorder
     - gocritic
     - godot
     - gosec
+    - inamedparam
     - intrange
     - mirror
     - misspell
@@ -26,8 +30,10 @@ linters:
     - nilnesserr
     - noctx
     - noinlineerr
+    - nonamedreturns
     - perfsprint
     - protogetter
+    - tagalign
     - testifylint
     - thelper
     - unconvert

--- a/consumer/http.go
+++ b/consumer/http.go
@@ -91,42 +91,6 @@ type MockServerConfig struct {
 	TLSConfig *tls.Config
 }
 
-// configure validates the configuration for the consumer test.
-func (p *httpMockProvider) configure() error {
-	log.Println("[DEBUG] pact setup")
-	dir, _ := os.Getwd()
-
-	if p.config.Host == "" {
-		p.config.Host = "127.0.0.1"
-	}
-
-	if p.config.LogDir == "" {
-		p.config.LogDir = filepath.Join(dir, "logs")
-	}
-
-	if p.config.PactDir == "" {
-		p.config.PactDir = filepath.Join(dir, "pacts")
-	}
-
-	if p.config.ClientTimeout == 0 {
-		p.config.ClientTimeout = 10 * time.Second
-	}
-
-	p.mockserver = native.NewHTTPPact(p.config.Consumer, p.config.Provider)
-	p.mockserver.WithMetadata("pact-go", "version", strings.TrimPrefix(command.Version, "v"))
-	switch p.specificationVersion {
-	case models.V2:
-		p.mockserver.WithSpecificationVersion(native.SPECIFICATION_VERSION_V2)
-	case models.V3:
-		p.mockserver.WithSpecificationVersion(native.SPECIFICATION_VERSION_V3)
-	case models.V4:
-		p.mockserver.WithSpecificationVersion(native.SPECIFICATION_VERSION_V4)
-	}
-	native.Init(string(logging.LogLevel()))
-
-	return nil
-}
-
 // ExecuteTest runs the current test case against a Mock Service.
 // Will cleanup interactions between tests within a suite
 // and write the pact file if successful.
@@ -176,6 +140,42 @@ func (p *httpMockProvider) ExecuteTest(t *testing.T, integrationTest func(MockSe
 	p.mockserver.CleanupPlugins()
 
 	return p.writePact()
+}
+
+// configure validates the configuration for the consumer test.
+func (p *httpMockProvider) configure() error {
+	log.Println("[DEBUG] pact setup")
+	dir, _ := os.Getwd()
+
+	if p.config.Host == "" {
+		p.config.Host = "127.0.0.1"
+	}
+
+	if p.config.LogDir == "" {
+		p.config.LogDir = filepath.Join(dir, "logs")
+	}
+
+	if p.config.PactDir == "" {
+		p.config.PactDir = filepath.Join(dir, "pacts")
+	}
+
+	if p.config.ClientTimeout == 0 {
+		p.config.ClientTimeout = 10 * time.Second
+	}
+
+	p.mockserver = native.NewHTTPPact(p.config.Consumer, p.config.Provider)
+	p.mockserver.WithMetadata("pact-go", "version", strings.TrimPrefix(command.Version, "v"))
+	switch p.specificationVersion {
+	case models.V2:
+		p.mockserver.WithSpecificationVersion(native.SPECIFICATION_VERSION_V2)
+	case models.V3:
+		p.mockserver.WithSpecificationVersion(native.SPECIFICATION_VERSION_V3)
+	case models.V4:
+		p.mockserver.WithSpecificationVersion(native.SPECIFICATION_VERSION_V4)
+	}
+	native.Init(string(logging.LogLevel()))
+
+	return nil
 }
 
 // Clear state between tests.

--- a/examples/basic_test.go
+++ b/examples/basic_test.go
@@ -53,8 +53,8 @@ func TestProductAPIClient(t *testing.T) {
 
 // Product domain model.
 type Product struct {
-	ID    int    `json:"id" pact:"example=10"`
-	Name  string `json:"name" pact:"example=Billy"`
+	ID    int    `json:"id"    pact:"example=10"`
+	Name  string `json:"name"  pact:"example=Billy"`
 	Price string `json:"price" pact:"example=23.33"`
 }
 

--- a/examples/grpc/routeguide/data/data.go
+++ b/examples/grpc/routeguide/data/data.go
@@ -28,7 +28,10 @@ import (
 var basepath string
 
 func init() {
-	_, currentFile, _, _ := runtime.Caller(0)
+	_, currentFile, _, ok := runtime.Caller(0)
+	if !ok {
+		panic("runtime.Caller failed to resolve data.go path")
+	}
 	basepath = filepath.Dir(currentFile)
 }
 

--- a/examples/grpc/routeguide/server/server.go
+++ b/examples/grpc/routeguide/server/server.go
@@ -66,10 +66,17 @@ var (
 
 type routeGuideServer struct {
 	pb.UnimplementedRouteGuideServer
+
 	savedFeatures []*pb.Feature // read-only after initialized
 
 	mu         sync.Mutex // protects routeNotes
 	routeNotes map[string][]*pb.RouteNote
+}
+
+func NewServer() *routeGuideServer {
+	s := &routeGuideServer{routeNotes: make(map[string][]*pb.RouteNote)}
+	s.loadFeatures(*jsonDBFile)
+	return s
 }
 
 // GetFeature returns the feature at the given point.
@@ -231,12 +238,6 @@ func inRange(point *pb.Point, rect *pb.Rectangle) bool {
 
 func serialize(point *pb.Point) string {
 	return fmt.Sprintf("%d %d", point.GetLatitude(), point.GetLongitude())
-}
-
-func NewServer() *routeGuideServer {
-	s := &routeGuideServer{routeNotes: make(map[string][]*pb.RouteNote)}
-	s.loadFeatures(*jsonDBFile)
-	return s
 }
 
 func main() {

--- a/examples/helpers_test.go
+++ b/examples/helpers_test.go
@@ -1,8 +1,8 @@
 package main
 
 type User struct {
-	ID       int    `json:"id" pact:"example=27"`
-	Name     string `json:"name" pact:"example=Billy"`
+	ID       int    `json:"id"       pact:"example=27"`
+	Name     string `json:"name"     pact:"example=Billy"`
 	LastName string `json:"lastName" pact:"example=Sampson"`
 	Date     string `json:"datetime" pact:"example=2020-01-01'T'08:00:45,format=yyyy-MM-dd'T'HH:mm:ss,generator=datetime"`
 }

--- a/examples/types/user_service.go
+++ b/examples/types/user_service.go
@@ -4,11 +4,11 @@ import "errors"
 
 // User is a representation of a User. Dah.
 type User struct {
-	Name     string `json:"name" pact:"example=Jean-Marie de La Beaujardière😀😍"`
+	Name     string `json:"name"     pact:"example=Jean-Marie de La Beaujardière😀😍"`
 	Username string `json:"username" pact:"example=jmarie"`
 	Password string `json:"password" pact:"example=password123"`
-	Type     string `json:"type" pact:"example=admin,regex=^(admin|user|guest)$"`
-	ID       int    `json:"id" pact:"example=10"`
+	Type     string `json:"type"     pact:"example=admin,regex=^(admin|user|guest)$"`
+	ID       int    `json:"id"       pact:"example=10"`
 }
 
 var (

--- a/installer/installer.go
+++ b/installer/installer.go
@@ -129,19 +129,6 @@ func (i *Installer) CheckInstallation() error {
 	return nil
 }
 
-func (i *Installer) getLibDir() string {
-	if i.libDir != "" {
-		return i.libDir
-	}
-
-	env := os.Getenv(downloadEnvVar)
-	if env != "" {
-		return env
-	}
-
-	return "/usr/local/lib"
-}
-
 // CheckPackageInstall discovers any existing packages, and checks installation of a given binary using semver-compatible checks.
 func (i *Installer) CheckPackageInstall() error {
 	for pkg, info := range packages {
@@ -191,6 +178,19 @@ func (i *Installer) CheckPackageInstall() error {
 	}
 
 	return nil
+}
+
+func (i *Installer) getLibDir() string {
+	if i.libDir != "" {
+		return i.libDir
+	}
+
+	env := os.Getenv(downloadEnvVar)
+	if env != "" {
+		return env
+	}
+
+	return "/usr/local/lib"
 }
 
 // Download all dependencies, and update the pact-go configuration file.
@@ -521,7 +521,7 @@ type configReader interface {
 	readConfig() pactConfig
 }
 type configWriter interface {
-	writeConfig(pactConfig) error
+	writeConfig(c pactConfig) error
 }
 
 type configReadWriter interface {

--- a/internal/native/message_server.go
+++ b/internal/native/message_server.go
@@ -325,97 +325,6 @@ func (m *Message) GetMessageRequestContents() ([]byte, error) {
 	return m.getSyncMessageRequestContents()
 }
 
-// getAsyncMessageRequestContents is the MESSAGE_TYPE_ASYNC branch of
-// GetMessageRequestContents, split out to keep both branches readable.
-func (m *Message) getAsyncMessageRequestContents() ([]byte, error) {
-	iter := C.pactffi_pact_handle_get_message_iter(m.pact.handle)
-	log.Println("[DEBUG] pactffi_pact_handle_get_message_iter")
-	if iter == nil {
-		return nil, errors.New("unable to get a message iterator")
-	}
-	log.Println("[DEBUG] pactffi_pact_handle_get_message_iter - OK")
-
-	///////
-	// TODO: some debugging in here to see what's exploding.......
-	///////
-
-	log.Println("[DEBUG] pactffi_pact_handle_get_message_iter - len", len(m.server.messages))
-
-	for i := range len(m.server.messages) {
-		log.Println("[DEBUG] pactffi_pact_handle_get_message_iter - index", i)
-		message := C.pactffi_pact_message_iter_next(iter)
-		log.Println("[DEBUG] pactffi_pact_message_iter_next - message", message)
-
-		if i != m.index {
-			continue
-		}
-		log.Println("[DEBUG] pactffi_pact_message_iter_next - index match", message)
-
-		if message == nil {
-			return nil, errors.New("retrieved a null message pointer")
-		}
-
-		len := C.pactffi_message_get_contents_length(message)
-		log.Println("[DEBUG] pactffi_message_get_contents_length - len", len)
-		if len == 0 {
-			// You can have empty bodies
-			log.Println("[DEBUG] message body is empty")
-			return nil, nil
-		}
-		data := C.pactffi_message_get_contents_bin(message)
-		log.Println("[DEBUG] pactffi_message_get_contents_bin - data", data)
-		if data == nil {
-			// You can have empty bodies
-			log.Println("[DEBUG] message binary contents are empty")
-			return nil, nil
-		}
-		ptr := unsafe.Pointer(data)
-		bytes := C.GoBytes(ptr, C.int(len))
-
-		return bytes, nil
-	}
-
-	return nil, errors.New("unable to find the message")
-}
-
-// getSyncMessageRequestContents is the synchronous-message branch of
-// GetMessageRequestContents, split out to keep both branches readable.
-func (m *Message) getSyncMessageRequestContents() ([]byte, error) {
-	iter := C.pactffi_pact_handle_get_sync_message_iter(m.pact.handle)
-	if iter == nil {
-		return nil, errors.New("unable to get a message iterator")
-	}
-
-	for i := range len(m.server.messages) {
-		message := C.pactffi_pact_sync_message_iter_next(iter)
-
-		if i != m.index {
-			continue
-		}
-
-		if message == nil {
-			return nil, errors.New("retrieved a null message pointer")
-		}
-
-		len := C.pactffi_sync_message_get_request_contents_length(message)
-		if len == 0 {
-			log.Println("[DEBUG] message body is empty")
-			return nil, nil
-		}
-		data := C.pactffi_sync_message_get_request_contents_bin(message)
-		if data == nil {
-			log.Println("[DEBUG] message binary contents are empty")
-			return nil, nil
-		}
-		ptr := unsafe.Pointer(data)
-		bytes := C.GoBytes(ptr, C.int(len))
-
-		return bytes, nil
-	}
-
-	return nil, errors.New("unable to find the message")
-}
-
 // GetMessageResponseContents retreives the binary contents of the response for a given message
 // any matchers are stripped away if given
 // if the contents is from a plugin, the byte[] representation of the parsed
@@ -624,4 +533,95 @@ func (m *Message) WithReference(group, name, value string) *Message {
 	C.pactffi_add_interaction_reference(m.handle, cGroup, cName, cValue)
 
 	return m
+}
+
+// getAsyncMessageRequestContents is the MESSAGE_TYPE_ASYNC branch of
+// GetMessageRequestContents, split out to keep both branches readable.
+func (m *Message) getAsyncMessageRequestContents() ([]byte, error) {
+	iter := C.pactffi_pact_handle_get_message_iter(m.pact.handle)
+	log.Println("[DEBUG] pactffi_pact_handle_get_message_iter")
+	if iter == nil {
+		return nil, errors.New("unable to get a message iterator")
+	}
+	log.Println("[DEBUG] pactffi_pact_handle_get_message_iter - OK")
+
+	///////
+	// TODO: some debugging in here to see what's exploding.......
+	///////
+
+	log.Println("[DEBUG] pactffi_pact_handle_get_message_iter - len", len(m.server.messages))
+
+	for i := range len(m.server.messages) {
+		log.Println("[DEBUG] pactffi_pact_handle_get_message_iter - index", i)
+		message := C.pactffi_pact_message_iter_next(iter)
+		log.Println("[DEBUG] pactffi_pact_message_iter_next - message", message)
+
+		if i != m.index {
+			continue
+		}
+		log.Println("[DEBUG] pactffi_pact_message_iter_next - index match", message)
+
+		if message == nil {
+			return nil, errors.New("retrieved a null message pointer")
+		}
+
+		len := C.pactffi_message_get_contents_length(message)
+		log.Println("[DEBUG] pactffi_message_get_contents_length - len", len)
+		if len == 0 {
+			// You can have empty bodies
+			log.Println("[DEBUG] message body is empty")
+			return nil, nil
+		}
+		data := C.pactffi_message_get_contents_bin(message)
+		log.Println("[DEBUG] pactffi_message_get_contents_bin - data", data)
+		if data == nil {
+			// You can have empty bodies
+			log.Println("[DEBUG] message binary contents are empty")
+			return nil, nil
+		}
+		ptr := unsafe.Pointer(data)
+		bytes := C.GoBytes(ptr, C.int(len))
+
+		return bytes, nil
+	}
+
+	return nil, errors.New("unable to find the message")
+}
+
+// getSyncMessageRequestContents is the synchronous-message branch of
+// GetMessageRequestContents, split out to keep both branches readable.
+func (m *Message) getSyncMessageRequestContents() ([]byte, error) {
+	iter := C.pactffi_pact_handle_get_sync_message_iter(m.pact.handle)
+	if iter == nil {
+		return nil, errors.New("unable to get a message iterator")
+	}
+
+	for i := range len(m.server.messages) {
+		message := C.pactffi_pact_sync_message_iter_next(iter)
+
+		if i != m.index {
+			continue
+		}
+
+		if message == nil {
+			return nil, errors.New("retrieved a null message pointer")
+		}
+
+		len := C.pactffi_sync_message_get_request_contents_length(message)
+		if len == 0 {
+			log.Println("[DEBUG] message body is empty")
+			return nil, nil
+		}
+		data := C.pactffi_sync_message_get_request_contents_bin(message)
+		if data == nil {
+			log.Println("[DEBUG] message binary contents are empty")
+			return nil, nil
+		}
+		ptr := unsafe.Pointer(data)
+		bytes := C.GoBytes(ptr, C.int(len))
+
+		return bytes, nil
+	}
+
+	return nil, errors.New("unable to find the message")
 }

--- a/internal/native/mismatch.go
+++ b/internal/native/mismatch.go
@@ -38,6 +38,7 @@ type MismatchDetail struct {
 // MismatchedRequest contains details of any request mismatches during pact verification.
 type MismatchedRequest struct {
 	Request
+
 	Mismatches []MismatchDetail `json:"mismatches"`
 	Type       string           `json:"type"`
 }

--- a/internal/native/mock_server.go
+++ b/internal/native/mock_server.go
@@ -489,25 +489,6 @@ func (i *Interaction) WithResponseHeaders(valueOrMatcher map[string][]any) *Inte
 	return i.withHeaders(INTERACTION_PART_RESPONSE, valueOrMatcher)
 }
 
-func (i *Interaction) withHeaders(part interactionPart, valueOrMatcher map[string][]any) *Interaction {
-	for k, v := range valueOrMatcher {
-		cName := C.CString(k)
-
-		for _, header := range v {
-			value := stringFromInterface(header)
-			cValue := C.CString(value)
-
-			C.pactffi_with_header_v2(i.handle, C.int(part), cName, CUlong(0), cValue)
-
-			free(cValue)
-		}
-
-		free(cName)
-	}
-
-	return i
-}
-
 func (i *Interaction) WithQuery(valueOrMatcher map[string][]any) *Interaction {
 	for k, values := range valueOrMatcher {
 		cName := C.CString(k)
@@ -535,6 +516,72 @@ func (i *Interaction) WithJSONResponseBody(body any) *Interaction {
 	return i.withJSONBody(body, INTERACTION_PART_RESPONSE)
 }
 
+func (i *Interaction) WithRequestBody(contentType string, body []byte) *Interaction {
+	return i.withBody(contentType, body, 0)
+}
+
+func (i *Interaction) WithResponseBody(contentType string, body []byte) *Interaction {
+	return i.withBody(contentType, body, 1)
+}
+
+func (i *Interaction) WithBinaryRequestBody(body []byte) *Interaction {
+	return i.withBinaryBody("application/octet-stream", body, INTERACTION_PART_REQUEST)
+}
+
+func (i *Interaction) WithBinaryResponseBody(body []byte) *Interaction {
+	return i.withBinaryBody("application/octet-stream", body, INTERACTION_PART_RESPONSE)
+}
+
+func (i *Interaction) WithRequestMultipartFile(contentType string, filename string, mimePartName string) *Interaction {
+	return i.withMultipartFile(contentType, filename, mimePartName, INTERACTION_PART_REQUEST)
+}
+
+func (i *Interaction) WithResponseMultipartFile(contentType string, filename string, mimePartName string) *Interaction {
+	return i.withMultipartFile(contentType, filename, mimePartName, INTERACTION_PART_RESPONSE)
+}
+
+// Set the expected HTTTP response status.
+func (i *Interaction) WithStatus(status int) *Interaction {
+	C.pactffi_response_status(i.handle, C.ushort(status))
+
+	return i
+}
+
+// WithReference records an external reference (e.g. a ticket or pull request)
+// against the interaction. References are stored under comments.references[group][name]
+// in the Pact file. This is a V4-only feature.
+func (i *Interaction) WithReference(group, name, value string) *Interaction {
+	cGroup := C.CString(group)
+	defer free(cGroup)
+	cName := C.CString(name)
+	defer free(cName)
+	cValue := C.CString(value)
+	defer free(cValue)
+
+	C.pactffi_add_interaction_reference(i.handle, cGroup, cName, cValue)
+
+	return i
+}
+
+func (i *Interaction) withHeaders(part interactionPart, valueOrMatcher map[string][]any) *Interaction {
+	for k, v := range valueOrMatcher {
+		cName := C.CString(k)
+
+		for _, header := range v {
+			value := stringFromInterface(header)
+			cValue := C.CString(value)
+
+			C.pactffi_with_header_v2(i.handle, C.int(part), cName, CUlong(0), cValue)
+
+			free(cValue)
+		}
+
+		free(cName)
+	}
+
+	return i
+}
+
 func (i *Interaction) withJSONBody(body any, part interactionPart) *Interaction {
 	cHeader := C.CString("application/json")
 	defer free(cHeader)
@@ -546,14 +593,6 @@ func (i *Interaction) withJSONBody(body any, part interactionPart) *Interaction 
 	C.pactffi_with_body(i.handle, C.int(part), cHeader, cBody)
 
 	return i
-}
-
-func (i *Interaction) WithRequestBody(contentType string, body []byte) *Interaction {
-	return i.withBody(contentType, body, 0)
-}
-
-func (i *Interaction) WithResponseBody(contentType string, body []byte) *Interaction {
-	return i.withBody(contentType, body, 1)
 }
 
 func (i *Interaction) withBody(contentType string, body []byte, part interactionPart) *Interaction {
@@ -577,22 +616,6 @@ func (i *Interaction) withBinaryBody(contentType string, body []byte, part inter
 	return i
 }
 
-func (i *Interaction) WithBinaryRequestBody(body []byte) *Interaction {
-	return i.withBinaryBody("application/octet-stream", body, INTERACTION_PART_REQUEST)
-}
-
-func (i *Interaction) WithBinaryResponseBody(body []byte) *Interaction {
-	return i.withBinaryBody("application/octet-stream", body, INTERACTION_PART_RESPONSE)
-}
-
-func (i *Interaction) WithRequestMultipartFile(contentType string, filename string, mimePartName string) *Interaction {
-	return i.withMultipartFile(contentType, filename, mimePartName, INTERACTION_PART_REQUEST)
-}
-
-func (i *Interaction) WithResponseMultipartFile(contentType string, filename string, mimePartName string) *Interaction {
-	return i.withMultipartFile(contentType, filename, mimePartName, INTERACTION_PART_RESPONSE)
-}
-
 func (i *Interaction) withMultipartFile(contentType string, filename string, mimePartName string, part interactionPart) *Interaction {
 	cHeader := C.CString(contentType)
 	defer free(cHeader)
@@ -604,29 +627,6 @@ func (i *Interaction) withMultipartFile(contentType string, filename string, mim
 	defer free(cFilename)
 
 	C.pactffi_with_multipart_file(i.handle, C.int(part), cHeader, cFilename, cPartName)
-
-	return i
-}
-
-// Set the expected HTTTP response status.
-func (i *Interaction) WithStatus(status int) *Interaction {
-	C.pactffi_response_status(i.handle, C.ushort(status))
-
-	return i
-}
-
-// WithReference records an external reference (e.g. a ticket or pull request)
-// against the interaction. References are stored under comments.references[group][name]
-// in the Pact file. This is a V4-only feature.
-func (i *Interaction) WithReference(group, name, value string) *Interaction {
-	cGroup := C.CString(group)
-	defer free(cGroup)
-	cName := C.CString(name)
-	defer free(cName)
-	cValue := C.CString(value)
-	defer free(cValue)
-
-	C.pactffi_add_interaction_reference(i.handle, cGroup, cName, cValue)
 
 	return i
 }

--- a/internal/native/verifier.go
+++ b/internal/native/verifier.go
@@ -16,6 +16,19 @@ type Verifier struct {
 	handle *C.VerifierHandle
 }
 
+func NewVerifier(name string, version string) *Verifier {
+	cName := C.CString(name)
+	cVersion := C.CString(version)
+	defer free(cName)
+	defer free(cVersion)
+
+	h := C.pactffi_verifier_new_for_application(cName, cVersion)
+
+	return &Verifier{
+		handle: h,
+	}
+}
+
 // Version returns the current semver FFI interface version.
 func (v *Verifier) Version() string {
 	return Version()
@@ -36,19 +49,6 @@ var (
 	// ErrVerifierFailedToRun indicates the verification process was unable to run.
 	ErrVerifierFailedToRun = errors.New("the verifier failed to execute (this is most likely a defect in the framework)")
 )
-
-func NewVerifier(name string, version string) *Verifier {
-	cName := C.CString(name)
-	cVersion := C.CString(version)
-	defer free(cName)
-	defer free(cVersion)
-
-	h := C.pactffi_verifier_new_for_application(cName, cVersion)
-
-	return &Verifier{
-		handle: h,
-	}
-}
 
 func (v *Verifier) Shutdown() {
 	C.pactffi_verifier_shutdown(v.handle)

--- a/matchers/matcher.go
+++ b/matchers/matcher.go
@@ -35,16 +35,15 @@ func (m eachLike) GetValue() any {
 	return m.Value
 }
 
-func (m eachLike) isMatcher() {
+func (m eachLike) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type  string `json:"pact:matcher:type"`
+		Value any    `json:"value"`
+		Min   int    `json:"min"`
+	}{"type", m.Value, m.Min})
 }
 
-func (m eachLike) MarshalJSON() ([]byte, error) {
-	type marshaler eachLike
-
-	return json.Marshal(struct {
-		Type string `json:"pact:matcher:type"`
-		marshaler
-	}{"type", marshaler(m)})
+func (m eachLike) isMatcher() {
 }
 
 type like struct {
@@ -70,16 +69,15 @@ func (m term) GetValue() any {
 	return m.Value
 }
 
-func (m term) isMatcher() {
+func (m term) MarshalJSON() ([]byte, error) {
+	return json.Marshal(struct {
+		Type  string `json:"pact:matcher:type"`
+		Value string `json:"value"`
+		Regex string `json:"regex"`
+	}{"regex", m.Value, m.Regex})
 }
 
-func (m term) MarshalJSON() ([]byte, error) {
-	type marshaler term
-
-	return json.Marshal(struct {
-		Type string `json:"pact:matcher:type"`
-		marshaler
-	}{"regex", marshaler(m)})
+func (m term) isMatcher() {
 }
 
 // EachLike specifies that a given element in a JSON body can be repeated
@@ -189,27 +187,25 @@ type Matcher interface {
 // we aren't using an alias here.
 type S string
 
-func (s S) isMatcher() {}
-
 // GetValue returns the raw generated value for the matcher
 // without any of the matching detail context.
 func (s S) GetValue() any {
 	return s
 }
 
-func (s S) string() string {
-	return string(s)
-}
-
 func (s S) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.string())
+}
+
+func (s S) isMatcher() {}
+
+func (s S) string() string {
+	return string(s)
 }
 
 // String is the longer named form of the string primitive wrapper,
 // it allows plain strings to be matched.
 type String string
-
-func (s String) isMatcher() {}
 
 // GetValue returns the raw generated value for the matcher
 // without any of the matching detail context.
@@ -217,25 +213,27 @@ func (s String) GetValue() any {
 	return s
 }
 
-func (s String) string() string {
-	return string(s)
-}
-
 func (s String) MarshalJSON() ([]byte, error) {
 	return json.Marshal(s.string())
+}
+
+func (s String) isMatcher() {}
+
+func (s String) string() string {
+	return string(s)
 }
 
 // StructMatcher matches a complex object structure, which may itself
 // contain nested Matchers.
 type StructMatcher map[string]any
 
-func (m StructMatcher) isMatcher() {}
-
 // GetValue returns the raw generated value for the matcher
 // without any of the matching detail context.
 func (m StructMatcher) GetValue() any {
 	return nil
 }
+
+func (m StructMatcher) isMatcher() {}
 
 // MapMatcher allows a map[string]string-like object
 // to also contain complex matchers.
@@ -246,11 +244,11 @@ type (
 
 // UnmarshalJSON is a custom JSON parser for MapMatcher
 // It treats the matchers as strings.
-func (m *MapMatcher) UnmarshalJSON(bytes []byte) (err error) {
+func (m *MapMatcher) UnmarshalJSON(bytes []byte) error {
 	sk := make(map[string]string)
-	err = json.Unmarshal(bytes, &sk)
+	err := json.Unmarshal(bytes, &sk)
 	if err != nil {
-		return
+		return err
 	}
 
 	*m = make(map[string]Matcher)
@@ -258,7 +256,7 @@ func (m *MapMatcher) UnmarshalJSON(bytes []byte) (err error) {
 		(*m)[k] = String(v)
 	}
 
-	return
+	return nil
 }
 
 type (

--- a/matchers/matcher_test.go
+++ b/matchers/matcher_test.go
@@ -388,117 +388,120 @@ func TestMatcher_SugarMatchers(t *testing.T) {
 	matchers := map[string]matcherTestCase{
 		"HexValue": {
 			matcher: HexValue(),
-			testCase: func(v any) (err error) {
+			testCase: func(v any) error {
 				s, valid := v.(string)
 				if !valid || s != "3F" {
-					err = fmt.Errorf("want '3F', got '%v'", reflect.TypeOf(v))
+					return fmt.Errorf("want '3F', got '%v'", reflect.TypeOf(v))
 				}
-				return
+				return nil
 			},
 		},
 		"Identifier": {
 			matcher: Identifier(),
-			testCase: func(v any) (err error) {
+			testCase: func(v any) error {
 				_, valid := v.(float64) // JSON converts numbers to float64 in anonymous structs
 				if !valid {
-					err = fmt.Errorf("want int, got '%v'", reflect.TypeOf(v))
+					return fmt.Errorf("want int, got '%v'", reflect.TypeOf(v))
 				}
-				return
+				return nil
 			},
 		},
 		"Integer": {
 			matcher: Integer(1),
-			testCase: func(v any) (err error) {
+			testCase: func(v any) error {
 				_, valid := v.(float64) // JSON converts numbers to float64 in anonymous structs
 				if !valid {
-					err = fmt.Errorf("want int, got '%v'", reflect.TypeOf(v))
+					return fmt.Errorf("want int, got '%v'", reflect.TypeOf(v))
 				}
-				return
+				return nil
 			},
 		},
 		"IPAddress": {
 			matcher: IPAddress(),
-			testCase: func(v any) (err error) {
+			testCase: func(v any) error {
 				s, valid := v.(string)
 				if !valid || s != "127.0.0.1" {
-					err = fmt.Errorf("want '127.0.0.1', got '%v'", reflect.TypeOf(v))
+					return fmt.Errorf("want '127.0.0.1', got '%v'", reflect.TypeOf(v))
 				}
-				return
+				return nil
 			},
 		},
 		"IPv4Address": {
 			matcher: IPv4Address(),
-			testCase: func(v any) (err error) {
+			testCase: func(v any) error {
 				s, valid := v.(string)
 				if !valid || s != "127.0.0.1" {
-					err = fmt.Errorf("want '127.0.0.1', got '%v'", reflect.TypeOf(v))
+					return fmt.Errorf("want '127.0.0.1', got '%v'", reflect.TypeOf(v))
 				}
-				return
+				return nil
 			},
 		},
 		"IPv6Address": {
 			matcher: IPv6Address(),
-			testCase: func(v any) (err error) {
+			testCase: func(v any) error {
 				s, valid := v.(string)
 				if !valid || s != "::ffff:192.0.2.128" {
-					err = fmt.Errorf("want '::ffff:192.0.2.128', got '%v'", reflect.TypeOf(v))
+					return fmt.Errorf("want '::ffff:192.0.2.128', got '%v'", reflect.TypeOf(v))
 				}
-				return
+				return nil
 			},
 		},
 		"Decimal": {
 			matcher: Decimal(27.3),
-			testCase: func(v any) (err error) {
+			testCase: func(v any) error {
 				_, valid := v.(float64)
 				if !valid {
-					err = fmt.Errorf("want float64, got '%v'", reflect.TypeOf(v))
+					return fmt.Errorf("want float64, got '%v'", reflect.TypeOf(v))
 				}
-				return
+				return nil
 			},
 		},
 		"Timestamp": {
 			matcher: Timestamp(),
-			testCase: func(v any) (err error) {
+			testCase: func(v any) error {
 				_, valid := v.(string)
 				if !valid {
-					err = fmt.Errorf("want string, got '%v'", reflect.TypeOf(v))
+					return fmt.Errorf("want string, got '%v'", reflect.TypeOf(v))
 				}
-				return
+				return nil
 			},
 		},
 		"Date": {
 			matcher: Date(),
-			testCase: func(v any) (err error) {
+			testCase: func(v any) error {
 				_, valid := v.(string)
 				if !valid {
-					err = fmt.Errorf("want string, got '%v'", reflect.TypeOf(v))
+					return fmt.Errorf("want string, got '%v'", reflect.TypeOf(v))
 				}
-				return
+				return nil
 			},
 		},
 		"Time": {
 			matcher: Time(),
-			testCase: func(v any) (err error) {
+			testCase: func(v any) error {
 				_, valid := v.(string)
 				if !valid {
-					err = fmt.Errorf("want string, got '%v'", reflect.TypeOf(v))
+					return fmt.Errorf("want string, got '%v'", reflect.TypeOf(v))
 				}
-				return
+				return nil
 			},
 		},
 		"UUID": {
 			matcher: UUID(),
-			testCase: func(v any) (err error) {
+			testCase: func(v any) error {
 				s, valid := v.(string)
 				if !valid {
 					return fmt.Errorf("want string, got '%v'", reflect.TypeOf(v))
 				}
 
 				match, err := regexp.MatchString(uuid, s)
-				if !match {
-					err = fmt.Errorf("want string, got '%v'", v)
+				if err != nil {
+					return err
 				}
-				return
+				if !match {
+					return fmt.Errorf("want string, got '%v'", v)
+				}
+				return nil
 			},
 		},
 	}
@@ -591,7 +594,7 @@ func TestMatch(t *testing.T) {
 	}
 	type numberDTO struct {
 		Integer int     `json:"integer" pact:"example=42"`
-		Float   float32 `json:"float" pact:"example=6.66"`
+		Float   float32 `json:"float"   pact:"example=6.66"`
 	}
 	str := "str"
 	type args struct {

--- a/matchers/matcher_v3.go
+++ b/matchers/matcher_v3.go
@@ -32,17 +32,14 @@ func (n Null) GetValue() any {
 	return nil
 }
 
-func (n Null) isMatcher() {}
-
 func (n Null) MarshalJSON() ([]byte, error) {
-	type marshaler Null
-
 	return json.Marshal(struct {
 		Specification models.SpecificationVersion `json:"pact:specification"`
 		Type          string                      `json:"pact:matcher:type"`
-		marshaler
-	}{models.V3, "null", marshaler(n)})
+	}{models.V3, "null"})
 }
+
+func (n Null) isMatcher() {}
 
 // equality resets matching cascades back to equality
 // see https://github.com/pact-foundation/pact-specification/tree/version-3#add-an-equality-matcher

--- a/message/v3/asynchronous_message.go
+++ b/message/v3/asynchronous_message.go
@@ -155,21 +155,6 @@ func NewAsynchronousPact(config Config) (*AsynchronousPact, error) {
 	return provider, err
 }
 
-// validateConfig validates the configuration for the consumer test.
-func (p *AsynchronousPact) validateConfig() error {
-	log.Println("[DEBUG] pact message validate config")
-	dir, _ := os.Getwd()
-
-	if p.config.PactDir == "" {
-		p.config.PactDir = filepath.Join(dir, "pacts")
-	}
-
-	p.messageserver = native.NewMessageServer(p.config.Consumer, p.config.Provider)
-	p.messageserver.WithMetadata("pact-go", "version", strings.TrimPrefix(command.Version, "v"))
-
-	return nil
-}
-
 // AddMessage creates a new asynchronous consumer expectation
 //
 // Deprecated: use AddAsynchronousMessage() instead.
@@ -189,6 +174,33 @@ func (p *AsynchronousPact) AddAsynchronousMessage() *AsynchronousMessageBuilder 
 	}
 
 	return m
+}
+
+// VerifyMessageConsumer is a test convience function for VerifyMessageConsumerRaw,
+// accepting an instance of `*testing.T`.
+func (p *AsynchronousPact) Verify(t *testing.T, message *AsynchronousMessageBuilder, handler AsynchronousConsumer) error {
+	t.Helper()
+	err := p.verifyMessageConsumerRaw(message, handler)
+	if err != nil {
+		t.Errorf("VerifyMessageConsumer failed: %v", err)
+	}
+
+	return err
+}
+
+// validateConfig validates the configuration for the consumer test.
+func (p *AsynchronousPact) validateConfig() error {
+	log.Println("[DEBUG] pact message validate config")
+	dir, _ := os.Getwd()
+
+	if p.config.PactDir == "" {
+		p.config.PactDir = filepath.Join(dir, "pacts")
+	}
+
+	p.messageserver = native.NewMessageServer(p.config.Consumer, p.config.Provider)
+	p.messageserver.WithMetadata("pact-go", "version", strings.TrimPrefix(command.Version, "v"))
+
+	return nil
 }
 
 // VerifyMessageConsumerRaw creates a new Pact _message_ interaction to build a testable
@@ -244,16 +256,4 @@ func (p *AsynchronousPact) verifyMessageConsumerRaw(messageToVerify *Asynchronou
 	}
 
 	return p.messageserver.WritePactFile(p.config.PactDir, false)
-}
-
-// VerifyMessageConsumer is a test convience function for VerifyMessageConsumerRaw,
-// accepting an instance of `*testing.T`.
-func (p *AsynchronousPact) Verify(t *testing.T, message *AsynchronousMessageBuilder, handler AsynchronousConsumer) error {
-	t.Helper()
-	err := p.verifyMessageConsumerRaw(message, handler)
-	if err != nil {
-		t.Errorf("VerifyMessageConsumer failed: %v", err)
-	}
-
-	return err
 }

--- a/message/v4/asynchronous_message.go
+++ b/message/v4/asynchronous_message.go
@@ -243,22 +243,6 @@ func NewAsynchronousPact(config Config) (*AsynchronousPact, error) {
 	return provider, err
 }
 
-// validateConfig validates the configuration for the consumer test.
-func (p *AsynchronousPact) validateConfig() error {
-	log.Println("[DEBUG] pact message validate config")
-	dir, _ := os.Getwd()
-
-	if p.config.PactDir == "" {
-		p.config.PactDir = filepath.Join(dir, "pacts")
-	}
-
-	p.messageserver = native.NewMessageServer(p.config.Consumer, p.config.Provider)
-	p.messageserver.WithSpecificationVersion(native.SPECIFICATION_VERSION_V4)
-	p.messageserver.WithMetadata("pact-go", "version", strings.TrimPrefix(command.Version, "v"))
-
-	return nil
-}
-
 // AddMessage creates a new asynchronous consumer expectation
 //
 // Deprecated: use AddAsynchronousMessage() instead.
@@ -276,6 +260,34 @@ func (p *AsynchronousPact) AddAsynchronousMessage() *AsynchronousMessageBuilder 
 		messageHandle: message,
 		pact:          p,
 	}
+}
+
+// VerifyMessageConsumer is a test convience function for VerifyMessageConsumerRaw,
+// accepting an instance of `*testing.T`.
+func (p *AsynchronousPact) Verify(t *testing.T, message *AsynchronousMessageBuilder, handler AsynchronousConsumer) error {
+	t.Helper()
+	err := p.verifyMessageConsumerRaw(message, handler)
+	if err != nil {
+		t.Errorf("VerifyMessageConsumer failed: %v", err)
+	}
+
+	return err
+}
+
+// validateConfig validates the configuration for the consumer test.
+func (p *AsynchronousPact) validateConfig() error {
+	log.Println("[DEBUG] pact message validate config")
+	dir, _ := os.Getwd()
+
+	if p.config.PactDir == "" {
+		p.config.PactDir = filepath.Join(dir, "pacts")
+	}
+
+	p.messageserver = native.NewMessageServer(p.config.Consumer, p.config.Provider)
+	p.messageserver.WithSpecificationVersion(native.SPECIFICATION_VERSION_V4)
+	p.messageserver.WithMetadata("pact-go", "version", strings.TrimPrefix(command.Version, "v"))
+
+	return nil
 }
 
 // VerifyMessageConsumerRaw creates a new Pact _message_ interaction to build a testable
@@ -299,18 +311,6 @@ func (p *AsynchronousPact) verifyMessageConsumerRaw(messageToVerify *Asynchronou
 	}
 
 	return p.messageserver.WritePactFile(p.config.PactDir, false)
-}
-
-// VerifyMessageConsumer is a test convience function for VerifyMessageConsumerRaw,
-// accepting an instance of `*testing.T`.
-func (p *AsynchronousPact) Verify(t *testing.T, message *AsynchronousMessageBuilder, handler AsynchronousConsumer) error {
-	t.Helper()
-	err := p.verifyMessageConsumerRaw(message, handler)
-	if err != nil {
-		t.Errorf("VerifyMessageConsumer failed: %v", err)
-	}
-
-	return err
 }
 
 func getAsynchronousMessageWithContents(message *native.Message) (AsynchronousMessage, error) {

--- a/message/v4/synchronous_message.go
+++ b/message/v4/synchronous_message.go
@@ -297,6 +297,17 @@ func NewSynchronousPact(config Config) (*SynchronousPact, error) {
 	return provider, err
 }
 
+func (m *SynchronousPact) AddSynchronousMessage(description string) *UnconfiguredSynchronousMessageBuilder {
+	log.Println("[DEBUG] add sync message")
+
+	message := m.mockserver.NewSyncMessageInteraction(description)
+
+	return &UnconfiguredSynchronousMessageBuilder{
+		messageHandle: message,
+		pact:          m,
+	}
+}
+
 // validateConfig validates the configuration for the consumer test.
 func (m *SynchronousPact) validateConfig() error {
 	log.Println("[DEBUG] pact synchronous message validate config")
@@ -311,17 +322,6 @@ func (m *SynchronousPact) validateConfig() error {
 	m.mockserver.WithMetadata("pact-go", "version", strings.TrimPrefix(command.Version, "v"))
 
 	return nil
-}
-
-func (m *SynchronousPact) AddSynchronousMessage(description string) *UnconfiguredSynchronousMessageBuilder {
-	log.Println("[DEBUG] add sync message")
-
-	message := m.mockserver.NewSyncMessageInteraction(description)
-
-	return &UnconfiguredSynchronousMessageBuilder{
-		messageHandle: message,
-		pact:          m,
-	}
 }
 
 // ExecuteTest runs the current test case against a Mock Service.

--- a/provider/verifier.go
+++ b/provider/verifier.go
@@ -47,6 +47,46 @@ func NewVerifier() *Verifier {
 	}
 }
 
+// VerifyProvider accepts an instance of `*testing.T`
+// running the provider verification with granular test reporting and
+// automatic failure reporting for nice, simple tests.
+//
+// The subtest "Provider pact verification" renders as:
+//   - PASS when verification succeeded;
+//   - SKIP (with the underlying error in the skip message) when
+//     request.SoftFail is true AND the error is a verification mismatch
+//     (errors.Is(err, ErrVerifierFailed)) — i.e. a downstream gate owns
+//     the authoritative compatibility decision;
+//   - FAIL otherwise — strict mode for any error, or soft-fail mode when
+//     the verifier itself could not produce a result (infrastructure
+//     error, panic, etc.).
+func (v *Verifier) VerifyProvider(t *testing.T, request VerifyRequest) error {
+	t.Helper()
+	err := v.verifyProviderRaw(request, t)
+
+	// TODO: granular test reporting
+	// runTestCases(t, res)
+
+	t.Run("Provider pact verification", func(t *testing.T) {
+		switch {
+		case err == nil:
+			// PASS — verification succeeded.
+		case request.SoftFail && errors.Is(err, native.ErrVerifierFailed):
+			// Soft-fail mode + verification mismatch: render as SKIP so the
+			// test framework does not propagate failure. The caller is
+			// responsible for gating elsewhere (e.g. broker can-i-merge).
+			t.Skipf("pact verification failed (soft-fail enabled, broker has the record): %v", err)
+		default:
+			// Strict mode + any error, OR soft-fail mode + infrastructure
+			// error: fail loudly. Infrastructure errors signal the verifier
+			// could not produce a result for downstream gates to act on.
+			t.Error(err)
+		}
+	})
+
+	return err
+}
+
 func (v *Verifier) validateConfig() error {
 	if v.ClientTimeout == 0 {
 		v.ClientTimeout = 10 * time.Second
@@ -175,46 +215,6 @@ func (v *Verifier) verifyProviderRaw(request VerifyRequest, writer outputWriter)
 	log.Println("[DEBUG] pact provider verification")
 
 	return request.Verify(v.handle, writer)
-}
-
-// VerifyProvider accepts an instance of `*testing.T`
-// running the provider verification with granular test reporting and
-// automatic failure reporting for nice, simple tests.
-//
-// The subtest "Provider pact verification" renders as:
-//   - PASS when verification succeeded;
-//   - SKIP (with the underlying error in the skip message) when
-//     request.SoftFail is true AND the error is a verification mismatch
-//     (errors.Is(err, ErrVerifierFailed)) — i.e. a downstream gate owns
-//     the authoritative compatibility decision;
-//   - FAIL otherwise — strict mode for any error, or soft-fail mode when
-//     the verifier itself could not produce a result (infrastructure
-//     error, panic, etc.).
-func (v *Verifier) VerifyProvider(t *testing.T, request VerifyRequest) error {
-	t.Helper()
-	err := v.verifyProviderRaw(request, t)
-
-	// TODO: granular test reporting
-	// runTestCases(t, res)
-
-	t.Run("Provider pact verification", func(t *testing.T) {
-		switch {
-		case err == nil:
-			// PASS — verification succeeded.
-		case request.SoftFail && errors.Is(err, native.ErrVerifierFailed):
-			// Soft-fail mode + verification mismatch: render as SKIP so the
-			// test framework does not propagate failure. The caller is
-			// responsible for gating elsewhere (e.g. broker can-i-merge).
-			t.Skipf("pact verification failed (soft-fail enabled, broker has the record): %v", err)
-		default:
-			// Strict mode + any error, OR soft-fail mode + infrastructure
-			// error: fail loudly. Infrastructure errors signal the verifier
-			// could not produce a result for downstream gates to act on.
-			t.Error(err)
-		}
-	})
-
-	return err
 }
 
 // beforeEachMiddleware is invoked before any other, only on the __setup

--- a/provider/verify_request.go
+++ b/provider/verify_request.go
@@ -189,6 +189,43 @@ type VerifyRequest struct {
 	DisableColoredOutput bool
 }
 
+// add in the PACT_URL env variable to support suggested webhook provider verification
+// see https://docs.pact.io/pact_broker/webhooks/template_library#bitbucket---trigger-pipeline-run
+// a generalized feature request added here https://github.com/pact-foundation/pact-reference/issues/250
+func addPactUrlsFromEnvironment(v *VerifyRequest) {
+	if pactUrl := os.Getenv("PACT_URL"); pactUrl != "" {
+		v.PactURLs = append(v.PactURLs, pactUrl)
+	}
+}
+
+func valueOrFromEnvironment(value string, envKey string) string {
+	if value != "" {
+		return value
+	}
+
+	return os.Getenv(envKey)
+}
+
+type outputWriter interface {
+	Log(args ...any)
+}
+
+func (v *VerifyRequest) Verify(handle *native.Verifier, writer outputWriter) error {
+	for _, transport := range v.Transports {
+		log.Println("[DEBUG] adding transport to verification", transport)
+		handle.AddTransport(transport.Protocol, transport.Port, transport.Path, transport.Scheme)
+	}
+
+	if v.ProviderStatesSetupURL != "" {
+		handle.SetProviderState(v.ProviderStatesSetupURL, true, true)
+	}
+
+	defer handle.Shutdown()
+	res := handle.Execute()
+
+	return res
+}
+
 // Validate checks that the minimum fields are provided.
 func (v *VerifyRequest) validate(handle *native.Verifier) error {
 	if v.ProviderBaseURL == "" {
@@ -292,43 +329,6 @@ func (v *VerifyRequest) validate(handle *native.Verifier) error {
 	handle.SetColoredOutput(!v.DisableColoredOutput)
 
 	return nil
-}
-
-// add in the PACT_URL env variable to support suggested webhook provider verification
-// see https://docs.pact.io/pact_broker/webhooks/template_library#bitbucket---trigger-pipeline-run
-// a generalized feature request added here https://github.com/pact-foundation/pact-reference/issues/250
-func addPactUrlsFromEnvironment(v *VerifyRequest) {
-	if pactUrl := os.Getenv("PACT_URL"); pactUrl != "" {
-		v.PactURLs = append(v.PactURLs, pactUrl)
-	}
-}
-
-func valueOrFromEnvironment(value string, envKey string) string {
-	if value != "" {
-		return value
-	}
-
-	return os.Getenv(envKey)
-}
-
-type outputWriter interface {
-	Log(args ...any)
-}
-
-func (v *VerifyRequest) Verify(handle *native.Verifier, writer outputWriter) error {
-	for _, transport := range v.Transports {
-		log.Println("[DEBUG] adding transport to verification", transport)
-		handle.AddTransport(transport.Protocol, transport.Port, transport.Path, transport.Scheme)
-	}
-
-	if v.ProviderStatesSetupURL != "" {
-		handle.SetProviderState(v.ProviderStatesSetupURL, true, true)
-	}
-
-	defer handle.Shutdown()
-	res := handle.Execute()
-
-	return res
 }
 
 // Sentinel returns from getPort, distinct from any valid port (0-65535).


### PR DESCRIPTION
## Summary

Enables the structure linters and reorders declarations to satisfy them.

## Motivation

Split out from the rest of the lint work because the diff is almost entirely code movement, and mixing it with a PR that rewrites code makes both unreadable.

## Notes for reviewers

Nothing changes except declaration order. Reviewing with whitespace and move detection on (`?w=1`, or `git diff --color-moved`) will collapse most of it.

<sub>Stack created with <a href="https://github.com/github/gh-stack">GitHub Stacks CLI</a> • <a href="https://gh.io/stacks-feedback">Give Feedback 💬</a></sub>
