### PR TITLE
fix: wait for a plugin transport to accept before returning its port

### DIFF
--- a/internal/native/message_server.go
+++ b/internal/native/message_server.go
@@ -478,6 +478,7 @@ func (m *MessageServer) StartTransport(transport string, address string, port in
 	default:
 		if msPort > 0 {
 			log.Println("[DEBUG] mock server running on port:", msPort)
+			waitForTransport(address, msPort)
 			return msPort, nil
 		}
 		return msPort, fmt.Errorf("an unknown error (code: %v) occurred when starting a mock server for the test", msPort)

--- a/internal/native/mock_server.go
+++ b/internal/native/mock_server.go
@@ -338,6 +338,7 @@ func (m *MockServer) StartTransport(transport string, address string, port int, 
 	default:
 		if msPort > 0 {
 			log.Println("[DEBUG] mock server running on port:", msPort)
+			waitForTransport(address, msPort)
 			return msPort, nil
 		}
 		return msPort, fmt.Errorf("an unknown error (code: %v) occurred when starting a mock server for the test", msPort)

--- a/internal/native/transport_wait.go
+++ b/internal/native/transport_wait.go
@@ -1,0 +1,48 @@
+package native
+
+import (
+	"log"
+	"net"
+	"strconv"
+	"time"
+)
+
+// transportAcceptTimeout bounds how long waitForTransport waits for a mock
+// server to accept connections.
+const transportAcceptTimeout = 10 * time.Second
+
+// waitForTransport blocks until the mock server on port accepts a connection,
+// or transportAcceptTimeout elapses.
+//
+// pactffi_create_mock_server_for_transport returns as soon as the port is
+// allocated. For a plugin transport that port belongs to the plugin, which
+// reports it over gRPC before its listener is necessarily accepting, so a test
+// that dials immediately can be refused on a loaded machine. Waiting here keeps
+// that race out of every caller.
+//
+// A timeout is logged rather than returned: the caller's own connection error
+// describes the failure better than a wait that gave up, and returning one here
+// would turn a slow start into a hard failure.
+func waitForTransport(address string, port int) {
+	target := net.JoinHostPort(address, strconv.Itoa(port))
+	deadline := time.Now().Add(transportAcceptTimeout)
+
+	for attempt := 0; ; attempt++ {
+		remaining := time.Until(deadline)
+		if remaining <= 0 {
+			log.Println("[WARN] mock server on", target, "did not accept a connection within", transportAcceptTimeout)
+			return
+		}
+
+		conn, err := net.DialTimeout("tcp", target, remaining)
+		if err == nil {
+			_ = conn.Close()
+			if attempt > 0 {
+				log.Println("[DEBUG] mock server on", target, "accepted a connection after", attempt, "retries")
+			}
+			return
+		}
+
+		time.Sleep(10 * time.Millisecond)
+	}
+}


### PR DESCRIPTION
## Summary

`StartTransport` now waits for a plugin transport's port to accept a connection before handing it back, closing the race behind the intermittent `TestTCPPlugin` failures.

## The failure

`TestTCPPlugin` fails intermittently on every platform, with the mock server refusing the connection:

```
dial tcp 127.0.0.1:61223: connectex: No connection could be made because the target machine actively refused it
```

It is not tied to one runner — it has failed on **macOS on `master`** (run [34221892830](https://github.com/pact-foundation/pact-go/actions/runs/34221892830), commit a90ecf39), and on **Windows** and the **Debian container** on a branch. It roams, which is what a timing race looks like.

## Cause

`pactffi_create_mock_server_for_transport` returns as soon as the port is *allocated*. For a plugin transport that port belongs to the plugin process, which reports it back over gRPC before its listener is necessarily accepting. A caller that dials the moment `StartTransport` returns can therefore be refused on a loaded machine.

This is not a test-only problem. Every caller of `StartTransport` has the same race — `examples/plugin` is simply the one that runs in CI and dials immediately.

## The fix

`StartTransport` waits for the port to accept before returning it, on both `MessageServer` and `MockServer`.

- **A timeout is logged, not returned.** If the port never accepts, the caller's own connection error describes the failure better than a wait that gave up, and returning an error here would turn a slow start into a hard failure.
- **`MockServer.Start` is deliberately untouched.** It starts the in-process HTTP mock server through the FFI directly, with no plugin in the loop, so it is already listening when it returns. That path has never been flaky.

## Notes for reviewers

- **This does not reproduce locally** — `TestTCPPlugin` passes 5 of 5 runs before the change — so CI across the full matrix is the real check.
- The log line that accompanies the failure, `Failed to shutdown plugin mock server - transport error`, is consistent with either a plugin that is *slow to start* or one that *sometimes dies*. A bounded wait fixes the first and costs nothing for the second. If the flake survives this, that points at the plugin crashing and needs a different fix.
